### PR TITLE
docs: mark CustomAuthProvider methods async to fix type errors

### DIFF
--- a/content/docs/reference/self-hosted/auth-provider/bring-your-own.md
+++ b/content/docs/reference/self-hosted/auth-provider/bring-your-own.md
@@ -38,13 +38,13 @@ export class CustomAuthProvider extends AbstractAuthProvider {
   async authenticate(props?: {}): Promise<any> {
     // Do any authentication here
   }
-  getToken() {
+  async getToken() {
     // Return the token here. The token will be passed as an Authorization header in the format `Bearer <token>`
   }
   async getUser() {
     // Returns a truthy value, the user is logged in and if it returns a falsy value the user is not logged in.
   }
-  logout() {
+  async logout() {
     // Do any logout logic here
   }
   async authorize(context?: any): Promise<any> {


### PR DESCRIPTION
Using Tina v1.5.28 authProvider expects async functions but the sample code doesn't have them marked async resulting in type errors

### General Contributing:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
