### PR TITLE
Fix typo in Adding Tina to an existing NextJS site

### DIFF
--- a/content/docs/introduction/tina-init.md
+++ b/content/docs/introduction/tina-init.md
@@ -29,7 +29,7 @@ In your `_app.jsx` file, you will want to wrap your layout with the TinaProvider
 from `.tina/components/TinaDynamicProvider.js`
 
 ```diff
-+ import TinaProvider from ../.tina/components/TinaDynamicProvider.js
++ import TinaProvider from '../.tina/components/TinaDynamicProvider.js'
 
 // ...
 


### PR DESCRIPTION
The code sample is missing the quotes around the import.

### General Contributing:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
