### PR TITLE
defocus tinacloud/tinacms in index page

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -5,16 +5,10 @@ last_edited: '2021-07-27T15:51:56.737Z'
 next: /docs/setup-overview
 ---
 
-**Tina** contains multiple tools and applications designed to improve collaboration between **content writers** and **developers** who work on web content. Under the umbrella of Tina, there are two main components:
+**Tina** contains multiple tools and applications designed to improve collaboration between **content writers** and **developers** who work on web content.
 
-- **Tina Cloud**, a hosted service designed to make Git-based content management more powerful and accessible for cross-functional teams.
-- The **TinaCMS toolkit**, a suite of packages that enable developers to quickly create a custom visual editing experience for content writers.
-
-## Tina Cloud
-
-**Tina Cloud** is a hosted service purpose built for integration with the TinaCMS Toolkit. Tina Cloud makes it possible for entire content teams to take advantage of a Git-based workflow, regardless of whether they write code or have GitHub accounts. Additionally, Tina Cloud exposes a GraphQL API for your site's file-based content, giving developers a more powerful interface for querying data and reconciling relationships.
-
-[Tina Cloud Dashboard](/docs/tina-cloud/dashboard/) - The Tina Cloud Dashboard is the interface for managing the administrative aspects of your content management. The dashboard allows you to create apps, and setup your users.
+- Our **TinaCMS JS library**, is an open source library that enables developers to add a custom visual editing experience directly into their site.
+- Our **Tina Cloud** hosted service allows cross-functional teams to collaborate on the site's content in a git-based worflow (regardless of whether they write code or have GitHub accounts).
 
 <div class="callout">
 <img className="learnImage" src="../img/tina-laptop.png" alt="" />
@@ -24,10 +18,6 @@ next: /docs/setup-overview
 <a href="/guides/tina-cloud/starter/overview/" class="calloutButton">Quick Start Guide <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg"><path d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"></path></svg></a>
 </div>
 </div>
-
-## TinaCMS Toolkit
-
-The **TinaCMS Toolkit** empowers developers to build a visual editing experience directly on their sites. By creating a custom editing experience with Tina instead of opting for a conventional CMS, developers can give their teams a contextual, intuitive editing experience without sacrificing code control.
 
 ## Guides
 

--- a/content/navigation.json
+++ b/content/navigation.json
@@ -2,7 +2,7 @@
   {
     "id": "docs",
     "label": "Docs",
-    "href": "/docs",
+    "href": "/docs/setup-overview/",
     "external": false
   },
   {


### PR DESCRIPTION
I cut out some of the copy differentiating between Tina Cloud & TinaCMS. 
Another change, that I could take or leave, is to link users directly from the "docs" link to the installation page. I find it may be a quicker aha, rather than our current index-page copy. 