### PR TITLE
docs: Improve docs for non-next external-media

### DIFF
--- a/content/docs/reference/media/external/authentication.md
+++ b/content/docs/reference/media/external/authentication.md
@@ -52,7 +52,13 @@ export default createMediaHandler({
 })
 ```
 
-### Option 2) Netlify Functions
+### Option 2) Vercel API Routes
+
+Vercel supports creating Serverless functions by creating a `/api` directory at the project root. To set this up, follow the above [NextJS-specific instructions](/docs/reference/media/external/authentication/#option-1-nextjs-api-routes-nextjs-only), but use `/api/<YOUR_MEDIA_STORE_NAME>/[...media].ts` instead of `/pages/api/<YOUR_MEDIA_STORE_NAME>/[...media].ts`
+
+> Note: You may notice that the package names may contain "next" (e.g: `next-tinacms-cloudinary`). You can still use these packages for other frameworks.
+
+### Option 3) Netlify Functions
 
 If your site is hosted on Netlify, you can use ["Netlify Functions"](https://docs.netlify.com/functions/overview/) to host your media handler.
 

--- a/content/docs/reference/media/external/cloudinary.md
+++ b/content/docs/reference/media/external/cloudinary.md
@@ -6,7 +6,7 @@ next: /docs/reference/media/external/do-spaces
 
 Manage **Cloudinary media assets** in TinaCMS.
 
-> The following guide relies on NextJS's API functions to authenticate the 3rd-party media interactions. We hope to document a framework-agnostic approach soon.
+> The following guide uses NextJS's API functions to authenticate the 3rd-party media interactions. If you are using another framework with Vercel, this guide still applies (with a small tweak that you need to use `/api/...` instead of `/pages/api` for your Serverless function).
 
 ## Installation
 
@@ -18,14 +18,12 @@ yarn add next-tinacms-cloudinary @tinacms/auth
 
 You need to provide your Cloudinary credentials to connect to your media library. Do [register on Cloudinary](https://cloudinary.com/users/register/free) if you don't have an account yet, your account details are displayed on the Cloudinary dashboard.
 
-**next-tinacms-cloudinary** uses environment variables within the context of a Next.js site to properly access your Cloudinary account.
-
 Add the following variables to an `.env` file.
 
 ```env
-NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=<Your Cloudinary Cloud Name>
+CLOUDINARY_CLOUD_NAME=<Your Cloudinary Cloud Name>
 
-NEXT_PUBLIC_CLOUDINARY_API_KEY=<Your Cloudinary API key>
+CLOUDINARY_API_KEY=<Your Cloudinary API key>
 
 CLOUDINARY_API_SECRET=<Your Cloudinary API secret>
 ```
@@ -54,22 +52,13 @@ export default defineConfig({
 })
 ```
 
-## Set up API routes (Next.js example)
+## Set up API routes
 
-> \*\* NOTE: \*\*this step will show you how to set up an API route for Next.js. If you are using a different framework, you will need to set up your own API route.
+Tina's "external media provider" support requires a light backend media handler, that needs to be setup/hosted by the user. There are multiple ways to setup this handler:
 
-Tina's "external media provider" support requires a light backend media handler, that needs to be setup/hosted by the user. There are multiple ways to do this, including the framework-agnostic [Netlify Functions implementation](/docs/reference/media/external/authentication/#netlify).
+### "NextJS API Routes"
 
-### "NextJS API Routes" example (NextJS-only)
-
-Set up a new API route in the `pages` directory of your Next.js app at `pages/api/cloudinary/[...media].ts`.
-Then add a new catch all API route for media.
-
-Call `createMediaHandler` to set up routes and connect your instance of the Media Store to your Cloudinary account.
-
-Import `isAuthorized` from ["@tinacms/auth"](https://github.com/tinacms/tinacms/tree/main/packages/%40tinacms/auth).
-
-The `authorized` key will make it so only authorized users within Tina Cloud can upload and make media edits.
+For sites using NextJS, you can setup the handler as a NextJS Server function. To do so, create a `pages/api/cloudinary/[...media].ts` file in your project, with the following implementation:
 
 ```ts
 // pages/api/cloudinary/[...media].ts
@@ -84,8 +73,8 @@ import { isAuthorized } from '@tinacms/auth'
 export const config = mediaHandlerConfig
 
 export default createMediaHandler({
-  cloud_name: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME,
-  api_key: process.env.NEXT_PUBLIC_CLOUDINARY_API_KEY,
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
   api_secret: process.env.CLOUDINARY_API_SECRET,
   authorized: async (req, _res) => {
     try {
@@ -103,6 +92,17 @@ export default createMediaHandler({
   },
 })
 ```
+
+Here's what's happening in the above snippet:
+
+- We call `createMediaHandler` to set up routes and connect your instance of the Media Store to your Cloudinary account.
+- The `authorized` key will make it so only authorized users within Tina Cloud can upload and make media edits.
+
+### Framework Agnostic implementations
+
+In the above example, we showed how to host the backend handler as a NextJS API function. If you are using Vercel with another framework, the same approach applies (with the small difference that you need to use `/api/...` instead of `/pages/api/...` for your handler).
+
+You can also check out our [Netlify Functions](/docs/reference/media/external/authentication/#option-3-netlify-functions) implementation.
 
 ## Update Schema
 

--- a/content/docs/reference/media/external/do-spaces.md
+++ b/content/docs/reference/media/external/do-spaces.md
@@ -26,16 +26,14 @@ npm install next-tinacms-dos
 
 You need some credentials provided by Digital Ocean Spaces to set this up properly. If you do not already have an account, you can [register here](https://cloud.digitalocean.com/registrations/new) .
 
-**next-tinacms-dos** uses environment variables within the context of a Next.js site to properly access your Digital Ocean Spaces account.
-
 Add the following variables to an `.env` file.
 
 ```env
-NEXT_PUBLIC_SPACES_ENDPOINT=<Your Digital Ocean Spaces Endpoint: ex. https://fra1.digitaloceanspaces.com> (Does not include the space name)
+SPACES_ENDPOINT=<Your Digital Ocean Spaces Endpoint: ex. https://fra1.digitaloceanspaces.com> (Does not include the space name)
 
-NEXT_PUBLIC_SPACES_NAME=<Your Digital Ocean Spaces Name: ex. my-spaces>
+SPACES_NAME=<Your Digital Ocean Spaces Name: ex. my-spaces>
 
-NEXT_PUBLIC_SPACES_KEY=<Your Digital Ocean Spaces access key>
+SPACES_KEY=<Your Digital Ocean Spaces access key>
 
 SPACES_SECRET_KEY=<Your Digital Ocean Spaces access secret>
 ```
@@ -92,14 +90,14 @@ export const config = mediaHandlerConfig
 
 export default createMediaHandler({
   config: {
-    endpoint: process.env.NEXT_PUBLIC_SPACES_ENDPOINT,
+    endpoint: process.env.SPACES_ENDPOINT,
     credentials: {
-      accessKeyId: process.env.NEXT_PUBLIC_SPACES_KEY || '',
+      accessKeyId: process.env.SPACES_KEY || '',
       secretAccessKey: process.env.SPACES_SECRET_KEY || '',
     },
     region: 'us-east-1',
   },
-  bucket: process.env.NEXT_PUBLIC_SPACES_NAME || '',
+  bucket: process.env.SPACES_NAME || '',
   authorized: async (req, _res) => {
     if (process.env.NODE_ENV === 'development') {
       return true

--- a/content/docs/reference/media/external/s3.md
+++ b/content/docs/reference/media/external/s3.md
@@ -25,16 +25,14 @@ npm install next-tinacms-s3
 
 You need some credentials provided to access AWS S3 Bucket to set this up properly.
 
-**next-tinacms-s3** uses environment variables within the context of a Next.js site to properly access your S3 Bucket account.
-
 Add the following variables to an `.env` file.
 
 ```env
-NEXT_PUBLIC_S3_REGION=<Your S3 Bucket Name: ex. us-east-1>
+S3_REGION=<Your S3 Bucket Name: ex. us-east-1>
 
-NEXT_PUBLIC_S3_BUCKET=<Your S3 Bucket Name: ex. my-bucket>
+S3_BUCKET=<Your S3 Bucket Name: ex. my-bucket>
 
-NEXT_PUBLIC_S3_ACCESS_KEY=<Your S3 Bucket access key>
+S3_ACCESS_KEY=<Your S3 Bucket access key>
 
 S3_SECRET_KEY=<Your S3 Bucket access secret>
 ```
@@ -136,12 +134,12 @@ export const config = mediaHandlerConfig
 export default createMediaHandler({
   config: {
     credentials: {
-      accessKeyId: process.env.NEXT_PUBLIC_S3_ACCESS_KEY || '',
+      accessKeyId: process.env.S3_ACCESS_KEY || '',
       secretAccessKey: process.env.S3_SECRET_KEY || '',
     },
-    region: process.env.NEXT_PUBLIC_S3_REGION,
+    region: process.env.S3_REGION,
   },
-  bucket: process.env.NEXT_PUBLIC_S3_BUCKET || '',
+  bucket: process.env.S3_BUCKET || '',
   authorized: async (req, _res) => {
     if (process.env.NODE_ENV === 'development') {
       return true
@@ -158,7 +156,11 @@ export default createMediaHandler({
 })
 ```
 
-For Netlify use case, please read how to set up Netlify Functions [here](/docs/reference/media/external/authentication/#netlify)
+### Framework Agnostic implementations
+
+In the above example, we showed how to host the backend handler as a NextJS API function. If you are using Vercel with another framework, the same approach applies (with the small difference that you need to use `/api/...` instead of `/pages/api/...` for your handler).
+
+You can also check out our [Netlify Functions](/docs/reference/media/external/authentication/#option-3-netlify-functions) implementation.
 
 ### Using a Custom URL
 


### PR DESCRIPTION
Improve docs for non-next external-media implementations.

One thing to confirm, I removed the NEXT_PUBLIC_ prefix from our environment variables. It doesn't look like these variables are refenced in the tinacms packages, and I don't believe they are needed on the frontend, but could use a second look just to confirm I'm not missing something. 