### PR TITLE
📄 Removed public reference to private repo

### DIFF
--- a/content/docs/tina-cloud/branching.mdx
+++ b/content/docs/tina-cloud/branching.mdx
@@ -19,8 +19,6 @@ cmsCallback: (cms) => {
 ```
 
 \
-For an example, see [this repo](https://github.com/tinacms/demo-incremental/blob/main/.tina/config.tsx#L16).
-
 ## Demo
 
 Here is a quick video demo of Tina's branch plugin


### PR DESCRIPTION
We had a reference to a private repo on https://tina.io/docs/tina-cloud/branching/. The related PBI is https://github.com/tinacms/tina.io/issues/1985.

This PR removes the reference to private repo so users dont think the link is broken 