### PR TITLE
Remove redundant content from Many Hands showcase

### DIFF
--- a/content/blocksPages/showcase.json
+++ b/content/blocksPages/showcase.json
@@ -92,7 +92,7 @@
         },
         {
           "headline": "We Are Many Hands",
-          "text": "[ManyHands](https://wearemanyhands.com) is an event  for product people.  The event (and website) is by [Lighthouse](https://wearelighthouse.com), a specialist UX and UI design agency based in London design agency based in London.  ",
+          "text": "[ManyHands](https://wearemanyhands.com) is an event  for product people.  The event (and website) is by [Lighthouse](https://wearelighthouse.com), a specialist UX and UI design agency based in London.",
           "url": "https://wearemanyhands.com",
           "media": {
             "src": "https://res.cloudinary.com/forestry-demo/image/upload/v1678369877/tina-showcase/wearemanyhands.png"


### PR DESCRIPTION
The [Lighthouse](https://wearelighthouse.com) reference in the [ManyHands](https://wearemanyhands.com) spotlight on the [Showcase](https://tina.io/showcase/) page repeats the phrase `design agency based in London`:

> The event (and website) is by [Lighthouse](https://wearelighthouse.com/), a specialist UX and UI  
> _design agency based in London_ **design agency based in London**.

This fix removes the duplicate content.

### General Contributing:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

* [ ] Title is short & specific
* [ ] Headers are logically ordered & consistent
* [ ] Purpose of document is explained in the first paragraph
* [ ] Procedures are tested and work
* [ ] Any technical concepts are explained or linked to
* [ ] Document follows structure from templates
* [ ] All links work
* [ ] The spelling and grammar checker has been run
* [ ] Graphics and images are clear and useful
* [ ] Any prerequisites and next steps are defined.
