### PR TITLE
Adds 'Problem saving your document' section to FAQ

### DIFF
--- a/content/docs/errors/faq.md
+++ b/content/docs/errors/faq.md
@@ -2,6 +2,24 @@
 title: 'FAQ: Content API Errors'
 ---
 
+## There was a problem saving your document
+
+When using Tina Cloud without [Editorial Workflow](https://tina.io/editorial-workflow/), you need to ensure that the [Tina Cloud App](https://github.com/apps/tina-cloud-app) is able to commit to the selected branch of the repository.
+
+If it cannot, you will see an error of the following form:
+
+```
+Tina caught an error while updating the page:
+
+Error: Unable to fetch, errors:
+    Error in PUT for src/pages/some-page.md
+```
+
+To fix this issue, either:
+
+- [Modify the branch's protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule#editing-a-branch-protection-rule) to allow the Tina Cloud App to bypass the [require a pull request before merging](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging) rule, or
+- Enable [Editorial Workflow](https://tina.io/editorial-workflow/) to create PRs on the branch.
+
 ## Invalid or undefined branch
 
 The current branch that Tina is using is invalid or undefined. Double check that the correct branch is selected and it does in fact exist.

--- a/content/docs/errors/faq.md
+++ b/content/docs/errors/faq.md
@@ -8,7 +8,7 @@ When using Tina Cloud without [Editorial Workflow](/editorial-workflow), you nee
 
 If it cannot, you will see an error of the following form:
 
-```diff
+```text
 Tina caught an error while updating the page:
 
 Error: Unable to fetch, errors:

--- a/content/docs/errors/faq.md
+++ b/content/docs/errors/faq.md
@@ -8,7 +8,7 @@ When using Tina Cloud without [Editorial Workflow](/editorial-workflow), you nee
 
 If it cannot, you will see an error of the following form:
 
-```
+```diff
 Tina caught an error while updating the page:
 
 Error: Unable to fetch, errors:

--- a/content/docs/errors/faq.md
+++ b/content/docs/errors/faq.md
@@ -4,7 +4,7 @@ title: 'FAQ: Content API Errors'
 
 ## There was a problem saving your document
 
-When using Tina Cloud without [Editorial Workflow](https://tina.io/editorial-workflow/), you need to ensure that the [Tina Cloud App](https://github.com/apps/tina-cloud-app) is able to commit to the selected branch of the repository.
+When using Tina Cloud without [Editorial Workflow](/editorial-workflow), you need to ensure that the [Tina Cloud App](https://github.com/apps/tina-cloud-app) is able to commit to the selected branch of the repository.
 
 If it cannot, you will see an error of the following form:
 
@@ -18,7 +18,7 @@ Error: Unable to fetch, errors:
 To fix this issue, either:
 
 - [Modify the branch's protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule#editing-a-branch-protection-rule) to allow the Tina Cloud App to bypass the [require a pull request before merging](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging) rule, or
-- Enable [Editorial Workflow](https://tina.io/editorial-workflow/) to create PRs on the branch.
+- Enable [Editorial Workflow](/editorial-workflow) to create PRs on the branch.
 
 ## Invalid or undefined branch
 


### PR DESCRIPTION
Users have reported issues arising from GitHub branch protection rules being enforced. This change adds a section regarding document saving issues, with general guidance on how to resolve them.

Issue 2108 has been raised separately on Tina Cloud to fix the error message displayed.

### General Contributing:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

* [x] Title is short & specific
* [x] Headers are logically ordered & consistent
* [x] Purpose of document is explained in the first paragraph
* [x] Procedures are tested and work
* [x] Any technical concepts are explained or linked to
* [x] Document follows structure from templates
* [x] All links work
* [x] The spelling and grammar checker has been run
* [x] Graphics and images are clear and useful
* [x] Any prerequisites and next steps are defined.
