### PR TITLE
Adding Ids on Action Blocks for Google Tag Manager

### DIFF
--- a/components/blocks/Actions.tsx
+++ b/components/blocks/Actions.tsx
@@ -122,11 +122,12 @@ export const Actions = ({ items, align = 'left' }) => {
 
 export const CodeButton = ({ children, ...props }) => {
   const [copied, setCopied] = React.useState(false)
+  const id = sanitizeLabel(children.toString())
 
   const clickEvent = () => {
     setCopied(true)
     copyToClipboard(children)
-    setTimeout(() => {
+        setTimeout(() => {
       setCopied(false)
     }, 2000)
   }
@@ -137,7 +138,7 @@ export const CodeButton = ({ children, ...props }) => {
         className="button event-cmd-button"
         onClick={clickEvent}
         {...props}
-        id={sanitizeLabel(children.toString())}
+        id={id}
       >
         <span className={`success-message ${copied ? `visible` : ``}`}>
           Copied to clipboard!

--- a/components/blocks/Actions.tsx
+++ b/components/blocks/Actions.tsx
@@ -122,7 +122,7 @@ export const Actions = ({ items, align = 'left' }) => {
 
 export const CodeButton = ({ children, ...props }) => {
   const [copied, setCopied] = React.useState(false)
-  const id = sanitizeLabel(children.toString())
+  const id = sanitizeLabel(children[0].toString())
 
   const clickEvent = () => {
     setCopied(true)

--- a/components/blocks/Actions.tsx
+++ b/components/blocks/Actions.tsx
@@ -127,7 +127,7 @@ export const CodeButton = ({ children, ...props }) => {
   const clickEvent = () => {
     setCopied(true)
     copyToClipboard(children)
-        setTimeout(() => {
+    setTimeout(() => {
       setCopied(false)
     }, 2000)
   }

--- a/components/blocks/Actions.tsx
+++ b/components/blocks/Actions.tsx
@@ -9,11 +9,13 @@ export const sanitizeLabel = (label: string): string => {
 };
 
 export const Actions = ({ items, align = 'left' }) => {
+  const isList = items.length > 2;
   return (
     <>
       <div
         className={[
           'actionGroup',
+          isList ? 'actionGroupList' : 'actionGroupRow',
           align === 'center' && 'actionGroupCenter',
         ].join(' ')}
       >
@@ -64,6 +66,16 @@ export const Actions = ({ items, align = 'left' }) => {
           :global(button) {
             margin: 0.5rem 0.75rem;
           }
+        }
+
+        .actionGroupRow {
+          flex-direction: row;
+          align-items: center;
+        }
+
+        .actionGroupList {
+          flex-direction: column;
+          align-items: flex-start;
         }
         
         .or-text{

--- a/components/blocks/Actions.tsx
+++ b/components/blocks/Actions.tsx
@@ -26,6 +26,7 @@ export const Actions = ({ items, align = 'left' }) => {
                 <React.Fragment key={item.label}>
                   {index === 2 && <span className="or-text">or</span>} {}
                   <CodeButton
+                  label={item.label}
                   data-tina-field={tinaField(item, 'label')}
                   id={sanitizeLabel(item.label)}
                   >
@@ -41,7 +42,7 @@ export const Actions = ({ items, align = 'left' }) => {
             return (
               <LinkButton
                 key={label}
-                id={label}
+                id={sanitizeLabel(label)}
                 size={item.size ? item.size : 'medium'}
                 link={url}
                 target="_blank"
@@ -120,9 +121,8 @@ export const Actions = ({ items, align = 'left' }) => {
   )
 }
 
-export const CodeButton = ({ children, ...props }) => {
+export const CodeButton = ({ children, label, ...props }) => {
   const [copied, setCopied] = React.useState(false)
-  const id = sanitizeLabel(children[0].toString())
 
   const clickEvent = () => {
     setCopied(true)
@@ -138,7 +138,6 @@ export const CodeButton = ({ children, ...props }) => {
         className="button event-cmd-button"
         onClick={clickEvent}
         {...props}
-        id={id}
       >
         <span className={`success-message ${copied ? `visible` : ``}`}>
           Copied to clipboard!

--- a/components/blocks/Actions.tsx
+++ b/components/blocks/Actions.tsx
@@ -4,6 +4,10 @@ import { copyToClipboard } from '../../components/layout/MarkdownContent'
 import { LinkButton } from '../../components/ui'
 import { tinaField } from 'tinacms/dist/react'
 
+export const sanitizeLabel = (label: string): string => {
+  return label.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9\-]/g, '');
+};
+
 export const Actions = ({ items, align = 'left' }) => {
   return (
     <>
@@ -19,7 +23,10 @@ export const Actions = ({ items, align = 'left' }) => {
               return (
                 <React.Fragment key={item.label}>
                   {index === 2 && <span className="or-text">or</span>} {}
-                  <CodeButton data-tina-field={tinaField(item, 'label')}>
+                  <CodeButton
+                  data-tina-field={tinaField(item, 'label')}
+                  id={sanitizeLabel(item.label)}
+                  >
                     {item.label}
                   </CodeButton>
                 </React.Fragment>
@@ -32,6 +39,7 @@ export const Actions = ({ items, align = 'left' }) => {
             return (
               <LinkButton
                 key={label}
+                id={label}
                 size={item.size ? item.size : 'medium'}
                 link={url}
                 color={variant}

--- a/components/blocks/Actions.tsx
+++ b/components/blocks/Actions.tsx
@@ -124,6 +124,7 @@ export const CodeButton = ({ children, ...props }) => {
         className="button event-cmd-button"
         onClick={clickEvent}
         {...props}
+        id={sanitizeLabel(children.toString())}
       >
         <span className={`success-message ${copied ? `visible` : ``}`}>
           Copied to clipboard!

--- a/components/blocks/Actions.tsx
+++ b/components/blocks/Actions.tsx
@@ -44,6 +44,7 @@ export const Actions = ({ items, align = 'left' }) => {
                 id={label}
                 size={item.size ? item.size : 'medium'}
                 link={url}
+                target="_blank"
                 color={variant}
                 data-tina-field={tinaField(item, 'label')}
               >

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,4 +1,3 @@
-import { sanitizeLabel } from 'components/blocks'
 import Link from 'next/link'
 
 interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,3 +1,4 @@
+import { sanitizeLabel } from 'components/blocks'
 import Link from 'next/link'
 
 interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
@@ -66,6 +67,7 @@ export const LinkButton = ({
   children,
   ...props
 }) => {
+  const id = sanitizeLabel(children[0].toString());
   return (
     <Link legacyBehavior href={link} passHref>
       <a

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -67,7 +67,6 @@ export const LinkButton = ({
   children,
   ...props
 }) => {
-  const id = sanitizeLabel(children[0].toString());
   return (
     <Link legacyBehavior href={link} passHref>
       <a


### PR DESCRIPTION
As per #1786 i am assigning ids for each action so that we can track them in Google Tag Manager.

 We have also modified the logic to do with action lists so that the list styling applied to the CTA buttons do not ruin the formatting of the rest of the site. This is so that groups of action buttons > 2 will be stacked vertically rather than horizontally. 