### PR TITLE
fix: Update link to the format-and-parse doc

### DIFF
--- a/content/docs/extending-tina/custom-field-components.md
+++ b/content/docs/extending-tina/custom-field-components.md
@@ -58,7 +58,7 @@ import { defineConfig, wrapFieldsWithMeta } from 'tinacms'
 }
 ```
 
-> Note in this example parse is also needed. [Read more about parse here](/docs/extending-tina/format-and-parse.md)
+> Note in this example parse is also needed. [Read more about parse here](/docs/extending-tina/format-and-parse/)
 
 ## Using pre-built components
 


### PR DESCRIPTION
### General Contributing:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### Work done
Fixed a typo that was causing a link on the [Custom field components documentation page](https://tina.io/docs/extending-tina/custom-field-components/) to lead to a 404.
