### PR TITLE
Direct User To Admin Route

### DIFF
--- a/content/guides/tina-cloud/starter/local.md
+++ b/content/guides/tina-cloud/starter/local.md
@@ -1,8 +1,7 @@
 ---
 title: Run Tina Cloud Starter Locally
-last_edited: '2021-07-23T10:00:00.000Z'
+last_edited: '2021-08-26T13:33:47.873Z'
 ---
-
 ## Initial Setup
 
 In the previous step, you forked the <a href="https://github.com/tinacms/tina-cloud-starter" target="_blank">tina-cloud-starter</a>. Now, **clone** this repository and ensure this is your working directory.
@@ -13,17 +12,13 @@ In the previous step, you forked the <a href="https://github.com/tinacms/tina-cl
 
 Install the project's dependencies:
 
-```
-yarn install
-```
+    yarn install
 
 > ⚠️ If you'd like to use `npm` beware that there is no `package-lock.json` so we can't guarantee the dependencies are the same for you.
 
 ## Run the project locally
 
-```
-yarn dev
-```
+    yarn dev
 
 This command starts the GraphQL server and the Next.js application in development mode. It also regenerates your schema types for TypeScript and GraphQL so changes to your `.tina` config are reflected immediately.
 
@@ -35,7 +30,7 @@ Open <a href="http://localhost:3000" target="_blank">http://localhost:3000</a> i
 
 ## Edit content locally
 
-To enter edit mode, click the "Edit with Tina" button in the lower left corner. You'll be put into edit mode and redirected back to the page you were on.
+To enter edit mode, navigate to the `/admin` route in the URL. This will prompt you to log in to Tina Cloud and will prompt you to either return to the page you were on or return to the home page.
 
 Next, click on the pencil in the lower left-hand corner to open Tina's sidebar which displays a variety of forms with fields you can edit and see updates live on the page. Since we're working locally, clicking save results in changes to your local filesystem.
 
@@ -43,5 +38,4 @@ Next, click on the pencil in the lower left-hand corner to open Tina's sidebar w
 
 Make some changes, build your own components and experience contextual editing with Tina. As fun as this is, you'll likely want to collaborate with others and view changes on a publicly available URL. To do that, in the next step we'll connect to Tina Cloud.
 
- 
 > Hint: To exit edit mode, navigate to the `/exit-admin` route.  If you are running on `localhost`, it is `http://localhost:3000/exit-admin`.


### PR DESCRIPTION
The starter no longer displays the edit link and the guide was pointing users to it to get them in to edit mode. This points them to the URL route.