### PR TITLE
docs: update text field docs

### DIFF
--- a/content/docs/fields/text.md
+++ b/content/docs/fields/text.md
@@ -2,9 +2,9 @@
 title: Text Field
 next: /docs/fields/textarea
 consumes:
-  - file: /packages/tinacms/src/plugins/fields/TextFieldPlugin.tsx
+  - file: /packages/@tinacms/fields/src/plugins/TextFieldPlugin.tsx
     details: Shows text field interface and config options
-  - file: /packages/@tinacms/fields/src/TextField.ts
+  - file: /packages/@tinacms/fields/src/components/TextField.ts
     details: Shows text field interface and config options
 ---
 
@@ -12,38 +12,44 @@ The `text` field represents a single line text input. It should be used for cont
 
 ![tinacms-text-field](/img/fields/text.png)
 
-## Definition
+## Options
 
-Below is an example of how a `text` field could be defined in a Gatsby remark form. [Read more on passing in form field options](/docs/gatsby/markdown#customizing-remark-forms).
+```typescript
+interface TextConfig extends FieldConfig {
+  component: 'text'
+  name: string
+  label?: string
+  description?: string
+  placeholder?: string
+}
+```
+
+| Option        | Description                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------- |
+| `component`   | The name of the plugin component. Always `'text'`.                                              |
+| `name`        | The path to some value in the data being edited.                                                |
+| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                      |
+| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_ |
+| `placeholder` | Placeholder text to appear in the input when it empty. _(Optional)_                             |
+
+> This interfaces only shows the keys unique to the text field.
+>
+> Visit the [Field Config](/docs/fields) docs for a complete list of options.
+
+## Example: Blog Post Title
+
+Below is an example of how a `text` field could be used to edit the title of a blog post.
 
 ```javascript
 const BlogPostForm = {
   fields: [
     {
-      name: 'rawFrontmatter.title',
       component: 'text',
+      name: 'title',
       label: 'Title',
       description: 'Enter the title of the post here',
+      placeholder: '...',
     },
-    // ...
   ],
-}
-```
-
-## Options
-
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/fields)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
-
-## Interface
-
-```typescript
-interface TextConfig {
-  name: string
-  component: 'text'
-  label?: string
-  description?: string
 }
 ```


### PR DESCRIPTION
* Switch options from list to table
* Add placeholder option
Move example below interface
* Remove gatsby specific references from example
* Added a tip with a link to the general field config

[Preview](https://tinacms-site-next-git-text-field-docs.tinacms.now.sh/docs/fields/text)