### PR TITLE
Fixes spacing around pictures in 'reference/types/object'.

### DIFF
--- a/content/docs/reference/types/object.mdx
+++ b/content/docs/reference/types/object.mdx
@@ -45,15 +45,15 @@ Ultimately there are 3 ways to configure this type...
 
 * With `list` set to `false`, the `fields` array can be used to wrap some data – this appears in the editor as a nested page. This can be used to organise the CMS, such as grouping options together, as in the gif below.
 
-<WebmEmbed embedSrc="/img/docs/reference/rodmap-grid.webm" width="50%" />
+  <WebmEmbed embedSrc="/img/docs/reference/rodmap-grid.webm" width="50%" />
 
 * With `list` set to `true`, the `fields` array contains the data structure to be repeated – this appears in the editor as above, but grouped as a list.
 
-<WebmEmbed embedSrc="/img/docs/reference/roadmap-items.webm" width="50%" />
+  <WebmEmbed embedSrc="/img/docs/reference/roadmap-items.webm" width="50%" />
 
 * With `list` set to `true`, and using `templates` as opposed to `fields` the user can select between associated templates – this appears as above, but pressing the `+`  gives you the option to choose between templates.
 
-<WebmEmbed embedSrc="/img/docs/reference/text-and-media-component.webm" width="50%" />
+  <WebmEmbed embedSrc="/img/docs/reference/text-and-media-component.webm" width="50%" />
 
 ## Examples
 


### PR DESCRIPTION
Dropping '-' in mdx so that the inconsistent margins are removed