### PR TITLE
♻️ Refactor carousel to use NextJS' Image component

### DIFF
--- a/components/blocks/CarouselFeature.tsx
+++ b/components/blocks/CarouselFeature.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import React, { useEffect, useRef, useState } from 'react';
 import { tinaField } from 'tinacms/dist/react';
 import { sanitizeLabel } from 'utils/sanitizeLabel';
@@ -170,12 +171,16 @@ export function CarouselFeatureBlock({ data, index }) {
     const fileExtension = fullVideoUrl.split('.').pop();
 
     if (fileExtension === 'gif') {
+      // Width and height values *must* be provided to NextJS's Image component to build,
+      // but they will not determine the rendered size of the image in this case.
       return (
         <div className="flex justify-center items-center">
-          <img
+          <Image
             key={index}
             src={fullVideoUrl}
             alt={`Media item ${index}`}
+            width={1200}
+            height={800}
             className="w-full h-auto mt-10 lg:mt-0 rounded-xl shadow-lg"
           />
         </div>


### PR DESCRIPTION
### General Contributing:

Refactors the carousel component to use NextJS' image component, which will permit the use of intermediate caching for GIFs and defer content loading until image is visible

### All New Content Submissions: (To be confirmed by reviewer)

- [ ] Title is short & specific
- [ ] Headers are logically ordered & consistent
- [ ] Purpose of document is explained in the first paragraph
- [ ] Procedures are tested and work
- [ ] Any technical concepts are explained or linked to
- [ ] Document follows structure from templates
- [ ] All links work
- [ ] The spelling and grammar checker has been run
- [ ] Graphics and images are clear and useful
- [ ] Any prerequisites and next steps are defined.
