### PR TITLE
fix: remove broken /docs redirect

### DIFF
--- a/now.json
+++ b/now.json
@@ -297,10 +297,6 @@
     {
       "source": "/packages/next-tinacms-cloudinary/(.*)",
       "destination": "/docs/media-cloudinary/"
-    },
-    {
-      "source": "/docs/",
-      "destination": "docs/tina-cloud/"
     }
   ]
 }


### PR DESCRIPTION
going to https://tina.io/docs (which we link to in several places) is redirecting to /docs/docs/tina-cloud, which gives a 404