### PR TITLE
Added Docs Pagination to Setup-Overview

### DIFF
--- a/components/layout/setup-overview.tsx
+++ b/components/layout/setup-overview.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { DocsLayout } from '../../components/layout';
 import * as ga from '../../utils/ga';
 import { Actions } from '../blocks/ActionButton/ActionsButton';
+import { DocsPagination } from 'components/ui';
 
 const pageData = {
   title: 'Getting Started',
@@ -54,6 +55,9 @@ const OverviewTemplate = (props) => {
     },
   ];
 
+  const nextPage = { slug: '/introduction/using-starter', title: 'Getting Started with a Starter'}
+  const prevPage = { slug: '/product-tour', title: 'Intorudction to TinaCMS'}
+
   return (
     <>
       <NextSeo
@@ -99,6 +103,12 @@ const OverviewTemplate = (props) => {
                 />
               </a>
             ))}
+          </div>
+          <div className='pt-6'>
+            <DocsPagination
+              prevPage={prevPage}
+              nextPage={nextPage}
+            />
           </div>
         </div>
         <style jsx>{`


### PR DESCRIPTION
The docs experience wasnt great because i couldnt use the pagination from the beginning. This has been fixed by adding the `<DocsPagination/>` component to the /setup-overview page 