### PR TITLE
fix issue with markdown format

### DIFF
--- a/content/docs/product-tour.md
+++ b/content/docs/product-tour.md
@@ -23,7 +23,7 @@ For a list of CLI commands or to learn more about Tina’s CLI, click [here](/do
 
 ## Tina GraphQl API
 
-![Tina GraphQL API](https://res.cloudinary.com/deuzrsg3m/image/upload/v1651008834/carbon_csq54s.png 'Fetch data using Tina's GraphQL API')
+![Tina GraphQL API](https://res.cloudinary.com/deuzrsg3m/image/upload/v1651008834/carbon_csq54s.png "Fetch data using Tina's GraphQL API")
 
 Tina’s GraphQL API provides a structured API that can be used to fetch your site’s content. This GraphQL API uses your local filesystem as a database. When you define your schema in the Tina schema file, the Tina GraphQL API will generate queries specific to your schema.
 


### PR DESCRIPTION

On https://tina.io/docs/product-tour/ you can see that there is an issue with how the markdown is formatted. This fixes that issue.

Old
<img width="970" alt="Screen Shot 2022-12-01 at 10 13 34 AM" src="https://user-images.githubusercontent.com/43075109/205089043-5dba7e55-b291-4f3f-8ca2-95455577fa58.png">

New
<img width="970" alt="Screen Shot 2022-12-01 at 10 15 00 AM" src="https://user-images.githubusercontent.com/43075109/205089405-ab0e19e2-1e6e-440b-a152-f5d19550a2c0.png">
