### PR TITLE
🐞 Headings cut off prematurely, small change so they render properly again

### DIFF
--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -283,7 +283,7 @@ function FormatHeaders({ children, level }) {
   const HeadingTag = `h${level}` as any
   const id = getDocId(children.props.content[0].text)
 
-  return <HeadingTag id={id}>{children.props.content[0].text}</HeadingTag>
+  return <HeadingTag id={id}>{children}</HeadingTag>
 }
 
 function BlogTemplate({ file, siteConfig, ...props }) {

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -281,7 +281,7 @@ export const components: Components<{
 
 function FormatHeaders({ children, level }) {
   const HeadingTag = `h${level}` as any
-  const id = getDocId(children.props.content[0].text)
+  const id = getDocId(children.props.content.map(content => content.text).join(''))
 
   return <HeadingTag id={id}>{children}</HeadingTag>
 }


### PR DESCRIPTION
Headings were getting cut off as they were split into children and only the first was being taken in some cases, changed to include all children.

![2024-08-07_14-56-53](https://github.com/user-attachments/assets/e3ec624e-28bd-481a-8002-f9bfea947a60)
*Figure 1 – bugged headings*

![2024-08-07_15-02-07](https://github.com/user-attachments/assets/a2235bbc-8672-498b-94ca-9164e063e5b8)
*Figure 2 – post fix*

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

- [ ] Title is short & specific
- [ ] Headers are logically ordered & consistent
- [ ] Purpose of document is explained in the first paragraph
- [ ] Procedures are tested and work
- [ ] Any technical concepts are explained or linked to
- [ ] Document follows structure from templates
- [ ] All links work
- [ ] The spelling and grammar checker has been run
- [ ] Graphics and images are clear and useful
- [ ] Any prerequisites and next steps are defined.
