### PR TITLE
🐛 Docs Title Styling Fix – Code Blocks

### DIFF
--- a/components/tinaMarkdownComponents/docAndBlogComponents.tsx
+++ b/components/tinaMarkdownComponents/docAndBlogComponents.tsx
@@ -1,16 +1,16 @@
 import { GraphQLQueryResponseTabs } from 'components/ui/GraphQLQueryResponseTabs';
+import Image from 'next/image';
 import { useState } from 'react';
 import { BiRightArrowAlt } from 'react-icons/bi';
 import { FaMinus, FaPlus } from 'react-icons/fa';
 import { FiLink } from 'react-icons/fi';
 import {
-    TinaMarkdown,
-    Components,
-  } from 'tinacms/dist/rich-text'
+  Components,
+  TinaMarkdown,
+} from 'tinacms/dist/rich-text';
 import { getDocId } from 'utils/docs/getDocIds';
 import { WarningCallout } from 'utils/shortcodes';
-import { Prism } from '../styles/Prism'
-import Image from 'next/image';
+import { Prism } from '../styles/Prism';
 
 export const docAndBlogComponents: Components<{
     Iframe: { iframeSrc: string; height: string }
@@ -280,9 +280,9 @@ export const docAndBlogComponents: Components<{
   
     return (
       <HeadingTag id={id} className="relative cursor-pointer">
-        <a href={linkHref} className="no-underline flex items-center group">
+        <a href={linkHref} className="no-underline group">
           {children}
-          <FiLink className="ml-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
+          <FiLink className="ml-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 inline-flex mb-2" />
         </a>
       </HeadingTag>
     );


### PR DESCRIPTION
There was a bit of styling that was interfering with the titles in doc bodies. See Screenshots below.

Removed the flex styling and made the link portion (only) with flex properties. Added some bottom margin to raise it up as well.

### Screenshots

![2024-09-18_14-35-47](https://github.com/user-attachments/assets/c5c73c4d-46d8-4dc2-b3b8-1ffdfdb5f6a9)
**From (bugged)**

![2024-09-18_14-35-27](https://github.com/user-attachments/assets/34559815-b214-46c4-a85b-476e3d8c88ae)
**To (with fix)**

<details>
### General Contributing:

- [ ] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

- [ ] Title is short & specific
- [ ] Headers are logically ordered & consistent
- [ ] Purpose of document is explained in the first paragraph
- [ ] Procedures are tested and work
- [ ] Any technical concepts are explained or linked to
- [ ] Document follows structure from templates
- [ ] All links work
- [ ] The spelling and grammar checker has been run
- [ ] Graphics and images are clear and useful
- [ ] Any prerequisites and next steps are defined.
</details>