### PR TITLE
🐛 Fix Doc Broken Links

### DIFF
--- a/content/docs/frameworks/next/app-router.mdx
+++ b/content/docs/frameworks/next/app-router.mdx
@@ -113,7 +113,7 @@ export default defineConfig({
 })
 ```
 
-**For a more detailed overview about the config see [Content Modeling with TinaCMS](docs/schema/)**
+**For a more detailed overview about the config see [Content Modeling with TinaCMS](/docs/extending-tina/overview/)**
 
 > 💡 If you've followed this guide using the `tina  init` command, you might have noticed that a `content` and a `pages` folder got created:
 

--- a/content/docs/frameworks/next/app-router.mdx
+++ b/content/docs/frameworks/next/app-router.mdx
@@ -113,7 +113,7 @@ export default defineConfig({
 })
 ```
 
-**For a more detailed overview about the config see [Content Modeling with TinaCMS](docs/extending-tina/overview/)**
+**For a more detailed overview about the config see [Content Modeling with TinaCMS](docs/schema/)**
 
 > 💡 If you've followed this guide using the `tina  init` command, you might have noticed that a `content` and a `pages` folder got created:
 

--- a/content/docs/frameworks/next/pages-router.mdx
+++ b/content/docs/frameworks/next/pages-router.mdx
@@ -113,7 +113,7 @@ export default defineConfig({
 })
 ```
 
-**For a more detailed overview about the config see [Content Modeling with TinaCMS](docs/schema/)**
+**For a more detailed overview about the config see [Content Modeling with TinaCMS](/docs/extending-tina/overview/)**
 
 > 💡 If you've followed this guide using the `tina  init` command, you might have noticed that a `content` and a `pages` folder got created:
 

--- a/content/docs/frameworks/next/pages-router.mdx
+++ b/content/docs/frameworks/next/pages-router.mdx
@@ -113,7 +113,7 @@ export default defineConfig({
 })
 ```
 
-**For a more detailed overview about the config see [Content Modeling with TinaCMS](docs/extending-tina/overview/)**
+**For a more detailed overview about the config see [Content Modeling with TinaCMS](docs/schema/)**
 
 > 💡 If you've followed this guide using the `tina  init` command, you might have noticed that a `content` and a `pages` folder got created:
 


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/2586 - fixing the internal linking to the TinaCMS content modelling docs