### PR TITLE
[docs] Fix typo in example code for S3MediaStore

### DIFF
--- a/content/docs/reference/media/external/s3.md
+++ b/content/docs/reference/media/external/s3.md
@@ -95,7 +95,7 @@ export default defineConfig({
   media: {
     loadCustomStore: async () => {
       const pack = await import('next-tinacms-s3')
-      return pack.TinaCloudCloudinaryMediaStore
+      return pack.TinaCloudS3MediaStore
     },
   },
 })


### PR DESCRIPTION
Change `TinaCloudCloudinaryMediaStore` to `TinaCloudS3MediaStore` given this code snippet is for the S3MediaStore
