### PR TITLE
tweak code style, match doc nav bg

### DIFF
--- a/components/layout/MarkdownContent.tsx
+++ b/components/layout/MarkdownContent.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactMarkdown from 'react-markdown/with-html'
 // import ReactMarkdown from 'react-markdown'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
-import { prism } from 'react-syntax-highlighter/dist/cjs/styles/prism'
+import CodeStyle from '../styles/Code'
 
 interface MarkdownContentProps {
   content: string
@@ -12,7 +12,7 @@ interface MarkdownContentProps {
 
 function WithCodeStyles({ language, value }) {
   return (
-    <SyntaxHighlighter language={language} style={prism}>
+    <SyntaxHighlighter language={language} style={CodeStyle}>
       {value}
     </SyntaxHighlighter>
   )

--- a/components/styles/Code.tsx
+++ b/components/styles/Code.tsx
@@ -1,202 +1,190 @@
-import { css } from 'styled-components'
-
-/*
-    
-    TODO: SHOULD WE DELETE THIS FILE SINCE WERE USING A THEME???
-
-    Code styles adapted from: 
-
-    Name:       Base16 Atelier Sulphurpool Light
-    Author:     Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool)
-
-    Prism template by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/prism/)
-    Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
-
-  */
-
-const Code = css`
-  code[class*='language-'],
-  pre[class*='language-'] {
-    font-family: 'Inconsolata', Consolas, Menlo, Monaco, 'Andale Mono WT',
-      'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter',
-      'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Liberation Mono',
-      'Nimbus Mono L', 'Courier New', Courier, monospace;
-    font-size: 16px;
-    line-height: 24px;
-    direction: ltr;
-    text-align: left;
-    white-space: pre;
-    word-spacing: normal;
-    word-break: normal;
-    -moz-tab-size: 4;
-    -o-tab-size: 4;
-    tab-size: 4;
-    -webkit-hyphens: none;
-    -moz-hyphens: none;
-    -ms-hyphens: none;
-    hyphens: none;
-    border-radius: 0.3rem;
-    color: var(--color-secondary);
-    border-radius: 3px;
-  }
-
-  /* Code blocks */
-  pre[class*='language-'] {
-    background-color: var(--color-light);
-    border: 1px solid var(--color-light-dark);
-    padding: 1em;
-    margin: 0.5em 0;
-    overflow: auto;
-  }
-
-  /* Inline code */
-  :not(pre) > code {
-    padding: 0.1em 0.2em;
-    border-radius: 0.3em;
-    background-color: var(--color-light);
-    border: 1px solid var(--color-light-dark);
-    border-radius: 0.3rem;
-    color: var(--color-primary);
-    font-size: 18px;
-    line-height: 28px;
-  }
-
-  .token.comment,
-  .token.prolog,
-  .token.doctype,
-  .token.cdata {
-    color: #898ea4;
-  }
-
-  .token.punctuation {
-    color: #5e6687;
-  }
-
-  .token.namespace {
-    opacity: 0.7;
-  }
-
-  .token.operator,
-  .token.boolean,
-  .token.number {
-    color: #c76b29;
-  }
-
-  .token.property {
-    color: #c08b30;
-  }
-
-  .token.tag {
-    color: #3d8fd1;
-  }
-
-  .token.string {
-    color: #269d9b;
-  }
-
-  .token.selector {
-    color: #6679cc;
-  }
-
-  .token.attr-name {
-    color: #c76b29;
-  }
-
-  .token.entity,
-  .token.url,
-  .language-css .token.string,
-  .style .token.string {
-    color: #c2a7fb;
-  }
-
-  .token.attr-value,
-  .token.keyword,
-  .token.control,
-  .token.directive,
-  .token.unit {
-    color: #ac9739;
-  }
-
-  .token.statement,
-  .token.regex,
-  .token.atrule {
-    color: #22a2c9;
-  }
-
-  .token.placeholder,
-  .token.variable {
-    color: #3d8fd1;
-  }
-
-  .token.deleted {
-    text-decoration: line-through;
-  }
-
-  .token.inserted {
-    border-bottom: 1px dotted #202746;
-    text-decoration: none;
-  }
-
-  .token.italic {
-    font-style: italic;
-  }
-
-  .token.important,
-  .token.bold {
-    font-weight: bold;
-  }
-
-  .token.important {
-    color: #c94922;
-  }
-
-  .token.entity {
-    cursor: help;
-  }
-
-  pre > code.highlight {
-    outline: 0.4em solid #c94922;
-    outline-offset: 0.4em;
-  }
-
-  /* overrides color-values for the Line Numbers plugin
-   * http://prismjs.com/plugins/line-numbers/
-   */
-  .line-numbers .line-numbers-rows {
-    border-right-color: #dfe2f1;
-  }
-
-  .line-numbers-rows > span:before {
-    color: #979db4;
-  }
-
-  /* overrides color-values for the Line Highlight plugin
-   * http://prismjs.com/plugins/line-highlight/
-   */
-  .line-highlight {
-    background: rgba(107, 115, 148, 0.2);
-    background: -webkit-linear-gradient(
-      left,
-      rgba(107, 115, 148, 0.2) 70%,
-      rgba(107, 115, 148, 0)
-    );
-    background: linear-gradient(
-      to right,
-      rgba(107, 115, 148, 0.2) 70%,
-      rgba(107, 115, 148, 0)
-    );
-  }
-
-  .language-diff .token.unchanged {
-    color: var(--color-grey);
-  }
-  .language-diff .token.inserted {
-    color: #269d9b;
-    border-bottom: none;
-  }
-  .language-diff .token.deleted {
-    color: var(--color-primary);
-  }
-`
-
-export default Code
+export default {
+  'code[class*="language-"]': {
+    color: 'black',
+    background: 'none',
+    textShadow: '0 1px white',
+    fontFamily: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+    textAlign: 'left',
+    whiteSpace: 'pre',
+    wordSpacing: 'normal',
+    wordBreak: 'normal',
+    wordWrap: 'normal',
+    lineHeight: '1.5',
+    MozTabSize: '4',
+    OTabSize: '4',
+    tabSize: '4',
+    WebkitHyphens: 'none',
+    MozHyphens: 'none',
+    msHyphens: 'none',
+    hyphens: 'none',
+  },
+  'pre[class*="language-"]': {
+    color: 'black',
+    background: '#FAFAFA',
+    textShadow: '0 1px white',
+    fontFamily: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+    textAlign: 'left',
+    whiteSpace: 'pre',
+    wordSpacing: 'normal',
+    wordBreak: 'normal',
+    wordWrap: 'normal',
+    lineHeight: '1.5',
+    MozTabSize: '4',
+    OTabSize: '4',
+    tabSize: '4',
+    WebkitHyphens: 'none',
+    MozHyphens: 'none',
+    msHyphens: 'none',
+    hyphens: 'none',
+    padding: '1em',
+    margin: '.5em 0',
+    overflow: 'auto',
+  },
+  'pre[class*="language-"]::-moz-selection': {
+    textShadow: 'none',
+    background: '#b3d4fc',
+  },
+  'pre[class*="language-"] ::-moz-selection': {
+    textShadow: 'none',
+    background: '#b3d4fc',
+  },
+  'code[class*="language-"]::-moz-selection': {
+    textShadow: 'none',
+    background: '#b3d4fc',
+  },
+  'code[class*="language-"] ::-moz-selection': {
+    textShadow: 'none',
+    background: '#b3d4fc',
+  },
+  'pre[class*="language-"]::selection': {
+    textShadow: 'none',
+    background: '#b3d4fc',
+  },
+  'pre[class*="language-"] ::selection': {
+    textShadow: 'none',
+    background: '#b3d4fc',
+  },
+  'code[class*="language-"]::selection': {
+    textShadow: 'none',
+    background: '#b3d4fc',
+  },
+  'code[class*="language-"] ::selection': {
+    textShadow: 'none',
+    background: '#b3d4fc',
+  },
+  ':not(pre) > code[class*="language-"]': {
+    background: '#f5f2f0',
+    padding: '.1em',
+    borderRadius: '.3em',
+    whiteSpace: 'normal',
+  },
+  comment: {
+    color: 'slategray',
+  },
+  prolog: {
+    color: 'slategray',
+  },
+  doctype: {
+    color: 'slategray',
+  },
+  cdata: {
+    color: 'slategray',
+  },
+  punctuation: {
+    color: '#999',
+  },
+  '.namespace': {
+    Opacity: '.7',
+  },
+  property: {
+    color: '#905',
+  },
+  tag: {
+    color: '#905',
+  },
+  boolean: {
+    color: '#905',
+  },
+  number: {
+    color: '#905',
+  },
+  constant: {
+    color: '#905',
+  },
+  symbol: {
+    color: '#905',
+  },
+  deleted: {
+    color: '#905',
+  },
+  selector: {
+    color: '#690',
+  },
+  'attr-name': {
+    color: '#690',
+  },
+  string: {
+    color: '#690',
+  },
+  char: {
+    color: '#690',
+  },
+  builtin: {
+    color: '#690',
+  },
+  inserted: {
+    color: '#690',
+  },
+  operator: {
+    color: '#9a6e3a',
+    background: 'hsla(0, 0%, 100%, .5)',
+  },
+  entity: {
+    color: '#9a6e3a',
+    background: 'hsla(0, 0%, 100%, .5)',
+    cursor: 'help',
+  },
+  url: {
+    color: '#9a6e3a',
+    background: 'hsla(0, 0%, 100%, .5)',
+  },
+  '.language-css .token.string': {
+    color: '#9a6e3a',
+    background: 'hsla(0, 0%, 100%, .5)',
+  },
+  '.style .token.string': {
+    color: '#9a6e3a',
+    background: 'hsla(0, 0%, 100%, .5)',
+  },
+  atrule: {
+    color: '#07a',
+  },
+  'attr-value': {
+    color: '#07a',
+  },
+  keyword: {
+    color: '#07a',
+  },
+  function: {
+    color: '#DD4A68',
+  },
+  'class-name': {
+    color: '#DD4A68',
+  },
+  regex: {
+    color: '#e90',
+  },
+  important: {
+    color: '#e90',
+    fontWeight: 'bold',
+  },
+  variable: {
+    color: '#e90',
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
+  italic: {
+    fontStyle: 'italic',
+  },
+}

--- a/components/ui/DocsNav.tsx
+++ b/components/ui/DocsNav.tsx
@@ -160,20 +160,7 @@ export const DocsNav = styled(({ navItems, ...styleProps }) => {
   left: 0;
   transform: translate3d(-100%, 0, 0);
   list-style-type: none;
-
-  /* Background */
-  &:after {
-    content: '';
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: var(--color-seafoam);
-    opacity: 0.5;
-    z-index: -1;
-  }
+  background-color: #fafafa;
 
   ::-webkit-scrollbar {
     display: none;

--- a/content/docs/fields/markdown.md
+++ b/content/docs/fields/markdown.md
@@ -29,12 +29,12 @@ const BlogPostForm = {
 
 ## Options
 
- - `name`: The path to some value in the data being edited.
- - `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
- - `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
- - `description`: An optional description that expands on the purpose of the field or prompts a specific action.
+- `name`: The path to some value in the data being edited.
+- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/concepts/fields#field-types)
+- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
+- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
 
- ## Interface
+## Interface
 
 ```typescript
 interface MarkdownConfig {


### PR DESCRIPTION
I wanted to match the code bg color to the old design without touching the rest of the code styles. I removed the old code styles and moved the new styles into the project so I could tweak that. I've matched the docs nav bg to the same color.