### PR TITLE
Fix hugo.md incorrect NPM command

### DIFF
--- a/content/docs/frameworks/hugo.md
+++ b/content/docs/frameworks/hugo.md
@@ -86,7 +86,7 @@ export default defineConfig({
 Tina's build will need to be a part of your site's static generation.
 If you are using Netlify, this is configured in `app.netlify.com/sites/<your-site-id>/settings/deploys`
 
-You should prepend `yarn tinacms build && ` or `npm run tinacms build && ` to your site's build command:
+You should prepend `yarn tinacms build && ` or `npx tinacms build && ` to your site's build command:
 
 ![](https://res.cloudinary.com/forestry-demo/image/upload/v1670337650/tina-io/docs/forestry-migration/Screen_Shot_2022-12-06_at_10.38.10_AM.png)
 


### PR DESCRIPTION
The docs say to run `npm run tinacms build` which leads to a failure as it's the wrong command. Instead the command `npx tinacms build` works on Netlify, given the example.

### General Contributing:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

* [ ] Title is short & specific
* [ ] Headers are logically ordered & consistent
* [ ] Purpose of document is explained in the first paragraph
* [ ] Procedures are tested and work
* [ ] Any technical concepts are explained or linked to
* [ ] Document follows structure from templates
* [ ] All links work
* [ ] The spelling and grammar checker has been run
* [ ] Graphics and images are clear and useful
* [ ] Any prerequisites and next steps are defined.
