### PR TITLE
Docs: Explain `static` property for media configuration

### DIFF
--- a/content/docs/reference/media/repo-based.md
+++ b/content/docs/reference/media/repo-based.md
@@ -20,7 +20,7 @@ export default defineConfig({
     tina: {
       publicFolder: 'public',
       mediaRoot: 'uploads',
-      static:false,  //default is false
+      static: false,  //default is false
     },
   },
 })

--- a/content/docs/reference/media/repo-based.md
+++ b/content/docs/reference/media/repo-based.md
@@ -20,6 +20,7 @@ export default defineConfig({
     tina: {
       publicFolder: 'public',
       mediaRoot: 'uploads',
+      static:false,  //default is false
     },
   },
 })
@@ -40,6 +41,13 @@ E.g, in our [tina-cloud-starter](https://github.com/tinacms/tina-cloud-starter/t
 > Note, anything in this directory will be synced with Tina Cloud's media server, and the images will be publicly accessible.
 
 `mediaRoot` can be set to "", if you want your media to be uploaded to the root of your `publicFolder`.
+
+### `static` (Boolean)
+
+This property determines whether media files can be uploaded, edited, or deleted directly through the editor.
+
+- **`static: true`** Editors cannot upload/delete media (static assets)
+- **`static: false`** (default): Editors can upload/delete media (dynamic assets).
 
 ### next/image
 


### PR DESCRIPTION
This pull request updates the TinaCMS documentation to clarify the behavior of the static property within the media configuration object in config.ts.

A new section has been added to explain the purpose and impact of the static property.
The explanation details how static: true makes media files static assets (uneditable through TinaCMS) and static: false (default) allows editors to upload, edit, and delete media directly within the editor.