### PR TITLE
Removes unused `defineSchema` import

### DIFF
--- a/.tina/config.ts
+++ b/.tina/config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, defineSchema } from 'tinacms'
+import { defineConfig } from 'tinacms'
 import { schema } from './schema'
 
 const tinaConfig = defineConfig({


### PR DESCRIPTION
Looks like some leftover from the refactoring that moved the schema to its own file.

### General Contributing:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

* [x] Title is short & specific
* [x] Headers are logically ordered & consistent
* [x] Purpose of document is explained in the first paragraph
* [x] Procedures are tested and work
* [x] Any technical concepts are explained or linked to
* [x] Document follows structure from templates
* [x] All links work
* [ ] Spelling and grammer checker has been run <- the template has a spelling mistake in the word "grammar"! 😛 
* [x] Graphics and images are clear and useful
* [x] Any prerequisites and next steps are defined.
