### PR TITLE
improve whitespace, roadmap

### DIFF
--- a/components/blocks/FAQ.tsx
+++ b/components/blocks/FAQ.tsx
@@ -6,7 +6,7 @@ import BlobBackground from '../../public/svg/blob-bg.svg'
 
 export function FaqBlock({ data, index }) {
   return (
-    <section key={index} className={`relative overflow-hidden py-16 lg:py-24`}>
+    <section key={index} className={`relative overflow-hidden py-20 lg:py-28`}>
       {data.color === 'gradient' && (
         <BlobBackground className="absolute pointer-events-none top-0 left-0 w-full h-auto min-h-screen max-h-full" />
       )}

--- a/components/blocks/FeatureGrid.tsx
+++ b/components/blocks/FeatureGrid.tsx
@@ -22,7 +22,7 @@ export function FeatureGridBlock({ data, index }) {
   return (
     <section
       key={'feature-grid-' + index}
-      className={'relative z-10 py-16 lg:py-24'}
+      className={'relative z-10 py-20 lg:py-28'}
     >
       <Container width="wide">
         <div className="grid gap-[0.5px] grid-flow-row grid-cols-auto-sm md:grid-cols-auto-lg auto-rows-auto w-full rounded-xl overflow-hidden shadow border border-blue-50/50 bg-gradient-to-br from-seafoam-200/30 to-blue-100/30">

--- a/components/blocks/LogoGrid.tsx
+++ b/components/blocks/LogoGrid.tsx
@@ -62,7 +62,7 @@ export function LogoGridBlock({ data, index }) {
       <Container width="wide">
         <div className="flex flex-col items-center">
           {data.title && (
-            <h3 className="font-tuner inline-block text-center text-3xl lg:text-4xl lg:leading-tight bg-gradient-to-br from-blue-200 via-blue-300 to-blue-500 bg-clip-text text-transparent mb-6">
+            <h3 className="font-tuner inline-block text-center text-3xl lg:text-4xl lg:leading-tight bg-gradient-to-br from-blue-200 via-blue-300 to-blue-500 bg-clip-text text-transparent mb-6 lg:mb-8">
               {data.title}
             </h3>
           )}

--- a/components/blocks/Pricing.tsx
+++ b/components/blocks/Pricing.tsx
@@ -3,12 +3,12 @@ import { Wrapper } from '../layout/Wrapper'
 import { Actions } from './Actions'
 import { TinaMarkdown } from 'tinacms/dist/rich-text'
 
-const PricingCard = ({ data }) => {
+const PricingCard = ({ data, single = false }) => {
   if (!data) return null
 
   return (
     <>
-      <div className="card">
+      <div className={`card ${single ? 'single' : 'grouped'}`}>
         <div className="header">
           <h3 className="title">{data.name}</h3>
           {data.price && (
@@ -36,15 +36,22 @@ const PricingCard = ({ data }) => {
           flex: 1 1 auto;
           width: 100%;
           margin: 0 auto;
-          max-width: 38rem;
           border: 1px solid var(--color-seafoam-300);
-          border-radius: 0.75rem;
-          box-shadow: 0 6px 24px rgba(0, 37, 91, 0.05),
-            0 2px 4px rgba(0, 37, 91, 0.03);
           overflow: hidden;
           display: flex;
           flex-direction: column;
           justify-content: space-between;
+        }
+        .single {
+          border-radius: 0.75rem;
+          background: white;
+          max-width: 38rem;
+          box-shadow: 0 6px 24px rgba(0, 37, 91, 0.05),
+            0 2px 4px rgba(0, 37, 91, 0.03);
+        }
+        .grouped {
+          box-shadow: inset 0 6px 24px rgba(0, 37, 91, 0.03),
+            inset 0 2px 4px rgba(0, 37, 91, 0.03);
         }
         .header {
           display: flex;
@@ -94,7 +101,6 @@ const PricingCard = ({ data }) => {
           flex-direction: column;
           justify-content: space-between;
           color: var(--color-secondary);
-          background: white;
           padding: 1.75rem 1.5rem;
 
           @media (min-width: 1400px) {
@@ -158,17 +164,17 @@ export function PricingBlock({ data, index }) {
                 <TinaMarkdown content={data.intro} />
               </div>
             )}
-            {data.base && <PricingCard data={data.base} />}
+            {data.base && <PricingCard data={data.base} single />}
             <div className="segue"></div>
           </Wrapper>
-          <Wrapper wide>
+          <div className="px-8 xl:px-12">
             <div className="card-wrapper">
               {data.plans &&
                 data.plans.map((plan, index) => (
                   <PricingCard data={plan} key={index} />
                 ))}
             </div>
-          </Wrapper>
+          </div>
         </RichTextWrapper>
       </section>
       <style jsx>{`
@@ -230,13 +236,15 @@ export function PricingBlock({ data, index }) {
         }
 
         .card-wrapper {
-          margin-bottom: 4rem;
           display: flex;
           width: 100%;
           overflow: hidden;
           border-radius: 0.75rem;
           box-shadow: 0 6px 24px rgba(0, 37, 91, 0.05),
             0 2px 4px rgba(0, 37, 91, 0.03);
+          background: white;
+          max-width: 152rem;
+          margin: 0 auto 4rem auto
 
           :global(> *) {
             box-shadow: none;

--- a/components/blocks/RecentPosts.tsx
+++ b/components/blocks/RecentPosts.tsx
@@ -1,5 +1,5 @@
 import { RichTextWrapper } from 'components/layout/RichTextWrapper'
-import { DynamicLink } from 'components/ui'
+import { Button, DynamicLink } from 'components/ui'
 import { BlogMeta, MetaBit } from 'pages/blog/page/[page_index]'
 import React from 'react'
 import { formatDate } from 'utils/blog_helpers'
@@ -10,24 +10,24 @@ export const RecentPostsBlock = ({ data, index, recentPosts }) => {
   return (
     <section
       key={'recent-posts-' + index}
-      className={'bg-white relative z-10 py-16 lg:py-24'}
+      className={'bg-white relative z-10 py-20 lg:py-28'}
     >
       <Container width="wide">
         {data.title && (
-          <div className="flex items-center mb-10 lg:mb-12 gap-6">
+          <div className="flex items-center mb-12 lg:mb-14 gap-6">
             <h3 className="font-tuner flex-shrink-0 inline-block mx-auto text-center text-3xl lg:text-4xl lg:leading-tight bg-gradient-to-br from-blue-200 via-blue-300 to-blue-500 bg-clip-text text-transparent">
               {data.title}
             </h3>
             <hr className="my-0" />
           </div>
         )}
-        <div className="w-full flex flex-wrap gap-12">
+        <div className="w-full flex flex-wrap gap-12 lg:gap-16">
           {recentPosts.edges.map(({ node: post }) => {
-const slug = post._sys.filename
+            const slug = post._sys.filename
             return (
               <DynamicLink key={slug} href={`/blog/${slug}`} passHref>
-                <a className="group flex-1 min-w-[20rem]">
-                  <h3 className="font-tuner inline-block text-3xl lg:text-4xl lg:leading-tight bg-gradient-to-br from-blue-700/70 via-blue-900/90 to-blue-1000 group-hover:from-orange-300 group-hover:via-orange-500 group-hover:to-orange-700 bg-clip-text text-transparent mb-4">
+                <a className="group flex-1 flex flex-col gap-6 items-start min-w-[24rem]">
+                  <h3 className="font-tuner inline-block text-3xl lg:text-4xl lg:leading-tight bg-gradient-to-br from-blue-700/70 via-blue-900/90 to-blue-1000 group-hover:from-orange-300 group-hover:via-orange-500 group-hover:to-orange-700 bg-clip-text text-transparent">
                     {post.title}
                   </h3>
                   <RichTextWrapper>

--- a/components/blocks/RoadmapGrid.tsx
+++ b/components/blocks/RoadmapGrid.tsx
@@ -16,6 +16,9 @@ const Roadmap = ({ data, last = false, index }) => {
         {!last && (
           <div className="w-[2px] h-full bg-gradient-to-b from-blue-700 to-blue-400"></div>
         )}
+        {last && (
+          <div className="w-[2px] h-2/3 bg-gradient-to-b from-blue-600 via-blue-500/30 to-blue-400/0"></div>
+        )}
       </div>
       <div className="flex-1 pt-10 pb-4 flex flex-col items-start gap-4">
         {data.headline && (

--- a/components/blocks/Social.tsx
+++ b/components/blocks/Social.tsx
@@ -9,7 +9,7 @@ export const SocialBlock = (props) => {
     <ButtonGroup>
       {props.tina && (
         <DynamicLink href={props.tina} passHref>
-          <Button color="white" as="a">
+          <Button color="white">
             <TinaIconSvg
               // @ts-ignore
               style={{
@@ -25,7 +25,7 @@ export const SocialBlock = (props) => {
       )}
       {props.discord && (
         <DynamicLink href={props.discord} passHref>
-          <Button color="white" as="a">
+          <Button color="white">
             <FaDiscord
               style={{
                 color: '#5865f2',
@@ -40,7 +40,7 @@ export const SocialBlock = (props) => {
       )}
       {props.github && (
         <DynamicLink href={props.github} passHref>
-          <Button color="white" as="a">
+          <Button color="white">
             <FaGithub
               style={{
                 color: '#24292e',
@@ -55,7 +55,7 @@ export const SocialBlock = (props) => {
       )}
       {props.twitter && (
         <DynamicLink href={props.twitter} passHref>
-          <Button color="white" as="a">
+          <Button color="white">
             <FaTwitter
               style={{
                 color: '#1DA1F2',

--- a/components/layout/CloudBanner.tsx
+++ b/components/layout/CloudBanner.tsx
@@ -22,7 +22,7 @@ export function CloudBanner() {
         <div className="actions">
           <ButtonGroup>
             <Link href="https://app.tina.io/">
-              <Button size="small" color="blueInverted">
+              <Button size="small" color="white">
                 Sign In
               </Button>
             </Link>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -97,7 +97,7 @@ export const Footer = ({}) => {
   return (
     <div>
       {/* Top */}
-      <div className="flex flex-col md:flex-row gap-6 w-full justify-between items-start bg-[url('/svg/orange-bg.svg')] bg-cover bg-center px-4 py-6 lg:py-10 lg:px-10 -mt-px">
+      <div className="flex flex-col md:flex-row gap-6 w-full justify-between items-start bg-[url('/svg/orange-bg.svg')] bg-cover bg-center px-6 py-8 lg:py-12 lg:px-12 -mt-px">
         <div className="max-w-[20%] flex-1 drop-shadow-sm">
           <TinaIcon color="white" />
         </div>
@@ -135,13 +135,13 @@ export const Footer = ({}) => {
       </div>
 
       {/* Bottom */}
-      <div className="flex flex-col lg:flex-row w-full lg:items-center lg:justify-between bg-gradient-to-br from-orange-600 via-orange-800 to-orange-900 text-white p-4 lg:py-6 lg:px-10">
+      <div className="flex flex-col lg:flex-row w-full lg:items-center lg:justify-between bg-gradient-to-br from-orange-600 via-orange-800 to-orange-900 text-white px-6 py-8 lg:px-12 gap-6">
         <div className="flex items-center gap-3 whitespace-nowrap">
           <span>Stay in touch 👉</span>
           <EmailForm isFooter />
         </div>
-        <div className="flex drop-shadow-sm flex-wrap justify-end gap-x-6 gap-y-2">
-          <div className="flex flex-wrap justify-end gap-x-3 gap-y-1">
+        <div className="flex drop-shadow-sm flex-wrap justify-end gap-6">
+          <div className="flex flex-wrap justify-end gap-x-6 gap-y-2">
             {footerLinks.map((item) => {
               const { link, label } = item
               return <FooterLink link={link} label={label} />

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -3,11 +3,7 @@ import Link from 'next/link'
 import GitHubButton from 'react-github-btn'
 import data from '../../content/navigation.json'
 import { Button } from '../../components/ui/Button'
-import {
-  BiChevronRight,
-  BiMenu,
-  BiRightArrowAlt,
-} from 'react-icons/bi'
+import { BiChevronRight, BiMenu, BiRightArrowAlt } from 'react-icons/bi'
 import { TinaIcon } from '../../components/logo'
 import { useInView } from 'react-intersection-observer'
 import TinaIconSvg from '../../public/svg/tina-icon.svg'
@@ -73,11 +69,15 @@ export function Navbar({}) {
             />
           </button>
           <ul className="flex flex-col py-4 px-6 relative z-20">
-            <li className="pb-3">
+            <li className="pb-4 pt-2">
               <Link href={'/'}>
-                <a>
+                <a
+                  onClick={() => {
+                    setOpen(false)
+                  }}
+                >
                   <h1 className="flex items-center">
-                    <TinaIconSvg className={`w-8 h-auto fill-orange-500`} />
+                    <TinaIconSvg className={`w-7 h-auto fill-orange-500`} />
                   </h1>
                 </a>
               </Link>
@@ -90,7 +90,14 @@ export function Navbar({}) {
                 return (
                   <li key={id} className={`group ${navLinkClasses}`}>
                     <Link href={href}>
-                      <a className="py-1">{label}</a>
+                      <a
+                        className="py-2"
+                        onClick={() => {
+                          setOpen(false)
+                        }}
+                      >
+                        {label}
+                      </a>
                     </Link>
                   </li>
                 )
@@ -102,7 +109,14 @@ export function Navbar({}) {
                     return (
                       <li key={id} className={`group ${navLinkClasses}`}>
                         <Link href={href}>
-                          <a className="py-1">{label}</a>
+                          <a
+                            className="py-2"
+                            onClick={() => {
+                              setOpen(false)
+                            }}
+                          >
+                            {label}
+                          </a>
                         </Link>
                       </li>
                     )
@@ -158,8 +172,8 @@ export function Navbar({}) {
             </h1>
           </a>
         </Link>
-        <nav className="flex-1 flex flex-wrap-reverse justify-end items-end lg:items-center gap-2 lg:gap-x-6 lg:gap-x-10">
-          <ul className="flex gap-6 lg:gap-10 relative z-20">
+        <nav className="flex-1 flex flex-wrap-reverse justify-end items-end lg:items-center gap-2 lg:gap-x-12">
+          <ul className="flex gap-6 lg:gap-8 xl:gap-12 relative z-20">
             {data.map((item) => {
               const navLinkClasses =
                 'flex items-center text-blue-700 hover:text-blue-500 transition ease-out duration-150 cursor-pointer drop-shadow-sm text-base font-medium'
@@ -190,7 +204,7 @@ export function Navbar({}) {
                               className={`${navLinkClasses} w-full whitespace-nowrap`}
                             >
                               <Link href={href}>
-                                <a className="block p-1 text-gray-600 hover:text-blue-500">
+                                <a className="block px-2 py-1.5 text-gray-600 hover:text-blue-500">
                                   {label}
                                 </a>
                               </Link>

--- a/components/layout/Section.tsx
+++ b/components/layout/Section.tsx
@@ -8,7 +8,7 @@ interface SectionProps {
 export const Section = ({ children, color = 'white' }: SectionProps) => {
   return (
     <section
-      className={`py-16 lg:py-24 ${
+      className={`py-20 lg:py-28 ${
         color === 'seafoam'
           ? 'bg-gradient-to-br from-seafoam-150/50 via-seafoam-100/30 to-white'
           : ''

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link'
-import styled, { css } from 'styled-components'
 
 interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   color?: 'white' | 'blue' | 'orange' | 'seafoam' | 'ghost'
   size?: 'large' | 'small' | 'medium'
   className?: string
   href?: string
+  type?: 'button' | 'submit' | 'reset'
   children: React.ReactNode | React.ReactNode[]
 }
 

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -3,7 +3,10 @@ import styled, { css } from 'styled-components'
 
 interface ButtonProps {
   color?: 'white' | 'blue' | 'orange' | 'seafoam' | 'ghost'
-  size?: 'large' | 'small'
+  size?: 'large' | 'small' | 'medium'
+  className?: string
+  href?: string
+  children: React.ReactNode | React.ReactNode[]
 }
 
 const baseClasses =
@@ -39,7 +42,7 @@ export const Button = ({
   className = '',
   children,
   ...props
-}) => {
+}: ButtonProps) => {
   return (
     <button
       className={`${baseClasses} ${

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import styled, { css } from 'styled-components'
 
-interface ButtonProps {
+interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   color?: 'white' | 'blue' | 'orange' | 'seafoam' | 'ghost'
   size?: 'large' | 'small' | 'medium'
   className?: string

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -30,13 +30,13 @@ function Page404() {
               </InfoText>
               <ButtonGroup>
                 <DynamicLink href={'/docs'} passHref>
-                  <Button as="a">Documentation</Button>
+                  <Button>Documentation</Button>
                 </DynamicLink>
                 <DynamicLink href={'/guides'} passHref>
-                  <Button as="a">Guides</Button>
+                  <Button>Guides</Button>
                 </DynamicLink>
                 <DynamicLink href={'/'} passHref>
-                  <Button as="a">Home</Button>
+                  <Button>Home</Button>
                 </DynamicLink>
               </ButtonGroup>
             </InfoContent>
@@ -48,7 +48,7 @@ function Page404() {
   )
 }
 
-export const getStaticProps = async function({ preview, previewData }) {
+export const getStaticProps = async function ({ preview, previewData }) {
   return { props: {} }
 }
 

--- a/pages/blog/page/[page_index].tsx
+++ b/pages/blog/page/[page_index].tsx
@@ -32,8 +32,8 @@ const Index = (props) => {
             href={`/blog/${post.data.slug}`}
             passHref
           >
-            <a className="group">
-              <h3 className="font-tuner inline-block text-3xl lg:text-4xl lg:leading-tight bg-gradient-to-br from-blue-700/70 via-blue-900/90 to-blue-1000 group-hover:from-orange-300 group-hover:via-orange-500 group-hover:to-orange-700 bg-clip-text text-transparent mb-4">
+            <a className="w-full group flex flex-col gap-6 lg:gap-8 items-start mb-6 lg:mb-8">
+              <h3 className="font-tuner inline-block text-3xl lg:text-4xl lg:leading-tight bg-gradient-to-br from-blue-700/70 via-blue-900/90 to-blue-1000 group-hover:from-orange-300 group-hover:via-orange-500 group-hover:to-orange-700 bg-clip-text text-transparent">
                 {post.data.title}
               </h3>
               <RichTextWrapper>
@@ -46,7 +46,6 @@ const Index = (props) => {
                 <MarkdownContent skipHtml={true} content={post.content} />
                 <hr />
               </RichTextWrapper>
-              <br />
             </a>
           </DynamicLink>
         ))}
@@ -153,8 +152,12 @@ const getLocalFiles = async (filePath: string) => {
  */
 
 export const BlogWrapper = styled(Wrapper)`
-  padding-top: 10rem;
+  padding-top: 4rem;
   max-width: 768px;
+
+  @media (min-width: 1024px) {
+    padding-top: 12rem;
+  }
 `
 
 export const MetaBit = styled.p`

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -48,7 +48,7 @@ function CommunityPage(props) {
                     href={'https://github.com/tinacms/tinacms/discussions'}
                     passHref
                   >
-                    <Button color="white" as="a">
+                    <Button color="white">
                       <TinaIconSvg
                         // @ts-ignore
                         style={{
@@ -65,7 +65,7 @@ function CommunityPage(props) {
                     href={'https://discord.com/invite/zumN63Ybpf'}
                     passHref
                   >
-                    <Button color="white" as="a">
+                    <Button color="white">
                       <FaDiscord
                         style={{
                           color: '#5865f2',
@@ -81,7 +81,7 @@ function CommunityPage(props) {
                     href={'https://github.com/tinacms/tinacms'}
                     passHref
                   >
-                    <Button color="white" as="a">
+                    <Button color="white">
                       <FaGithub
                         style={{
                           color: '#24292e',
@@ -94,7 +94,7 @@ function CommunityPage(props) {
                     </Button>
                   </DynamicLink>
                   <DynamicLink href={'https://twitter.com/tinacms'} passHref>
-                    <Button color="white" as="a">
+                    <Button color="white">
                       <FaTwitter
                         style={{
                           color: '#1DA1F2',


### PR DESCRIPTION
A number of small styling improvements, mostly adding whitespace. Adds a line for the last item on a roadmap that fades out, improves pricing table styles, fixes issues with padding on the blog page. 

<img width="576" alt="Screen Shot 2022-11-29 at 12 55 40 PM" src="https://user-images.githubusercontent.com/5075484/204592963-9c1f9399-da4b-4006-854a-524bbae19d27.png">
<img width="1267" alt="Screen Shot 2022-11-29 at 12 56 05 PM" src="https://user-images.githubusercontent.com/5075484/204593031-96854fa7-36b2-4446-b900-85103ecd7b62.png">
