### PR TITLE
yarn develop -> dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Source code for the [tina.io](https://tina.io) website.
 ```
 cp .env.example .env
 yarn install
-yarn develop
+yarn dev
 ```
 
 ### Testing Local TinaCMS Changes
@@ -15,7 +15,7 @@ yarn develop
 If you have the **tinacms** repository cloned locally you can use it when running **tina.io**:
 
 ```
-TINA=../path/to/tinacms yarn develop
+TINA=../path/to/tinacms yarn dev
 ```
 
 You can also specify which packages you want to watch:


### PR DESCRIPTION
It looks like `yarn develop` command is gone and replaced by `yarn dev` since https://github.com/tinacms/tina.io/commit/17246f0b43313b44fada50c2afe36f65bb88ec8c

### General Contributing:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

