### PR TITLE
💄Decrease Logo Spacing

### DIFF
--- a/components/blocks/CompareBox.tsx
+++ b/components/blocks/CompareBox.tsx
@@ -225,7 +225,7 @@ export function CompareBoxBlock({ data, index }: CompareBoxBlockProps) {
     dots: false,
     infinite: true,
     speed: 500,
-    slidesToShow: 4,
+    slidesToShow: 5,
     slidesToScroll: 1,
     centerMode: true,
     centerPadding: '40px',


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/1875 we wanted to decrease spacing between the company logos on the comparison box slider. To do so, i have increased the amount of logos we show on the XL view (i.e dev mode laptop L + view) 

![Screenshot 2024-07-08 at 9 30 32 AM](https://github.com/tinacms/tina.io/assets/137844305/13d19014-017f-4c5d-87c4-1826e371b53c)
**Figure: 💄Before Fix - Company Logos Spacing**


![Screenshot 2024-07-08 at 9 27 43 AM](https://github.com/tinacms/tina.io/assets/137844305/13c78c8b-a5d5-4dd6-bb5d-c7b96120c0a0)
**Figure: 💄After Fix - Company Logos Spacing**