### PR TITLE
SEO & Redirects - Remove Trailing Slash and Fix Redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -86,7 +86,6 @@ const config = {
       },
     ]
   },
-  trailingSlash: true,
   exportPathMap: async function () {
     return {}
   },

--- a/vercel.json
+++ b/vercel.json
@@ -250,11 +250,7 @@
       "destination": "/",
       "permanent": true
     },
-    {
-      "source": "/enterprise/",
-      "destination": "/",
-      "permanent": true
-    },
+
     {
       "source": "/docs/gatsby/quickstart/",
       "destination": "/guides/gatsby/adding-tina/project-setup",


### PR DESCRIPTION
This PR is to address [#24](https://github.com/tinacms/business-backlog/issues/24)

Essentially we were seeing in our SEMRush audits that we had a series of long redirect chains. However they were primarily because we were using the 'trailingSlash: true' which saw redirects that did not have an appended final '/' having added them.

i.e if we re-routed a user to `/legacy-redirect`, our config was then re-routing to `/legacy-redirect/`

Adding this extra forward slash was increasing this chain. 

@landonmaxwell tested this branch on SEMRush and found that this fixed the issue o redirect chains and loops

![image (7)](https://github.com/user-attachments/assets/e6420eaf-601a-4ad5-8b61-de36967ab3d2)
**Figure: Long Redirect chains eliminated**