### PR TITLE
workflow - added a workflow to create a what's new page

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.yml]
+indent_style = space
+space_indentation = 2

--- a/.github/workflows/dispatch-create-whats-new-page.yml
+++ b/.github/workflows/dispatch-create-whats-new-page.yml
@@ -1,0 +1,58 @@
+name: Create What's New Page for TinaCMS or TinaCloud
+
+on:
+  workflow_dispatch:
+    inputs:
+      project:
+        description: 'The project to create the Whats New page for.'
+        required: true
+      versionNumber:
+        description: 'The version of the project to create the Whats New page for.'
+        required: true
+      dateReleased:
+        description: 'The date the version was released.'
+        required: true
+      releaseNotes:
+        description: 'The release notes for the version.'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-whats-new-page:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create What's New Page
+        run: |
+          ./scripts/create-whats-new-page.sh
+        env:
+          PROJECT_NAME: ${{ github.event.inputs.project }}
+          VERSION_NUMBER: ${{ github.event.inputs.versionNumber }}
+          DATE_RELEASED: ${{ github.event.inputs.dateReleased }}
+          RELEASE_NOTES: ${{ github.event.inputs.releaseNotes }}
+
+      - name: Create Pull Request
+        id: create-pull-request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: Release Notes - Add ${{ github.event.inputs.project }} ${{ github.event.inputs.versionNumber }}
+          title: Release Notes - Add ${{ github.event.inputs.project }} ${{ github.event.inputs.versionNumber }}
+          body: |
+            This PR adds the release notes for ${{ github.event.inputs.project }} ${{ github.event.inputs.versionNumber }}.
+
+            This was created automatically by a GitHub Action - `.github/workflows/dispatch-create-whats-new-page.yml`
+          branch: releaseNotes/${{ github.event.inputs.project }}-${{ github.event.inputs.releaseNotes }}
+          # We only expect changes to these folders
+          add-paths: |
+            content/*
+
+      - name: Enable Auto-Merge
+        if: ${{ steps.create-pull-request.outputs.pull-request-number }}
+        run: gh pr merge -s --auto ${{ steps.create-pull-request.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/create-release-notes.sh
+++ b/scripts/create-release-notes.sh
@@ -1,0 +1,47 @@
+#! /bin/sh
+
+# This script uses 4 environment variables:
+# - PROJECT_NAME: the name of the project
+# - VERSION_NUMBER: the version of the release
+# - DATE_RELEASED: the date of the release
+# - RELEASE_NOTES: the content of the release notes in markdown format
+
+# Check if the environment variables are set
+if [ -z "$PROJECT_NAME" ]; then
+  echo "PROJECT_NAME is not set"
+  exit 1
+fi
+if [ -z "$VERSION_NUMBER" ]; then
+  echo "VERSION_NUMBER is not set"
+  exit 1
+fi
+if [ -z "$DATE_RELEASED" ]; then
+  echo "DATE_RELEASED is not set"
+  exit 1
+fi
+if [ -z "$RELEASE_NOTES" ]; then
+  echo "RELEASE_NOTES is not set"
+  exit 1
+fi
+
+# Create the release notes file
+pathToReleaseNotesRoot="content/whats-new-$(echo "$PROJECT_NAME" | tr '[:upper:]' '[:lower:]')"
+releaseNotesFile="$pathToReleaseNotesRoot/$(echo "$VERSION_NUMBER" | tr '[:upper:]' '[:lower:]').mdx"
+
+echo "Creating release notes file: $releaseNotesFile"
+
+{
+  echo "---"
+  # Trim the 'v' prefix if it exists in VERSION_NUMBER
+  trimmedVersionNumber=$(echo "$VERSION_NUMBER" | sed 's/^v//')
+  echo "versionNumber: $trimmedVersionNumber"
+  echo "dateReleased: $DATE_RELEASED"
+  echo "---"
+  echo ""
+  # Use printf to correctly interpret \n as new lines
+  printf "%b\n" "$RELEASE_NOTES"
+} > "$releaseNotesFile"
+
+
+echo "✅ File created"
+cat $releaseNotesFile


### PR DESCRIPTION
Intent is to get TinaCMS and TinaCloud repos to call this workflow when pushing new releases to production.

Workflow also opens a new PR (with automerge). Once this is known to be stable - rules can be relaxed for these PRs

scripts/create-release-notes.sh - creates the file in the same format as the existing release notes

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

- [ ] Title is short & specific
- [ ] Headers are logically ordered & consistent
- [ ] Purpose of document is explained in the first paragraph
- [ ] Procedures are tested and work
- [ ] Any technical concepts are explained or linked to
- [ ] Document follows structure from templates
- [ ] All links work
- [ ] The spelling and grammar checker has been run
- [ ] Graphics and images are clear and useful
- [ ] Any prerequisites and next steps are defined.
