### PR TITLE
checking more types of text in payload

### DIFF
--- a/utils/getExcerpt.ts
+++ b/utils/getExcerpt.ts
@@ -5,19 +5,24 @@ export const getExcerpt = (
   return body.children
     .filter((c) => c.type == 'p')
     .reduce(function (excerpt, child) {
-      // combine all of child's text nodes into a single string
+      // combine all of child's text and link nodes into a single string
       excerpt +=
         (excerpt ? ' ' : '') +
         child.children
-          .filter((c) => c.type == 'text')
+          .filter((c) => c.type == 'text' || c.type == 'a')
           .reduce(function (text, child) {
-            return text + (text ? ' ' : '') + child.text
-          }, '')
+            if (child.type == 'text') {
+              return text + (text ? ' ' : '') + child.text;
+            } else if (child.type == 'a') {
+              return text + (text ? ' ' : '') + child.children.map((c: any) => c.text).join(' ');
+            }
+            return text;
+          }, '');
       // if the combined text is too long, truncate it
       if (excerpt.length > excerptLength) {
-        excerpt = excerpt.substring(0, excerptLength) + '...'
+        excerpt = excerpt.substring(0, excerptLength) + '...';
       }
 
-      return excerpt
-    }, '')
-}
+      return excerpt;
+    }, '');
+};


### PR DESCRIPTION
As per #1798 the blog posts were not including text that was not of type 'text'. Therefore all text of type <a> was being dismissed. This change modified the `getExcerpt` method used to retrieve text from posts, making sure we include anchored text and map it to text.

<img width="719" alt="Screenshot 2024-05-27 at 10 58 59 am" src="https://github.com/tinacms/tina.io/assets/137844305/b7e65f7a-f274-49f0-ba8a-18202a70bc33">

**Figure: After the change has been implemented, <a> text now appears**