### PR TITLE
Attempted Fix for Safari Issues

### DIFF
--- a/components/blocks/FeatureCarousel/CarouselFeature.tsx
+++ b/components/blocks/FeatureCarousel/CarouselFeature.tsx
@@ -188,25 +188,29 @@ export function CarouselFeatureBlock({ data, index }) {
       );
     }
 
-    return (
-      <video
-        key={index}
-        autoPlay
-        muted
-        playsInline
-        loop
-        preload="metadata"
-        className="w-full h-auto mt-6 lg:mt-0 rounded-xl shadow-lg"
-      >
-        {fullVideoUrl.endsWith('.webm') && (
-          <source src={fullVideoUrl} type="video/webm" />
-        )}
-        {fullVideoUrl.endsWith('.mp4') && (
-          <source src={fullVideoUrl} type="video/mp4" />
-        )}
-        Your browser does not support the video tag.
-      </video>
-    );
+    if (fileExtension === 'mp4' || fileExtension === 'webm') {
+      return (
+        <video
+          key={index}
+          autoPlay
+          muted
+          playsInline
+          loop
+          preload="metadata"
+          className="w-full h-auto mt-6 lg:mt-0 rounded-xl shadow-lg"
+        >
+          {fileExtension === 'webm' && (
+            <source src={fullVideoUrl} type="video/webm" />
+          )}
+          {fileExtension === 'mp4' && (
+            <source src={fullVideoUrl} type="video/mp4" />
+          )}
+          There was an issue displaying the video.
+        </video>
+      );
+    }
+
+    throw new Error(`Unsupported video format: ${fileExtension}`);
   };
 
   return (

--- a/components/blocks/FeatureCarousel/CarouselFeature.tsx
+++ b/components/blocks/FeatureCarousel/CarouselFeature.tsx
@@ -193,6 +193,7 @@ export function CarouselFeatureBlock({ data, index }) {
         key={index}
         autoPlay
         muted
+        playsInline
         loop
         className="w-full h-auto mt-6 lg:mt-0 rounded-xl shadow-lg"
       >

--- a/components/blocks/FeatureCarousel/CarouselFeature.tsx
+++ b/components/blocks/FeatureCarousel/CarouselFeature.tsx
@@ -195,10 +195,15 @@ export function CarouselFeatureBlock({ data, index }) {
         muted
         playsInline
         loop
+        preload="metadata"
         className="w-full h-auto mt-6 lg:mt-0 rounded-xl shadow-lg"
       >
-        <source src={fullVideoUrl} type="video/webm" />
-        <source src={fullVideoUrl} type="video/mp4" />
+        {fullVideoUrl.endsWith('.webm') && (
+          <source src={fullVideoUrl} type="video/webm" />
+        )}
+        {fullVideoUrl.endsWith('.mp4') && (
+          <source src={fullVideoUrl} type="video/mp4" />
+        )}
         Your browser does not support the video tag.
       </video>
     );


### PR DESCRIPTION
Video's have been made to play-inline, preload less and make source tags more explicit. Which seems to stop a constant refresh issue as described in #2589.

Trying to use an invalid file type will throw an error now too...

<img width="520" alt="SCR-20241211-ndbv" src="https://github.com/user-attachments/assets/472d46dd-5620-4fc2-995e-9473ab594bd4">


### General Contributing:

- [ ] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

- [ ] Title is short & specific
- [ ] Headers are logically ordered & consistent
- [ ] Purpose of document is explained in the first paragraph
- [ ] Procedures are tested and work
- [ ] Any technical concepts are explained or linked to
- [ ] Document follows structure from templates
- [ ] All links work
- [ ] The spelling and grammar checker has been run
- [ ] Graphics and images are clear and useful
- [ ] Any prerequisites and next steps are defined.
