### PR TITLE
♻️ Refactor Icon Selector Component

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "trailingComma": "es5",
-  "semi": false,
+  "semi": true,
   "singleQuote": true,
   "tabWidth": 2
 }

--- a/components/blocks/IconSelector.tsx
+++ b/components/blocks/IconSelector.tsx
@@ -81,6 +81,7 @@ const IconSelector = ({ input }) => {
                 <IconComponent
                   color={selectedIcon === key ? 'blue' : 'black'}
                   size={16}
+                  className="mr-2"
                 />
                 <span className="text-xs">{trimmedKey}</span>
               </div>

--- a/components/blocks/IconSelector.tsx
+++ b/components/blocks/IconSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState } from 'react';
 import {
   FaClock,
   FaUnlock,
@@ -13,14 +13,17 @@ import {
   FaShare,
   FaDesktop,
   FaLockOpen,
-} from 'react-icons/fa'
-import { AiOutlineUser } from 'react-icons/ai'
-import { BiBadge, BiSupport } from 'react-icons/bi'
-import { AiOutlineUsergroupAdd } from 'react-icons/ai'
-import { CgCrown } from 'react-icons/cg'
-import { HiOutlineSparkles } from 'react-icons/hi2'
-import { TbPlugConnected } from 'react-icons/tb'
-import { SlLock } from 'react-icons/sl'
+  FaArrowDown,
+  FaAngleDown,
+  FaAngleUp,
+} from 'react-icons/fa';
+import { AiOutlineUser } from 'react-icons/ai';
+import { BiBadge, BiSupport } from 'react-icons/bi';
+import { AiOutlineUsergroupAdd } from 'react-icons/ai';
+import { CgCrown } from 'react-icons/cg';
+import { HiOutlineSparkles } from 'react-icons/hi2';
+import { TbPlugConnected } from 'react-icons/tb';
+import { SlLock } from 'react-icons/sl';
 
 const icons = {
   FaClock,
@@ -44,37 +47,53 @@ const icons = {
   FaDesktop,
   FaLockOpen,
   FaHandPointer,
-}
+};
 
 const IconSelector = ({ input }) => {
-  const iconKeys = Object.keys(icons)
-  const [selectedIcon, setSelectedIcon] = useState(input.value || '')
-  const [isMinimized, setIsMinimized] = useState(true)
+  const iconKeys = Object.keys(icons);
+  const [selectedIcon, setSelectedIcon] = useState(input.value || '');
+  const [isMinimized, setIsMinimized] = useState(true);
 
   const handleIconChange = (iconKey) => {
-    setSelectedIcon(iconKey)
-    input.onChange(iconKey)
-  }
+    setSelectedIcon(iconKey);
+    input.onChange(iconKey);
+  };
 
   const toggleMinimize = () => {
-    setIsMinimized(!isMinimized)
-  }
+    setIsMinimized(!isMinimized);
+  };
+
+  const TinaButtonClasses =
+    'text-sm mb-2 shadow focus:shadow-outline focus:border-blue-500 w-full border border-gray-100 hover:border-gray-200 text-gray-500 hover:text-blue-400 focus:text-blue-500 rounded-md';
 
   return (
     <div>
-      <button onClick={toggleMinimize} className='text-red-600 text-sm mb-2'>
-        {isMinimized ? 'Show Icons' : 'Minimize Icons'}
+      <button
+        onClick={toggleMinimize}
+        className={`${TinaButtonClasses} bg-white hover:bg-gray-50`}
+      >
+        <span className="inline-flex items-center m-2">
+          {isMinimized ? (
+            <>
+              Show icons <FaAngleDown className="m-1" />
+            </>
+          ) : (
+            <>
+              Hide icons <FaAngleUp className="m-1" />
+            </>
+          )}{' '}
+        </span>
       </button>
       {!isMinimized && (
         <div className="grid grid-cols-2 gap-2">
           {iconKeys.map((key) => {
-            const IconComponent = icons[key]
-            const trimmedKey = key.slice(2)
+            const IconComponent = icons[key];
+            const trimmedKey = key.slice(2);
             return (
               <div
                 key={key}
                 onClick={() => handleIconChange(key)}
-                className={`flex items-center cursor-pointer p-2 ${
+                className={`${TinaButtonClasses} flex items-center cursor-pointer p-2 ${
                   selectedIcon === key ? 'bg-blue-200' : 'bg-white'
                 }`}
               >
@@ -85,12 +104,12 @@ const IconSelector = ({ input }) => {
                 />
                 <span className="text-xs">{trimmedKey}</span>
               </div>
-            )
+            );
           })}
         </div>
       )}
     </div>
-  )
-}
+  );
+};
 
-export default IconSelector
+export default IconSelector;

--- a/components/blocks/IconSelector.tsx
+++ b/components/blocks/IconSelector.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   FaClock,
   FaUnlock,
@@ -12,12 +12,10 @@ import {
   FaDatabase,
   FaShare,
   FaDesktop,
-  FaLockOpen
-
+  FaLockOpen,
 } from 'react-icons/fa'
 import { AiOutlineUser } from 'react-icons/ai'
-import { BiBadge } from 'react-icons/bi'
-import { BiSupport } from 'react-icons/bi'
+import { BiBadge, BiSupport } from 'react-icons/bi'
 import { AiOutlineUsergroupAdd } from 'react-icons/ai'
 import { CgCrown } from 'react-icons/cg'
 import { HiOutlineSparkles } from 'react-icons/hi2'
@@ -45,23 +43,52 @@ const icons = {
   FaShare,
   FaDesktop,
   FaLockOpen,
-  FaHandPointer
+  FaHandPointer,
 }
 
 const IconSelector = ({ input }) => {
   const iconKeys = Object.keys(icons)
+  const [selectedIcon, setSelectedIcon] = useState(input.value || '')
+  const [isMinimized, setIsMinimized] = useState(true)
+
+  const handleIconChange = (iconKey) => {
+    setSelectedIcon(iconKey)
+    input.onChange(iconKey)
+  }
+
+  const toggleMinimize = () => {
+    setIsMinimized(!isMinimized)
+  }
 
   return (
-    <select
-      value={input.value}
-      onChange={(event) => input.onChange(event.target.value)}
-    >
-      {iconKeys.map((key) => (
-        <option key={key} value={key}>
-          {key}
-        </option>
-      ))}
-    </select>
+    <div>
+      <button onClick={toggleMinimize} className='text-red-600 text-sm mb-2'>
+        {isMinimized ? 'Show Icons' : 'Minimize Icons'}
+      </button>
+      {!isMinimized && (
+        <div className="grid grid-cols-2 gap-2">
+          {iconKeys.map((key) => {
+            const IconComponent = icons[key]
+            const trimmedKey = key.slice(2)
+            return (
+              <div
+                key={key}
+                onClick={() => handleIconChange(key)}
+                className={`flex items-center cursor-pointer p-2 ${
+                  selectedIcon === key ? 'bg-blue-200' : 'bg-white'
+                }`}
+              >
+                <IconComponent
+                  color={selectedIcon === key ? 'blue' : 'black'}
+                  size={16}
+                />
+                <span className="text-xs">{trimmedKey}</span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/2086 i have refactored the icon selector component to have

 1. a drop down,
 2. displaying the icons nexto the names and 
 3. removing the prefix (i.e 'Fa') 
 
<img width="350" alt="Screenshot 2024-09-02 at 5 59 17 PM" src="https://github.com/user-attachments/assets/0dc57868-a36f-4122-aaaa-0ce8b8c25e61">

**Figure: Click 'Show Icons'**

<img width="354" alt="Screenshot 2024-09-02 at 5 59 37 PM" src="https://github.com/user-attachments/assets/768d04f5-3c5d-4a8a-8289-946b86682727">

**Figure: New Icon Selector**

