### PR TITLE
add explicit markdown styling for anchor tags

### DIFF
--- a/components/tinaMarkdownComponents/docAndBlogComponents.tsx
+++ b/components/tinaMarkdownComponents/docAndBlogComponents.tsx
@@ -49,8 +49,7 @@ export const docAndBlogComponents: Components<{
 }> = {
   recipeBlock: (props) => {
     return (
-      <div className='text-white'>
-        TEST
+      <div className="text-white">
         <RecipeBlock data={props} />
       </div>
     );
@@ -109,6 +108,16 @@ export const docAndBlogComponents: Components<{
   ul: (props) => <ul className="list-disc ml-5" {...props} />,
   ol: (props) => <ol className="list-decimal ml-5" {...props} />,
   li: (props) => <li className="mb-2" {...props} />,
+  a: (props) => {
+    return (
+      <a
+        href={props.url}
+        {...props}
+        className="underline opacity-80 transition-all duration-[185ms] ease-out hover:text-orange-500"
+      />
+      //Ripped the styling from styles/RichText.tsx " a:not([class]) "
+    );
+  },
 
   Iframe: ({ iframeSrc, height }) => {
     return (


### PR DESCRIPTION
As per #2506

- Issue was occurring on safari (instead of chromium browsers) 
- safari wasnt recognising `text-decoration: underline rgba(0, 0, 0, 0.3);` in css sheet 
- added explicit markdown styling for <a/> tags

<img width="1332" alt="Screenshot 2024-12-02 at 10 15 47 am" src="https://github.com/user-attachments/assets/ae0d0eb8-dfd1-4a6b-921d-93b5bf26619c">

**Figure: Safari underlined links fixed**
