### PR TITLE
🔌 Change DEMO Url

### DIFF
--- a/content/blocksPages/home.json
+++ b/content/blocksPages/home.json
@@ -16,7 +16,7 @@
               "icon": true,
               "variant": "blue",
               "size": "small",
-              "url": "https://quick-edit-demo.vercel.app/admin#/~",
+              "url": "https://demo.tina.io/admin#/~",
               "_template": "actions"
             },
             {
@@ -146,7 +146,7 @@
             "icon": true,
             "variant": "ghostBlue",
             "size": "medium",
-            "url": "https://quick-edit-demo.vercel.app/admin#/"
+            "url": "https://demo.tina.io/admin#/"
           }
         },
         {

--- a/content/blog/Click-to-Edit-Comes-to-Visual-Editing.mdx
+++ b/content/blog/Click-to-Edit-Comes-to-Visual-Editing.mdx
@@ -16,7 +16,7 @@ Our goal is to make visual editing the most intuitive editing experience _withou
 
 If you want to get a feel for the UX, try this demo (no log in required).
 
-<Button link="https://quick-edit-demo.vercel.app/admin" label="Try the Demo" />
+<Button link="https://demo.tina.io/admin" label="Try the Demo" />
 
 ## Getting Started
 

--- a/content/docs/contextual-editing/react.mdx
+++ b/content/docs/contextual-editing/react.mdx
@@ -63,7 +63,7 @@ Tina's "click to edit" feature allows editors to select the element they want to
 
 <WebmEmbed embedSrc="/video/quick-edit-demo.webm"/>
 
-> [Try the demo](https://quick-edit-demo.vercel.app/admin#/~)!
+> [Try the demo](https://demo.tina.io/admin#/~)!
 
 In order for this to work, Tina needs to know what document and field the
 element is associated with. Tina makes this easy with the `tinaField` helper

--- a/content/docs/contextual-editing/tinafield.mdx
+++ b/content/docs/contextual-editing/tinafield.mdx
@@ -9,7 +9,7 @@ Tina's "click to edit" feature allows editors to select the element they want to
 
 <WebmEmbed embedSrc="/video/quick-edit-demo.webm"/>
 
-> [Try the demo](https://quick-edit-demo.vercel.app/admin#/~)!
+> [Try the demo](https://demo.tina.io/admin#/~)!
 
 In order for this to work, Tina needs to know what document and field the
 element is associated with. Tina makes this easy with the `tinaField` helper


### PR DESCRIPTION
For https://github.com/tinacms/quick-edit-demo/issues/11 we created a subdomain `demo.tina.io` to make the site more integrated to our tina.io. 

This PR just changes all url references on tina.io from `quick-edit-demo.vercel.app` to `demo.tina.io`

![Screenshot 2024-11-13 at 12 40 29 pm](https://github.com/user-attachments/assets/9a727740-f060-480e-9a20-ab68b9b63f4d)

**Figure: Vercel Domains - Old Domain Redirects to New (301)**