### PR TITLE
🐛 /whats-new/tinacms mobile ui fix layout bug 

### DIFF
--- a/pages/whats-new/tinacms.tsx
+++ b/pages/whats-new/tinacms.tsx
@@ -25,7 +25,7 @@ export const getStaticProps = async () => {
 const Tinacms = ({ items }) => {
   return (
     <Layout>
-      <div className="p-6 py-12 lg:py-16 last:pb-20 last:lg:pb-32 max-w-prose mx-auto">
+      <div className="p-6 py-12 lg:py-16 last:pb-20 last:lg:pb-32 max-w-prose md:mx-auto">
         <h1 className="text-center justify-center font-tuner text-3xl lg:text-4xl lg:leading-tight bg-gradient-to-br from-orange-400 via-orange-600 to-orange-700 group-hover:from-orange-300 group-hover:via-orange-500 group-hover:to-orange-700 bg-clip-text text-transparent">
           What's new with TinaCMS
         </h1>


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/2194 I have addressed the mobile ui of the /whats-new/tinacms page.

Prior, it seemed that mx-auto was setting a margin for the smaller screens and therefore we had a gutter of white. I have restricted this to only medium+ screens using tailwind. 

Tssted on iPhone 15 Safari ✅
![IMG_8046](https://github.com/user-attachments/assets/88510503-8c9c-44ce-bfd1-a56813c92e3e)
**Figure: iPhone 15 Test**