### PR TITLE
Force branch index editing tina/tina-lock.json

### DIFF
--- a/content/docs/tina-cloud/faq.md
+++ b/content/docs/tina-cloud/faq.md
@@ -77,5 +77,5 @@ The most common reasons for this issue are:
 
 If you receive an error like `The specified branch, 'my-branch-name', has not been indexed by Tina Cloud`, first verify that the correct branch has been specified in
 the config properties passed to defineConfig in `tina/config.ts`. Note, that this value may be set as an environment variable in your CI build process. Second, verify that the branch exists
-in the GitHub repository. Lastly, you can force a reindexing of a particular branch by making a whitespace change to the `tina/__generated__/_schema.json` file in that branch,
+in the GitHub repository. Lastly, you can force a reindexing of a particular branch by making a whitespace change to the `tina/tina-lock.json` file in that branch,
 commit the change, and push it to GitHub. This will initiate indexing for the branch and (after a few minutes) the error should be resolved.


### PR DESCRIPTION
The docs is currently indicating to _force a reindexing of a particular branch by making a whitespace change to the `tina/__generated__/_schema.json`_, but it doesn't seem to be working (or at least it didn't work for me).
Following this issue resolution https://github.com/tinacms/tinacms/issues/3841#issuecomment-1518290115 I've tried editing `tina/tina-lock.json` and it worked, so I'm proposing this update here...

### General Contributing:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

* [x] Title is short & specific
* [x] Headers are logically ordered & consistent
* [x] Purpose of document is explained in the first paragraph
* [x] Procedures are tested and work
* [x] Any technical concepts are explained or linked to
* [x] Document follows structure from templates
* [x] All links work
* [x] The spelling and grammar checker has been run
* [x] Graphics and images are clear and useful
* [x] Any prerequisites and next steps are defined.
