### PR TITLE
Resolve Feature Grid Button Overlap

### DIFF
--- a/components/blocks/FeatureGrid.tsx
+++ b/components/blocks/FeatureGrid.tsx
@@ -25,7 +25,7 @@ export function FeatureGridBlock({ data, index }) {
   return (
     <section
       key={'feature-grid-' + index}
-      className={'relative z-10 py-20 lg:py-28'}
+      className={'relative z-0 py-20 lg:py-28'}
     >
       <Container width="wide">
         <div className="grid gap-[0.5px] grid-flow-row grid-cols-auto-sm md:grid-cols-auto-lg auto-rows-auto w-full rounded-xl overflow-hidden shadow border border-blue-50/50 bg-gradient-to-br from-seafoam-200/30 to-blue-100/30">


### PR DESCRIPTION
This resolves an overlap that's occurring on pages uses the Hero template. Resulting Overlap is presenting anything below the overlap from being intractable. For example, a button from being used. It also poses accessability issues due to text not being copyable..

I've checked the Home page for any issues as a result of making these change and didn't spot any. I'm not familiar with your overall usage however so I may be missing something on other pages. I did not note any visual differences from lowering it to `z-0`. `z-0` is required for the SVG to display correctly so removing the z-index overall isn't an option.

To replicate this issue
- Open a browser window that has a viewport of at least 1920px.
- [view the Forestry.io page](https://tina.io/forestry/)
- Click the Tiny Migration Guide button, or try to click the copy button.
- Depending on the browser window, the overlap may only be present towards the bottom so if it works, try clicking towards the bottom.

[Try viewing the Agencies page](https://tina.io/agencies/). Try selecting the sub headline "treat your clients [...]" and you'll be unable to.

### General Contributing:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

* [ ] Title is short & specific
* [ ] Headers are logically ordered & consistent
* [ ] Purpose of document is explained in the first paragraph
* [ ] Procedures are tested and work
* [ ] Any technical concepts are explained or linked to
* [ ] Document follows structure from templates
* [ ] All links work
* [ ] The spelling and grammar checker has been run
* [ ] Graphics and images are clear and useful
* [ ] Any prerequisites and next steps are defined.
