### PR TITLE
Project-based-users

### DIFF
--- a/components/cloud-beta-disclaimer.tsx
+++ b/components/cloud-beta-disclaimer.tsx
@@ -1,9 +1,0 @@
-import React from 'react'
-import Link from 'next/link'
-
-export const CloudDisclaimer = () => (
-  <blockquote>
-    Tina Cloud is in public beta.{' '}
-    <Link href="https://app.tina.io/register">Get Started</Link>
-  </blockquote>
-)

--- a/content/docs/tina-cloud/dashboard.md
+++ b/content/docs/tina-cloud/dashboard.md
@@ -6,7 +6,7 @@ next: '/docs/tina-cloud/dashboard/registration'
 
 The **Tina Cloud Dashboard** is the interface for managing the administrative aspects of your content management. The dashboard allows you to create **projects**, and setup your **users**.
 
-![tina-cloud-dashboard](/img/cloud-dashboard.png)
+![tina-cloud-dashboard](https://res.cloudinary.com/forestry-demo/image/upload/v1667433436/tina-io/docs/tina-cloud/Screen_Shot_2022-11-02_at_8.57.01_PM.png)
 
 A **project** connects to your site's GitHub repository and authorizes Tina Cloud to push and pull content directly from it. You can also authorize **collaborators** to edit your site. Once an editor has been added via the User Management page, grant them access in your project's **Collaborator's Tab**. Now they will be able to login directly to your site, start editing content, and have their changes saved to your GitHub repository.
 

--- a/content/docs/tina-cloud/dashboard/organizations.md
+++ b/content/docs/tina-cloud/dashboard/organizations.md
@@ -10,7 +10,7 @@ Each user can belong to multiple organization. The organization can be toggled w
 
 ![tina-cloud-dropdown](https://res.cloudinary.com/forestry-demo/image/upload/v1667430691/tina-io/docs/tina-cloud/Screen_Shot_2022-11-02_at_8.09.55_PM.png)
 
-Each user in an organization can have one of the following roles:
+Each user in an organization can have one of the following org-level roles:
 
 - Editor
 - Admin

--- a/content/docs/tina-cloud/dashboard/organizations.md
+++ b/content/docs/tina-cloud/dashboard/organizations.md
@@ -1,0 +1,27 @@
+---
+title: Organizations
+id: '/docs/tina-cloud/dashboard/organizations'
+next: '/docs/tina-cloud/connecting-site'
+---
+
+Organizations make it easy to manage users across multiple projects.
+
+Each user can belong to multiple organization. The organization can be toggled with the top left dropdown.
+
+![tina-cloud-dropdown](https://res.cloudinary.com/forestry-demo/image/upload/v1667430691/tina-io/docs/tina-cloud/Screen_Shot_2022-11-02_at_8.09.55_PM.png)
+
+Each user in an organization can have one of the following roles:
+
+- Editor
+- Admin
+
+The following roles/permissions apply to "Org Admins" & "Org Editors":
+
+| Actions                            | Org Admin | Org Editor |
+| ---------------------------------- | --------- | ---------- |
+| Create New Projects                | ✔️        | ✔️         |
+| List **all** organization projects | ✔️        | ❌         |
+| Manage Project Collaborators       | ✔️        | ❌         |
+| Edit Project Content               | ❌        | ❌         |
+
+In order to sign in to a project and edit through TinaCMS, the org user needs to be explicitly added to the given project.

--- a/content/docs/tina-cloud/dashboard/projects.md
+++ b/content/docs/tina-cloud/dashboard/projects.md
@@ -97,8 +97,8 @@ been successfully pushed to GitHub using the Export Branch feature.
 ##### Force Push
 
 If there are changes in the repository cache which cannot be automatically merged to your GitHub repository, it may be
-necessary to execute a force push. With a force push, the commit history on the remote will be forcefully overwritten 
-with the history in the repository cache. This should only be used if you are confident that the changes in the 
+necessary to execute a force push. With a force push, the commit history on the remote will be forcefully overwritten
+with the history in the repository cache. This should only be used if you are confident that the changes in the
 TinaCMS repository cache are correct.
 
 ### Read Only Tokens
@@ -108,15 +108,11 @@ Read-only tokens provide read-only access to your project's content.
 #### Generate tokens from the dashboard
 
 Navigate to [Tina Cloud](https://app.tina.io) and click on the project you wish to add a token to, click on the "tokens" tab
-![Tina cloud token tab](/img/graphql-docs/token-tab.png)
+![Tina cloud token tab](https://res.cloudinary.com/forestry-demo/image/upload/v1667433036/tina-io/docs/tina-cloud/Screen_Shot_2022-11-02_at_8.50.24_PM.png)
 
 Next, click "New Token" and fill out fields. The token name is how you can identify the token and "Git branches" is the list of branches separated by commas that the token has access to.
 
-![Creating a new token in Tina Cloud](/img/graphql-docs/create-new-token.png)
-
-Finally, click "Create Token".
-
-![Successful creation of a token in Tina Cloud](/img/graphql-docs/final-token-page.png)
+![Creating a new token in Tina Cloud](https://res.cloudinary.com/forestry-demo/image/upload/v1667433115/tina-io/docs/tina-cloud/Screen_Shot_2022-11-02_at_8.51.47_PM.png)
 
 This token will be used later when we connect the site's frontend to our project.
 

--- a/content/docs/tina-cloud/dashboard/users.md
+++ b/content/docs/tina-cloud/dashboard/users.md
@@ -1,25 +1,25 @@
 ---
-title: Users
+title: Project Collaborators
 id: '/docs/tina-cloud/dashboard/users'
-next: '/docs/tina-cloud/connecting-site'
+next: '/docs/tina-cloud/dashboard/organizations'
 ---
 
-The **User** section of the Tina Cloud dashboard allows external users to be invited to the Tina Cloud dashboard. Within each project, there is a **Collaborators'** tab. Adding an editor as a collaborator grants them authorization to edit directly on that Tina configured site. This allows you to organize and grant editors access on a per-project basis. All admins will have access to all projects by default so they do not need to be set up as collaborators.
+The **Collaborations** tab of a project allows users manage a project.
 
-> When a site is configured to use Tina Cloud, an authorized user will be prompted for their Tina Cloud credentials to access the editing route of the site.
+Project collaborators can have one of the following project-level roles:
 
-## Admins vs Editors
+- Editor
+- Admin
 
-When creating a new user in the dashboard, the permission section will require a role selection for the user.
+The following roles/permissions apply to "Project Admins" & "Project Editors":
 
-There are currently two roles for Tina Cloud users:
-
-### Admin
-
-An **Admin** has complete access to the Tina Cloud dashboard. This user can add, edit and delete Tina Cloud projects. This user can also setup additional user accounts, edit existing user accounts and setup collaborators. Admins also have access to edit on any specific project and do not need to be setup as collaborators.
-
-### Editor
-
-An **Editor** can login to the Tina Cloud dashboard, but is only authorized to view the sites that they are listed as collaborators for.
+| Actions                      | Org Admin | Org Editor |
+| ---------------------------- | --------- | ---------- |
+| Edit Project Content         | ✔️        | ✔️         |
+| View Project Overview        | ✔️        | ✔️         |
+| Manage Project Configuration | ✔️        | ❌         |
+| Manage Project Collaborators | ✔️        | ❌         |
 
 Both Admins and Editors are authorized to access the editing route on a Tina configured site. Both users can save content changes directly to a site's GitHub repository using TinaCMS.
+
+> When a site is configured to use Tina Cloud, an authorized user will be prompted for their Tina Cloud credentials to access the editing route of the site.

--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -201,6 +201,11 @@
             "id": "/docs/tina-cloud/dashboard/users/",
             "slug": "/docs/tina-cloud/dashboard/users/",
             "title": "Users"
+          },
+          {
+            "id": "/docs/tina-cloud/dashboard/organizations/",
+            "slug": "/docs/tina-cloud/dashboard/organizations/",
+            "title": "Organizations"
           }
         ]
       },

--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -195,12 +195,14 @@
           {
             "id": "/docs/tina-cloud/dashboard/projects/",
             "slug": "/docs/tina-cloud/dashboard/projects/",
-            "title": "Projects"
-          },
-          {
-            "id": "/docs/tina-cloud/dashboard/users/",
-            "slug": "/docs/tina-cloud/dashboard/users/",
-            "title": "Users"
+            "title": "Projects",
+            "items": [
+              {
+                "id": "/docs/tina-cloud/dashboard/users/",
+                "slug": "/docs/tina-cloud/dashboard/users/",
+                "title": "Project Collaborators"
+              }
+            ]
           },
           {
             "id": "/docs/tina-cloud/dashboard/organizations/",

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -10,7 +10,6 @@ import { openGraphImage } from 'utils/open-graph-image'
 import Error from 'next/error'
 import { NotFoundError } from 'utils/error/NotFoundError'
 import { useRouter } from 'next/router'
-import { CloudDisclaimer } from 'components/cloud-beta-disclaimer'
 import * as ga from '../../utils/ga'
 import { Breadcrumbs } from 'components/DocumentationNavigation/Breadcrumbs'
 import { useTocListener } from 'utils/toc_helpers'
@@ -80,7 +79,6 @@ function _DocTemplate(props) {
           </DocGridToc>
           <DocGridContent ref={contentRef}>
             <hr />
-            {isCloudDocs ? <CloudDisclaimer /> : null}
             <MarkdownContent escapeHtml={false} content={markdownBody} />
             <LastEdited date={frontmatter.last_edited} />
             {(props.prevPage?.slug !== null ||


### PR DESCRIPTION
Update our tina cloud docs now that we've shifted user management to be per-project