### PR TITLE
💄UI docs pagination

### DIFF
--- a/components/ui/DocsPagination.tsx
+++ b/components/ui/DocsPagination.tsx
@@ -23,31 +23,30 @@ export function DocsPagination({ prevPage, nextPage }: PaginationProps) {
           >
             <span className="text-sm uppercase opacity-50">Previous</span>
             <h5
-              className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500"
+              className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500 flex items-center"
             >
+              <RightArrowSvg className="w-8 h-8 fill-gray-400 transition-all ease-out duration-150 rotate-180 group-hover:fill-orange-500 mr-2" />
               {prevPage.title}
             </h5>
-            <RightArrowSvg className="absolute left-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 rotate-180 group-hover:fill-orange-500" />
           </a>
         </DynamicLink>
       )}
-{nextPage && nextPage.slug && (
-  <DynamicLink href={`${nextPage.slug}`} passHref>
-    <a
-      className="col-start-2 block p-4 text-right pr-14 relative transition-all group border border-gray-100"
-      style={{ backgroundColor: '#FAFAFA' }}
-    >
-      <span className="text-sm uppercase opacity-50">Next</span>
-      <h5
-        className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500 absolute -top-1"
-      >
-        {nextPage.title}
-      </h5>
-      <RightArrowSvg className="absolute right-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 group-hover:fill-orange-500 pt-3 mt-2" />
-    </a>
-  </DynamicLink>
-)}
-
+      {nextPage && nextPage.slug && (
+        <DynamicLink href={`${nextPage.slug}`} passHref>
+          <a
+            className="col-start-2 block p-4 text-right pr-14 relative transition-all group border border-gray-100"
+            style={{ backgroundColor: '#FAFAFA' }}
+          >
+            <span className="text-sm uppercase opacity-50">Next</span>
+            <h5
+              className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500 flex items-center justify-end"
+            >
+              {nextPage.title}
+              <RightArrowSvg className="w-8 h-8 fill-gray-400 transition-all ease-out duration-150 group-hover:fill-orange-500 ml-2" />
+            </h5>
+          </a>
+        </DynamicLink>
+      )}
     </div>
   )
 }

--- a/components/ui/DocsPagination.tsx
+++ b/components/ui/DocsPagination.tsx
@@ -34,7 +34,7 @@ export function DocsPagination({ prevPage, nextPage }: PaginationProps) {
       {nextPage && nextPage.slug && (
         <DynamicLink href={`${nextPage.slug}`} passHref>
           <a
-            className="block p-4 text-right pr-14 relative transition-all group border border-gray-100"
+            className=" col-start-2 block p-4 text-right pr-14 relative transition-all group border border-gray-100"
             style={{ backgroundColor: '#FAFAFA' }}
           >
             <span className="text-sm uppercase opacity-50">Next</span>

--- a/components/ui/DocsPagination.tsx
+++ b/components/ui/DocsPagination.tsx
@@ -17,8 +17,8 @@ export function DocsPagination({ prevPage, nextPage }: PaginationProps) {
     <div className="mt-8 grid grid-cols-2 gap-4">
       {prevPage && prevPage.slug && (
         <DynamicLink href={`${prevPage.slug}`} passHref>
-          <a
-            className="block p-4 text-left relative transition-all group border border-gray-100"
+          <div
+            className="block p-4 text-left relative transition-all group border border-gray-100 cursor-pointer"
             style={{ backgroundColor: '#FAFAFA' }}
           >
             <span className="text-sm uppercase opacity-50 pl-10">Previous</span>
@@ -28,13 +28,13 @@ export function DocsPagination({ prevPage, nextPage }: PaginationProps) {
               <RightArrowSvg className="w-8 h-8 fill-gray-400 transition-all ease-out duration-150 rotate-180 group-hover:fill-orange-500 mr-2" />
               {prevPage.title}
             </h5>
-          </a>
+          </div>
         </DynamicLink>
       )}
       {nextPage && nextPage.slug && (
         <DynamicLink href={`${nextPage.slug}`} passHref>
-          <a
-            className="col-start-2 block p-4 text-right relative transition-all group border border-gray-100"
+          <div
+            className="col-start-2 block p-4 text-right relative transition-all group border border-gray-100 cursor-pointer"
             style={{ backgroundColor: '#FAFAFA' }}
           >
             <span className="text-sm uppercase opacity-50 pr-10">Next</span>
@@ -44,7 +44,7 @@ export function DocsPagination({ prevPage, nextPage }: PaginationProps) {
               {nextPage.title}
               <RightArrowSvg className="w-8 h-8 fill-gray-400 transition-all ease-out duration-150 group-hover:fill-orange-500 ml-2" />
             </h5>
-          </a>
+          </div>
         </DynamicLink>
       )}
     </div>

--- a/components/ui/DocsPagination.tsx
+++ b/components/ui/DocsPagination.tsx
@@ -14,43 +14,36 @@ interface PaginationProps {
 
 export function DocsPagination({ prevPage, nextPage }: PaginationProps) {
   return (
-    <div className="mt-8 grid grid-cols-2 gap-4 rounded overflow-hidden p-0.5">
+    <div className="mt-8 grid grid-cols-2 gap-4">
       {prevPage && prevPage.slug && (
-        <div className="p-0.5" style={{ backgroundColor: '#E9E9E9' }}>
-          <DynamicLink href={`${prevPage.slug}`} passHref>
-            <a
-              className="block p-4 text-left pl-14 relative transition-all group"
-              style={{ backgroundColor: '#FAFAFA' }}
+        <DynamicLink href={`${prevPage.slug}`} passHref>
+          <a
+            className="block p-4 text-left pl-14 relative transition-all group border border-gray-100"
+            style={{ backgroundColor: '#FAFAFA' }}
+          >
+            <span className="text-sm uppercase opacity-50">Previous</span>
+            <h5
+              className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500"
             >
-              <span className="text-sm uppercase opacity-50">Previous</span>
-              <h5
-                className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500"
-              >
-                {prevPage.title}
-              </h5>
-              <RightArrowSvg className="absolute left-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 rotate-180 group-hover:fill-orange-500" />
-            </a>
-          </DynamicLink>
-        </div>
+              {prevPage.title}
+            </h5>
+            <RightArrowSvg className="absolute left-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 rotate-180 group-hover:fill-orange-500" />
+          </a>
+        </DynamicLink>
       )}
       {nextPage && nextPage.slug && (
-        <div
-          className="p-0.5 col-start-2"
-          style={{ backgroundColor: '#E9E9E9' }}
-        >
-          <DynamicLink href={`${nextPage.slug}`} passHref>
-            <a
-              className="block p-4 text-right pr-14 relative transition-all group"
-              style={{ backgroundColor: '#FAFAFA' }}
-            >
-              <span className="text-sm uppercase opacity-50">Next</span>
-              <h5 className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500">
-                {nextPage.title}
-              </h5>
-              <RightArrowSvg className="absolute right-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 group-hover:fill-orange-500" />
-            </a>
-          </DynamicLink>
-        </div>
+        <DynamicLink href={`${nextPage.slug}`} passHref>
+          <a
+            className="block p-4 text-right pr-14 relative transition-all group border border-gray-100"
+            style={{ backgroundColor: '#FAFAFA' }}
+          >
+            <span className="text-sm uppercase opacity-50">Next</span>
+            <h5 className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500">
+              {nextPage.title}
+            </h5>
+            <RightArrowSvg className="absolute right-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 group-hover:fill-orange-500" />
+          </a>
+        </DynamicLink>
       )}
     </div>
   )

--- a/components/ui/DocsPagination.tsx
+++ b/components/ui/DocsPagination.tsx
@@ -43,7 +43,7 @@ export function DocsPagination({ prevPage, nextPage }: PaginationProps) {
       >
         {nextPage.title}
       </h5>
-      <RightArrowSvg className="absolute right-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 group-hover:fill-orange-500 pt-1 mt-2" />
+      <RightArrowSvg className="absolute right-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 group-hover:fill-orange-500 pt-3 mt-2" />
     </a>
   </DynamicLink>
 )}

--- a/components/ui/DocsPagination.tsx
+++ b/components/ui/DocsPagination.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import styled, { css } from 'styled-components'
 import RightArrowSvg from '../../public/svg/right-arrow.svg'
 import { DynamicLink } from '../ui/DynamicLink'
+
 interface NextPrevPageProps {
   title: string
   slug: string
@@ -14,109 +14,46 @@ interface PaginationProps {
 
 export function DocsPagination({ prevPage, nextPage }: PaginationProps) {
   return (
-    <Wrapper>
+    <div className="mt-8 grid grid-cols-2 gap-4 rounded overflow-hidden p-0.5">
       {prevPage && prevPage.slug && (
-        <DynamicLink href={`${prevPage.slug}`} passHref>
-          <PaginationLink previous>
-            <span>Previous</span>
-            <h5>{prevPage.title}</h5>
-            <RightArrowSvg />
-          </PaginationLink>
-        </DynamicLink>
+        <div className="p-0.5" style={{ backgroundColor: '#E9E9E9' }}>
+          <DynamicLink href={`${prevPage.slug}`} passHref>
+            <a
+              className="block p-4 text-left pl-14 relative transition-all group"
+              style={{ backgroundColor: '#FAFAFA' }}
+            >
+              <span className="text-sm uppercase opacity-50">Previous</span>
+              <h5
+                className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500"
+              >
+                {prevPage.title}
+              </h5>
+              <RightArrowSvg className="absolute left-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 rotate-180 group-hover:fill-orange-500" />
+            </a>
+          </DynamicLink>
+        </div>
       )}
       {nextPage && nextPage.slug && (
-        <DynamicLink href={`${nextPage.slug}`} passHref>
-          <PaginationLink>
-            <span>Next</span>
-            <h5>{nextPage.title}</h5>
-            <RightArrowSvg />
-          </PaginationLink>
-        </DynamicLink>
+        <div
+          className="p-0.5 col-start-2"
+          style={{ backgroundColor: '#E9E9E9' }}
+        >
+          <DynamicLink href={`${nextPage.slug}`} passHref>
+            <a
+              className="block p-4 text-right pr-14 relative transition-all group"
+              style={{ backgroundColor: '#FAFAFA' }}
+            >
+              <span className="text-sm uppercase opacity-50">Next</span>
+              <h5 className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500">
+                {nextPage.title}
+              </h5>
+              <RightArrowSvg className="absolute right-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 group-hover:fill-orange-500" />
+            </a>
+          </DynamicLink>
+        </div>
       )}
-    </Wrapper>
+    </div>
   )
 }
 
 export default DocsPagination
-
-/*
- ** Styles ------------------------------------------
- */
-
-interface PaginationLinkProps {
-  previous?: boolean
-}
-
-const PaginationLink = styled.a<PaginationLinkProps>`
-  padding: 1rem;
-  display: block;
-  flex: 1 1 auto;
-  font-family: var(--font-tuner);
-  font-weight: regular;
-  font-style: normal;
-  text-decoration: none;
-  background-color: #fafafa;
-  color: var(--color-secondary);
-  position: relative;
-  text-align: right;
-  padding-right: 3.5rem;
-  margin: 0 1px 1px 0;
-
-  span {
-    font-size: 0.9375rem;
-    text-transform: uppercase;
-    opacity: 0.5;
-  }
-
-  h5 {
-    font-size: 1.25rem;
-    line-height: 1.3;
-    margin: 0 !important;
-    transition: all 180ms ease-out;
-  }
-
-  svg {
-    position: absolute;
-    right: 0.75rem;
-    top: 50%;
-    transform: translate3d(0, -50%, 0);
-    width: 2rem;
-    height: auto;
-    fill: var(--color-grey);
-    transition: all 180ms ease-out;
-  }
-
-  &:hover {
-    h5 {
-      color: var(--color-orange);
-    }
-    svg {
-      fill: var(--color-orange);
-    }
-  }
-
-  ${props =>
-    props.previous &&
-    css`
-      padding-right: 1rem;
-      padding-left: 3.5rem;
-      text-align: left;
-
-      svg {
-        right: auto;
-        left: 0.75rem;
-        transform: translate3d(0, -50%, 0) rotate(180deg);
-      }
-    `};
-`
-
-const Wrapper = styled.div`
-  margin-top: 2rem;
-  background-color: var(--color-light-dark);
-  display: flex;
-  border-radius: 5px;
-  overflow: hidden;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  padding: 1px 0 0 1px;
-`

--- a/components/ui/DocsPagination.tsx
+++ b/components/ui/DocsPagination.tsx
@@ -18,12 +18,12 @@ export function DocsPagination({ prevPage, nextPage }: PaginationProps) {
       {prevPage && prevPage.slug && (
         <DynamicLink href={`${prevPage.slug}`} passHref>
           <a
-            className="block p-4 text-left pl-14 relative transition-all group border border-gray-100"
+            className="block p-4 text-left relative transition-all group border border-gray-100"
             style={{ backgroundColor: '#FAFAFA' }}
           >
-            <span className="text-sm uppercase opacity-50">Previous</span>
+            <span className="text-sm uppercase opacity-50 pl-10">Previous</span>
             <h5
-              className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500 flex items-center"
+              className="text-xl leading-[1.3] m-0 pl transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500 flex items-center"
             >
               <RightArrowSvg className="w-8 h-8 fill-gray-400 transition-all ease-out duration-150 rotate-180 group-hover:fill-orange-500 mr-2" />
               {prevPage.title}
@@ -34,10 +34,10 @@ export function DocsPagination({ prevPage, nextPage }: PaginationProps) {
       {nextPage && nextPage.slug && (
         <DynamicLink href={`${nextPage.slug}`} passHref>
           <a
-            className="col-start-2 block p-4 text-right pr-14 relative transition-all group border border-gray-100"
+            className="col-start-2 block p-4 text-right relative transition-all group border border-gray-100"
             style={{ backgroundColor: '#FAFAFA' }}
           >
-            <span className="text-sm uppercase opacity-50">Next</span>
+            <span className="text-sm uppercase opacity-50 pr-10">Next</span>
             <h5
               className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500 flex items-center justify-end"
             >

--- a/components/ui/DocsPagination.tsx
+++ b/components/ui/DocsPagination.tsx
@@ -31,20 +31,23 @@ export function DocsPagination({ prevPage, nextPage }: PaginationProps) {
           </a>
         </DynamicLink>
       )}
-      {nextPage && nextPage.slug && (
-        <DynamicLink href={`${nextPage.slug}`} passHref>
-          <a
-            className=" col-start-2 block p-4 text-right pr-14 relative transition-all group border border-gray-100"
-            style={{ backgroundColor: '#FAFAFA' }}
-          >
-            <span className="text-sm uppercase opacity-50">Next</span>
-            <h5 className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500">
-              {nextPage.title}
-            </h5>
-            <RightArrowSvg className="absolute right-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 group-hover:fill-orange-500" />
-          </a>
-        </DynamicLink>
-      )}
+{nextPage && nextPage.slug && (
+  <DynamicLink href={`${nextPage.slug}`} passHref>
+    <a
+      className="col-start-2 block p-4 text-right pr-14 relative transition-all group border border-gray-100"
+      style={{ backgroundColor: '#FAFAFA' }}
+    >
+      <span className="text-sm uppercase opacity-50">Next</span>
+      <h5
+        className="text-xl leading-[1.3] m-0 transition-all ease-out duration-150 text-blue-800 group-hover:text-orange-500 absolute -top-1"
+      >
+        {nextPage.title}
+      </h5>
+      <RightArrowSvg className="absolute right-3 top-1/2 transform -translate-y-1/2 w-8 fill-gray-400 transition-all ease-out duration-150 group-hover:fill-orange-500 pt-1 mt-2" />
+    </a>
+  </DynamicLink>
+)}
+
     </div>
   )
 }

--- a/content/docs/extending-tina/validation.mdx
+++ b/content/docs/extending-tina/validation.mdx
@@ -11,7 +11,26 @@ To include other field values of the form in the validation, a data argument can
 
 ## Example
 
-### Validate the length of a \`string\` field![](https://res.cloudinary.com/forestry-demo/image/upload/v1722216591/invalid1_fbnwh1.png)
+### Validate the length of a \`string\` field
+
+```javascript
+{
+  label: "Title",
+  name: "title",
+  type: "string",
+  ui: {
+    validate: (value, data)=>{
+      const lengthOfTitle = value?.length || 0
+      const lengthOfDescription = data?.description?.length || 0
+      if(lengthOfTitle >= lengthOfDescription){
+        return 'The description must be longer than the title'
+      }
+    }
+  }
+}
+```
+
+![](https://res.cloudinary.com/forestry-demo/image/upload/v1722216591/invalid1_fbnwh1.png)
 
 The following schema types support the use of `validate`:
 

--- a/content/docs/extending-tina/validation.mdx
+++ b/content/docs/extending-tina/validation.mdx
@@ -1,6 +1,5 @@
 ---
 id: /docs/extending-tina/validation/
-
 title: Validation
 next: content/docs/extending-tina/custom-field-components.mdx
 previous: content/docs/extending-tina/overview.mdx
@@ -12,25 +11,12 @@ To include other field values of the form in the validation, a data argument can
 
 ## Example
 
-### Validate the length of a \`string\` field
-
-<ImageAndText
-  text={<>
-    ```
-    {
-    label:
-    
-    
-    }
-    ```
-  </>}
-  image="https://res.cloudinary.com/forestry-demo/image/upload/v1722216591/invalid1_fbnwh1.png"
-/>
+### Validate the length of a \`string\` field![](https://res.cloudinary.com/forestry-demo/image/upload/v1722216591/invalid1_fbnwh1.png)
 
 The following schema types support the use of `validate`:
 
-- [string](/docs/reference/types/string/)
-- [datetime](/docs/reference/types/datetime/)
-- [boolean](/docs/reference/types/boolean/)
-- [image](/docs/reference/types/image/)
-- [number](/docs/reference/types/number/)
+* [string](/docs/reference/types/string/)
+* [datetime](/docs/reference/types/datetime/)
+* [boolean](/docs/reference/types/boolean/)
+* [image](/docs/reference/types/image/)
+* [number](/docs/reference/types/number/)

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -29,6 +29,7 @@ import { BiRightArrowAlt } from 'react-icons/bi'
 import { getDocId } from 'utils/docs/getDocIds'
 import { FaPlus, FaMinus } from 'react-icons/fa'
 import { useState } from 'react'
+import Image from 'next/image'
 
 export const components: Components<{
   Iframe: { iframeSrc: string; height: string }
@@ -61,7 +62,7 @@ export const components: Components<{
           />{' '}
         </div>
         <div>
-          <img src={props?.image} alt="image" className="w-full" />
+          <Image src={props?.image} alt="image" className="w-full" />
         </div>
       </div>
     )

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -19,7 +19,11 @@ import { openGraphImage } from 'utils/open-graph-image'
 import { WarningCallout } from '../../utils/shortcodes'
 import { useTina } from 'tinacms/dist/react'
 import path from 'path'
-import { TinaMarkdown, Components, TinaMarkdownContent } from 'tinacms/dist/rich-text'
+import {
+  TinaMarkdown,
+  Components,
+  TinaMarkdownContent,
+} from 'tinacms/dist/rich-text'
 import { Prism } from '../../components/styles/Prism'
 import { BiRightArrowAlt } from 'react-icons/bi'
 import { getDocId } from 'utils/docs/getDocIds'
@@ -28,7 +32,7 @@ import { useState } from 'react'
 
 export const components: Components<{
   Iframe: { iframeSrc: string; height: string }
-  Youtube: { embedSrc: string }
+  Youtube: { embedSrc: string;}
   CreateAppCta: { ctaText: string; cliText: string }
   Callout: {
     title: string
@@ -48,36 +52,47 @@ export const components: Components<{
 }> = {
   ImageAndText: (props) => {
     return (
-<div className='grid grid-cols-2 gap-4'>
-  <div className='bg-red'> <TinaMarkdown content={props.docText as any} components={components} /> </div>
-  <div>
-    <img src={props?.image} alt='image' className='w-full'/>
-  </div>
-</div>
-  )},
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-red">
+          {' '}
+          <TinaMarkdown
+            content={props.docText as any}
+            components={components}
+          />{' '}
+        </div>
+        <div>
+          <img src={props?.image} alt="image" className="w-full" />
+        </div>
+      </div>
+    )
+  },
 
   Summary: (props) => {
-    const [openTab, setOpenTab] = useState(false);
+    const [openTab, setOpenTab] = useState(false)
 
     const handleToggle = () => {
-      setOpenTab(!openTab);
-    };
+      setOpenTab(!openTab)
+    }
 
     console.log('props found', props.text)
 
     return (
       <div>
         <hr></hr>
-        <button className="flex w-full items-start justify-between text-left text-gray-900" onClick={handleToggle}>
+        <button
+          className="flex w-full items-start justify-between text-left text-gray-900"
+          onClick={handleToggle}
+        >
           <h3>{props.heading}</h3>
-            {openTab ? <FaMinus /> : <FaPlus />}
-          </button>
-        {openTab && 
+          {openTab ? <FaMinus /> : <FaPlus />}
+        </button>
+        {openTab && (
           <div>
-            <TinaMarkdown content={props.text as any} components={components}/>
-          </div>}
+            <TinaMarkdown content={props.text as any} components={components} />
+          </div>
+        )}
       </div>
-    );
+    )
   },
 
   h1: (props) => <FormatHeaders level={1} {...props} />,
@@ -88,18 +103,23 @@ export const components: Components<{
   h6: (props) => <FormatHeaders level={6} {...props} />,
 
   Iframe: ({ iframeSrc, height }) => {
-    return <iframe width="100%" height={`${height}px`} src={iframeSrc} />
+    return (
+      <div>
+        <iframe width="100%" height={`${height}px`} src={iframeSrc} />
+      </div>
+    )
   },
   Youtube: ({ embedSrc }) => (
-    <iframe
-      width="560"
-      height="315"
-      src={embedSrc}
-      title="YouTube video player"
-      frameBorder="0"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-      allowFullScreen={true}
-    ></iframe>
+    <div className="youtube-container">
+      <iframe
+        width="560"
+        height="315"
+        src={embedSrc}
+        title="YouTube video player"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen={true}
+      ></iframe>
+    </div>
   ),
   CreateAppCta: ({ ctaText, cliText }) => (
     <>
@@ -164,20 +184,22 @@ export const components: Components<{
     </div>
   ),
   Codesandbox: ({ embedSrc, title }) => (
-    <iframe
-      src={embedSrc}
-      style={{
-        width: '100%',
-        height: '500px',
-        border: 'none',
-        borderRadius: '4px',
-        overflow: 'hidden',
-      }}
-      title={title}
-      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-      className="wide"
-    ></iframe>
+    <div>
+      <iframe
+        src={embedSrc}
+        style={{
+          width: '100%',
+          height: '500px',
+          border: 'none',
+          borderRadius: '4px',
+          overflow: 'hidden',
+        }}
+        title={title}
+        allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+        sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+        className="wide"
+      ></iframe>
+    </div>
   ),
   Diagram: ({ alt, src }) => (
     <img
@@ -260,11 +282,7 @@ function FormatHeaders({ children, level }) {
   const HeadingTag = `h${level}` as any
   const id = getDocId(children.props.content[0].text)
 
-  return (
-    <HeadingTag id={id}>
-      {children.props.content[0].text}
-    </HeadingTag>
-  )
+  return <HeadingTag id={id}>{children.props.content[0].text}</HeadingTag>
 }
 
 function BlogTemplate({ file, siteConfig, ...props }) {

--- a/pages/docs/product-tour.tsx
+++ b/pages/docs/product-tour.tsx
@@ -169,7 +169,9 @@ export default function Page(props) {
               </div>
             </SplitContent>
             <LastEdited date={doc_data.last_edited} />
-              <DocsPagination prevPage={previousPage} nextPage={nextPage} />
+            <div className='w-1/2'>
+                            <DocsPagination prevPage={previousPage} nextPage={nextPage} />
+            </div>
           </DocGridContent>
         </DocContainer>
       </DocsLayout>

--- a/pages/docs/product-tour.tsx
+++ b/pages/docs/product-tour.tsx
@@ -7,11 +7,7 @@ import * as ga from '../../utils/ga'
 import { NextSeo } from 'next-seo'
 import { openGraphImage } from 'utils/open-graph-image'
 import { DocsLayout, MarkdownContent } from 'components/layout'
-import {
-  DocGridContent,
-  DocGridHeader,
-  DocsPageTitle,
-} from './[...slug]'
+import { DocGridContent, DocGridHeader, DocsPageTitle } from './[...slug]'
 import { Breadcrumbs } from 'components/DocumentationNavigation/Breadcrumbs'
 import { DocsPagination, LastEdited } from 'components/ui'
 import styled from 'styled-components'
@@ -22,7 +18,9 @@ import { components } from 'pages/blog/[slug]'
 import { getSeoDescription } from 'utils/docs/getSeoDescription'
 
 export const getStaticProps: GetStaticProps = async function (props) {
-  const new_results = await client.queries.doc({ relativePath: `product-tour.mdx` })
+  const new_results = await client.queries.doc({
+    relativePath: `product-tour.mdx`,
+  })
   const oldNavDocs = await getDocsNav()
   return { props: { new: { new_results }, oldNavDocs } }
 }
@@ -169,8 +167,8 @@ export default function Page(props) {
               </div>
             </SplitContent>
             <LastEdited date={doc_data.last_edited} />
-            <div className='w-1/2'>
-                            <DocsPagination prevPage={previousPage} nextPage={nextPage} />
+            <div className="w-1/2">
+              <DocsPagination prevPage={previousPage} nextPage={nextPage} />
             </div>
           </DocGridContent>
         </DocContainer>


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/1929 this PR addresses the UI of the docs pagination

- [ ] Having only a `next` will show the next on the right side of screen (see figure) 
- [ ] having only `prev` will show prev on the left side of screen (see figure) 
- [ ] Arrow aligned with the prev/ next

![Screenshot 2024-08-02 at 5 35 24 PM](https://github.com/user-attachments/assets/8fd5a45a-8f4a-44b7-9f9b-e49780a2f2cb)

**Figure: ❌ Current - NEXT is over entire page**

![Screenshot 2024-08-02 at 5 36 05 PM](https://github.com/user-attachments/assets/e8497482-e337-447f-b73b-3a4952471059)
**Figure: ✅ Test passed by @bettybondoc - NEXT is only on the right**

