### PR TITLE
drop z-index for lefthand nav

### DIFF
--- a/components/DocumentationNavigation/DocsLeftSidebar.tsx
+++ b/components/DocumentationNavigation/DocsLeftSidebar.tsx
@@ -6,14 +6,13 @@ export const DocsLeftSidebar = styled.div<{ open: boolean }>`
 
   padding: 10px;
   position: fixed;
-  z-index: 49;
+  z-index: 39;
   left: 0; 
   top: 0;
   width: 80%;
   min-width: 16rem;
   max-width: 24rem;
   height: 100%; 
-  z-index: 49;
   transform: translate3d(-100%, 0, 0);
   transition: all 140ms ease-in;
   display: flex;


### PR DESCRIPTION
tiny pr fix for #2452 dropping the z-index of the left hand navigation menu 

**Changes**
- removed duplicate z-index css 
- dropped z-index below nav bar hover item z-index (49 -> 39) 