### PR TITLE
Remove duplicated `Overview` link

### DIFF
--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -148,10 +148,6 @@
     "description": "Powerful Git-based content management for teams",
     "items": [
       {
-        "slug": "/docs/tina-cloud",
-        "title": "Overview"
-      },
-      {
         "slug": "/docs/tina-cloud/",
         "title": "Overview"
       },


### PR DESCRIPTION

| <img width="258" alt="image" src="https://user-images.githubusercontent.com/11611397/207047043-fb4e82ed-aee1-4c54-9881-579180c22d8f.png"> |
|---|

"Overview" menu of "Going To Production" is duplicated



### General Contributing:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
