### PR TITLE
🌠 Fix Lost Media

### DIFF
--- a/content/docs/forestry/media.mdx
+++ b/content/docs/forestry/media.mdx
@@ -16,7 +16,7 @@ Each media destination was configured through ForestryCMS's UI
 
 ## Media in TinaCMS
 
-![](https://tina.io/img/media-manager-ui.png)
+![](/img/media-manager-ui.png)
 
 At this time, Tina has integrations the following media solutions:
 


### PR DESCRIPTION
As per [🖼️ Broken image link - Migrating from Forestry Docs](https://github.com/tinacms/tina.io/issues/2383) fixes media

<img width="1254" alt="Screenshot 2024-11-04 at 9 40 11 am" src="https://github.com/user-attachments/assets/ec64c90e-ef31-4c4b-ab60-e7f59b0b2d1c">

**Figure: Media being served in preview**