### PR TITLE
dispatch-create-whats-new-page - fix branch name

### DIFF
--- a/.github/workflows/dispatch-create-whats-new-page.yml
+++ b/.github/workflows/dispatch-create-whats-new-page.yml
@@ -46,7 +46,7 @@ jobs:
             This PR adds the release notes for ${{ github.event.inputs.project }} ${{ github.event.inputs.versionNumber }}.
 
             This was created automatically by a GitHub Action - `.github/workflows/dispatch-create-whats-new-page.yml`
-          branch: releaseNotes/${{ github.event.inputs.project }}-${{ github.event.inputs.releaseNotes }}
+          branch: releaseNotes/${{ github.event.inputs.project }}-${{ github.event.inputs.versionNumber }}
           # We only expect changes to these folders
           add-paths: |
             content/*

--- a/content/whats-new-tinacloud/2024.09.22.mdx
+++ b/content/whats-new-tinacloud/2024.09.22.mdx
@@ -1,8 +1,0 @@
----
-versionNumber: 2024.09.22
-dateReleased: 2024-09-16T12:34:16Z
----
-
-## What's Changed
-### \u2728 Features
-* fix: description in project configuration still refs .tina by @kldavis4 in https:\/\/github.com\/tinacms\/tinacloud\/pull\/2287

--- a/content/whats-new-tinacloud/2024.09.22.mdx
+++ b/content/whats-new-tinacloud/2024.09.22.mdx
@@ -1,0 +1,8 @@
+---
+versionNumber: 2024.09.22
+dateReleased: 2024-09-16T12:34:16Z
+---
+
+## What's Changed
+### \u2728 Features
+* fix: description in project configuration still refs .tina by @kldavis4 in https:\/\/github.com\/tinacms\/tinacloud\/pull\/2287


### PR DESCRIPTION
Based off the logs from https://github.com/tinacms/tina.io/actions/runs/10893065830/job/30227231474 - the release notes were being used to generate the branch name

This PR uses the version number in the branch name and should alleviate the issue

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

- [ ] Title is short & specific
- [ ] Headers are logically ordered & consistent
- [ ] Purpose of document is explained in the first paragraph
- [ ] Procedures are tested and work
- [ ] Any technical concepts are explained or linked to
- [ ] Document follows structure from templates
- [ ] All links work
- [ ] The spelling and grammar checker has been run
- [ ] Graphics and images are clear and useful
- [ ] Any prerequisites and next steps are defined.
