### PR TITLE
remove docs -> tina cloud redirect

### DIFF
--- a/now.json
+++ b/now.json
@@ -299,10 +299,6 @@
       "destination": "/docs/media-cloudinary/"
     },
     {
-      "source": "/docs/",
-      "destination": "/docs/tina-cloud/"
-    },
-    {
       "source": "/docs/tinacms-context-advanced/",
       "destination": "/docs/tinacms-context/"
     },


### PR DESCRIPTION
This has weird behaviour, where homepage takes you to /docs, but if you refresh on /docs, we redirect you to our tina-cloud page