### PR TITLE
change title from experimental to legacy

### DIFF
--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -402,7 +402,7 @@
       },
       {
         "id": "/guides#experimental",
-        "title": "Experimental",
+        "title": "Legacy",
         "slug": "/guides#experimental",
         "items": [
           {


### PR DESCRIPTION
We have been having a lot of confusion from the open source community about are plans for these packages and the reality is we do not plan to support them as is.  I am suggesting we change the "experimental" title to "Legacy". So these docs can still stay on our site but we are more transparent about their state.

What do you think @jamespohalloran @perkinsjr @dwalkr ? Feel free to tag anyone else who might have an opinion on these. If we want to more forward I can update the URLs and redirect links. 

<img width="878" alt="Screen Shot 2021-10-14 at 9 40 18 AM" src="https://user-images.githubusercontent.com/43075109/137319919-a93aa41c-3524-47c2-8419-8001174f1c52.png">