### PR TITLE
fix: point to correct url for config references

### DIFF
--- a/content/docs/tina-cloud/branching.md
+++ b/content/docs/tina-cloud/branching.md
@@ -9,7 +9,7 @@ If your content editors need to work on multiple branches, you can enable Tina's
 
 ## Installation
 
-Simply add the branch-switcher flag to your CMS callback function in your tina [config file](http://localhost:3000/docs/reference/config/). If your site does not already make use of the CMS callback function, add this to your config.
+Simply add the branch-switcher flag to your CMS callback function in your tina [config file](https://tina.io/docs/reference/config/). If your site does not already make use of the CMS callback function, add this to your config.
 
 ```javascript
 cmsCallback: cms => {

--- a/content/docs/tina-cloud/branching.md
+++ b/content/docs/tina-cloud/branching.md
@@ -9,7 +9,7 @@ If your content editors need to work on multiple branches, you can enable Tina's
 
 ## Installation
 
-Simply add the branch-switcher flag to your CMS callback function in your tina [config file](https://tina.io/docs/reference/config/). If your site does not already make use of the CMS callback function, add this to your config.
+Simply add the branch-switcher flag to your CMS callback function in your Tina [config file](/docs/reference/config/). If your site does not already make use of the CMS callback function, add this to your config.
 
 ```javascript
 cmsCallback: cms => {


### PR DESCRIPTION
The url before is localhost:3000 which may be caused by human error

### General Contributing:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

* [x] Title is short & specific
* [x] Headers are logically ordered & consistent
* [x] Purpose of document is explained in the first paragraph
* [x] Procedures are tested and work
* [x] Any technical concepts are explained or linked to
* [x] Document follows structure from templates
* [x] All links work
* [x] The spelling and grammar checker has been run
* [x] Graphics and images are clear and useful
* [x] Any prerequisites and next steps are defined.
