### PR TITLE
🐛 TInaGPT covering footer text

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -300,7 +300,7 @@ export const Footer = ({}) => {
       </div>
 
       {/* Bottom */}
-      <div className="flex justify-end flex-col lg:flex-row w-full lg:items-center bg-gradient-to-br from-orange-600 via-orange-800 to-orange-900 text-white px-6 py-8 lg:px-12 gap-6 ">
+      <div className="flex justify-end flex-col lg:flex-row w-full lg:items-center bg-gradient-to-br from-orange-600 via-orange-800 to-orange-900 text-white px-6 py-8 lg:px-18 gap-6">
         <div className="flex drop-shadow-sm flex-wrap gap-6">
           <div className="flex flex-wrap gap-x-6 gap-y-2">
             {footerLinks.map((item) => {


### PR DESCRIPTION
As per #1817 we have marginally increased the right padding of the footer so that the tinaGPT does not overlap with the footer text .
 
![Screenshot 2024-06-24 at 3 30 41 pm](https://github.com/tinacms/tina.io/assets/137844305/9340d203-92f5-4608-b284-c724244946fb)
**Figure: After padding shift**