### PR TITLE
Add tina-lock.json info

### DIFF
--- a/content/docs/reference/media/external/authentication.md
+++ b/content/docs/reference/media/external/authentication.md
@@ -260,4 +260,6 @@ export default defineConfig({
 })
 ```
 
+> Make sure you commit your changes to the config and [`tina-lock.json`](/docs/tina-folder/overview/#tina-lockjson) file at the same time as you push to production on tina.cloud as otherwise your assets will still be prefixed with `https://assets.tina.io` as if you were [still using repo based media](/docs/reference/media/repo-based/)
+
 Now you can manage external media store inside TinaCMS. To learn more about each media store in detail, please refer to the next sections.

--- a/content/docs/reference/media/external/authentication.md
+++ b/content/docs/reference/media/external/authentication.md
@@ -260,6 +260,6 @@ export default defineConfig({
 })
 ```
 
-> Make sure you commit your changes to the config and [`tina-lock.json`](/docs/tina-folder/overview/#tina-lockjson) file at the same time as you push to production on tina.cloud as otherwise your assets will still be prefixed with `https://assets.tina.io` as if you were [still using repo based media](/docs/reference/media/repo-based/)
+> Make sure you commit your changes to the config and [`tina-lock.json`](/docs/tina-folder/overview/#tina-lockjson) file at the same time as you push to production on TinaCloud as otherwise your assets will still be prefixed with `https://assets.tina.io` as if you were [still using repo based media](/docs/reference/media/repo-based/)
 
 Now you can manage external media store inside TinaCMS. To learn more about each media store in detail, please refer to the next sections.


### PR DESCRIPTION
See [original PR on tinacms](https://github.com/tinacms/tinacms/pull/4598) and [discord discussion](https://discord.com/channels/835168149439643678/1256612728257384511) for reasoning why `tina-lock.json` should be mentioned within this section to prevent developers from running against a wall.