### PR TITLE
🌠 Fix docs highlighting 

### DIFF
--- a/components/DocumentationNavigation/DocsNavigationList.tsx
+++ b/components/DocumentationNavigation/DocsNavigationList.tsx
@@ -17,6 +17,7 @@ interface NavTitleProps {
   onClick?: () => void;
 }
 
+
 const NavTitle = ({
   children,
   level = 3,

--- a/components/DocumentationNavigation/DocsNavigationList.tsx
+++ b/components/DocumentationNavigation/DocsNavigationList.tsx
@@ -90,17 +90,18 @@ const NavLevel = ({
   const navLevelElem = React.useRef(null);
   const router = useRouter();
   const path = router.asPath;
-  const slug = categoryData.slug;
+  const slug = categoryData.slug?.replace(/\/$/, '');
   const [expanded, setExpanded] = React.useState(
     matchActualTarget(slug || categoryData.href, path) ||
       hasNestedSlug(categoryData.items, path) ||
       level === 0
   );
 
-  const selected = path.split("#")[0] == slug || (slug == '/docs' && path == "/docs/")
-  const childSelected = hasNestedSlug(categoryData.items, router.asPath)
 
+  const selected =
+    path.split('#')[0] == slug || (slug == '/docs' && path == '/docs/');
 
+  const childSelected = hasNestedSlug(categoryData.items, router.asPath);
   React.useEffect(() => {
     if (
       navListElem &&
@@ -124,7 +125,6 @@ const NavLevel = ({
       }
     }
   }, [navLevelElem.current, navListElem, selected]);
-
   return (
     <>
       <NavLabelContainer ref={navLevelElem} status={categoryData.status}>
@@ -157,17 +157,26 @@ const NavLevel = ({
             )}
           </NavTitle>
         )}
+        
+        {!childSelected && selected && level > 0 && (
+          <div
+            className="absolute right-0 top-1/2 -translate-y-1/2 h-[5px] w-full -z-10"
+            
+          ></div>
+        )}
       </NavLabelContainer>
       {categoryData.items && (
         <AnimateHeight duration={300} height={expanded ? 'auto' : 0}>
           <NavLevelChildContainer level={level}>
             {(categoryData.items || []).map((item) => (
-              <NavLevel
-                key={item.slug ? item.slug + level : item.title + level}
-                navListElem={navListElem}
-                level={level + 1}
-                categoryData={item}
-              />
+              <div>
+                <NavLevel
+                  key={item.slug ? item.slug + level : item.title + level}
+                  navListElem={navListElem}
+                  level={level + 1}
+                  categoryData={item}
+                />
+              </div>
             ))}
           </NavLevelChildContainer>
         </AnimateHeight>
@@ -251,7 +260,6 @@ export const DocsNavigationList = ({ navItems }: DocsNavProps) => {
     </>
   );
 };
-
 
 const DocsNavigationContainer = styled.div`
   overflow-y: auto;

--- a/components/DocumentationNavigation/DocsNavigationList.tsx
+++ b/components/DocumentationNavigation/DocsNavigationList.tsx
@@ -18,6 +18,7 @@ interface NavTitleProps {
 }
 
 
+
 const NavTitle = ({
   children,
   level = 3,


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/2403 

I investigated as to why the highlighting wasnt working - through a series of logs i found it was because one of the conditions of a nav item being highlighted was `!categoryData.items && !selected`. 

Upon further looking it turns out that the `selected` boolean wasnt being set correctly due to a trailing back slash. 

This would be due to the removal of automatic trailing backslashes made last week as we aimed to reduce our redirect chains (see https://github.com/tinacms/tina.io/pull/2399 for more context) 

This PR just removes the trailing backslash at the end of the `slug` var using regex 