### PR TITLE
add index route for /docs

### DIFF
--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -96,10 +96,12 @@ export async function unstable_getStaticPaths() {
   const fg = require('fast-glob')
   const contentDir = './content/docs/'
   const files = await fg(`${contentDir}**/*.md`)
-  return files.map(file => {
-    const path = file.substring(contentDir.length, file.length - 3)
-    return { params: { slug: path.split('/') } }
-  })
+  return files
+    .filter(file => !file.endsWith('index.md'))
+    .map(file => {
+      const path = file.substring(contentDir.length, file.length - 3)
+      return { params: { slug: path.split('/') } }
+    })
 }
 
 interface DocsHeader {

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -1,0 +1,34 @@
+import DocTemplate from './[...slug]'
+import matter from 'gray-matter'
+import { readFile } from '../../utils/readFile'
+
+export async function unstable_getStaticProps(ctx) {
+  const content = await readFile(`content/docs/index.md`)
+  const doc = matter(content)
+
+  const docsNavData = await import('../../content/toc-doc.json')
+  const nextDocPage =
+    doc.data.next && matter(await readFile(`content${doc.data.next}.md`))
+  const prevDocPage =
+    doc.data.prev && matter(await readFile(`content${doc.data.prev}.md`))
+
+  return {
+    props: {
+      doc: {
+        data: { ...doc.data, slug: '/docs' },
+        content: doc.content,
+      },
+      docsNav: docsNavData.default,
+      nextPage: {
+        slug: doc.data.next,
+        title: nextDocPage && nextDocPage.data.title,
+      },
+      prevPage: {
+        slug: doc.data.prev,
+        title: prevDocPage && prevDocPage.data.title,
+      },
+    },
+  }
+}
+
+export default DocTemplate


### PR DESCRIPTION
`docs/index.md` is the ONLY `index.md` that has a page route. To preserve filepath-url parity, if you wish to add an index for a subsection add it as `docs/getting-started.md` instead of `docs/getting-started/index.md`. This is the same file routing scheme used by https://github.com/forestryio/forestry.io