### PR TITLE
✨ Add Search Highlighting

### DIFF
--- a/components/docsSearch/SearchComponent.tsx
+++ b/components/docsSearch/SearchComponent.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
 import { fetchAlgoliaSearchResults } from "utils/new-search";
+import { highlightText } from "./SearchNavigation";
 
 export const SearchHeader = ({ query }: { query: string }) => {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
@@ -164,6 +165,7 @@ export const SearchTabs = ({ query }: { query: string }) => {
   );
 };
 
+
 export const SearchBody = ({
   results,
   activeItem,
@@ -172,16 +174,17 @@ export const SearchBody = ({
   activeItem: string;
 }) => {
   const bodyItem = activeItem === 'DOCS' ? results?.docs : results?.blogs;
+
   return (
     <div className="py-10">
       {bodyItem?.results.map((item: any) => (
         <div key={item.objectID} className="py-4 px-4 border-b group">
           <Link href={`/${activeItem.toLowerCase()}/${item.slug}`}>
             <h2 className="text-xl font-inter font-semibold bg-gradient-to-br from-blue-600/80 via-blue-800/80 to-blue-1000 bg-clip-text text-transparent group-hover:from-orange-300 group-hover:via-orange-400 group-hover:to-orange-600 break-words">
-              {item.title}
+              {highlightText(item._highlightResult.title.value)}
             </h2>
             <p className="text-gray-600 group-hover:text-gray-800 text-sm font-light line-clamp-3 break-words">
-              {item.excerpt}
+              {highlightText(item._highlightResult.excerpt?.value || '')}
             </p>
           </Link>
         </div>

--- a/components/docsSearch/SearchNavigation.tsx
+++ b/components/docsSearch/SearchNavigation.tsx
@@ -7,6 +7,30 @@ import { useEffect, useRef, useState } from 'react';
 import { HiMagnifyingGlass } from 'react-icons/hi2';
 import { fetchAlgoliaSearchResults } from 'utils/new-search';
 
+//Helper function for highlighting algolia search hits
+const highlightText = (text: string) => {
+  const regex = /<em>(.*?)<\/em>/g;
+  const segments = [];
+  let lastIndex = 0;
+
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push(text.substring(lastIndex, match.index));
+    }
+    segments.push(
+      <span key={match.index} className="bg-yellow-200 text-black font-bold">
+        {match[1]}
+      </span>
+    );
+    lastIndex = regex.lastIndex;
+  }
+  if (lastIndex < text.length) {
+    segments.push(text.substring(lastIndex));
+  }
+  return segments;
+};
+
 export const SearchResultsOverflowBody = ({
   results,
   activeItem,
@@ -21,16 +45,17 @@ export const SearchResultsOverflowBody = ({
   isLoading: boolean;
 }) => {
   const bodyItem = activeItem === 'DOCS' ? results?.docs : results?.blogs;
+
   return (
-    <div className="mt-2 py-2  max-h-[45vh]">
+    <div className="mt-2 py-2 max-h-[45vh]">
       {bodyItem?.results.slice(0, 10).map((item: any) => (
         <div key={item.objectID} className="py-2 px-4 border-b group">
           <Link href={`/${activeItem.toLowerCase()}/${item.slug}`}>
             <h2 className="text-md font-inter font-semibold bg-gradient-to-br from-blue-600/80 via-blue-800/80 to-blue-1000 bg-clip-text text-transparent group-hover:from-orange-300 group-hover:via-orange-400 group-hover:to-orange-600 break-words">
-              {item.title}
+              {highlightText(item._highlightResult.title.value)}
             </h2>
             <p className="text-gray-600 group-hover:text-gray-800 text-xs font-light line-clamp-3 break-words">
-              {item.excerpt}
+              {highlightText(item._highlightResult.excerpt?.value || '')}
             </p>
           </Link>
         </div>
@@ -56,6 +81,7 @@ export const SearchResultsOverflowBody = ({
     </div>
   );
 };
+
 
 export const SearchResultsOverflowTabs = ({ query }) => {
   const [activeTab, setActiveTab] = useState('DOCS');
@@ -227,7 +253,7 @@ export const DocsSearchBarHeader = ({
               setSearchOverflowOpen(false);
             }
           }}
-        />{' '}
+        />
       </div>
       {userHasTyped && searchOverFlowOpen && (
         <SearchResultsOverflow query={searchTerm} />

--- a/components/docsSearch/SearchNavigation.tsx
+++ b/components/docsSearch/SearchNavigation.tsx
@@ -19,7 +19,7 @@ const highlightText = (text: string) => {
       segments.push(text.substring(lastIndex, match.index));
     }
     segments.push(
-      <span key={match.index} className="bg-yellow-200 text-black font-bold">
+      <span key={match.index} className="bg-orange-200 text-black font-bold">
         {match[1]}
       </span>
     );

--- a/components/docsSearch/SearchNavigation.tsx
+++ b/components/docsSearch/SearchNavigation.tsx
@@ -8,7 +8,7 @@ import { HiMagnifyingGlass } from 'react-icons/hi2';
 import { fetchAlgoliaSearchResults } from 'utils/new-search';
 
 //Helper function for highlighting algolia search hits
-const highlightText = (text: string) => {
+export const highlightText = (text: string) => {
   const regex = /<em>(.*?)<\/em>/g;
   const segments = [];
   let lastIndex = 0;

--- a/utils/new-search.tsx
+++ b/utils/new-search.tsx
@@ -5,7 +5,8 @@ const DEFAULT_ALGOLIA_SEARCH_KEY = 'f13c10ad814c92b85f380deadc2db2dc';
 
 const searchClient = algoliasearch(
   process.env.GATSBY_ALGOLIA_APP_ID || DEFAULT_ALGOLIA_APP_ID,
-  (process.env.GATSBY_ALGOLIA_SEARCH_KEY || DEFAULT_ALGOLIA_SEARCH_KEY) as string
+  (process.env.GATSBY_ALGOLIA_SEARCH_KEY ||
+    DEFAULT_ALGOLIA_SEARCH_KEY) as string
 );
 
 interface SearchResults {
@@ -13,15 +14,21 @@ interface SearchResults {
   blogs: { results: any[]; count: number };
 }
 
-export const fetchAlgoliaSearchResults = async (query: string): Promise<SearchResults> => {
+export const fetchAlgoliaSearchResults = async (
+  query: string
+): Promise<SearchResults> => {
   try {
-    
     const [docsResults, blogsResults] = await Promise.all([
-      searchClient.initIndex('Tina-Docs-Next').search(query, { hitsPerPage: 50 }),
-      searchClient.initIndex('Tina-Blogs-Next').search(query, { hitsPerPage: 50 }),
+      searchClient
+        .initIndex('Tina-Docs-Next')
+        .search(query, { hitsPerPage: 50, attributesToHighlight: ['title', 'excerpt']
+      }),
+      searchClient
+        .initIndex('Tina-Blogs-Next')
+        .search(query, { hitsPerPage: 50 , attributesToHighlight: ['title', 'excerpt']
+      }),
     ]);
 
-    
     return {
       docs: { results: docsResults.hits, count: docsResults.nbHits },
       blogs: { results: blogsResults.hits, count: blogsResults.nbHits },


### PR DESCRIPTION
As per #2551 we want to be able to see highlighting in our search hits. This was an awesome feature of the old docs searching that we still need to reimplement into the new style of search

Added a helper function which, when passed through the newly included `item._highlightResult` will regex match to format hits accordingly 

![Screenshot 2024-12-23 at 11 10 32 am](https://github.com/user-attachments/assets/5352c17b-bf75-4d02-96ba-4180d7f38bab)
**Figure: Highlighting Search Results**

![Screenshot 2024-12-23 at 11 15 02 am](https://github.com/user-attachments/assets/77f7b0ea-b4b2-450c-8482-b444bd4adb09)

**Figure: Highlight search results on /search**
