### PR TITLE
added lang tag to _document.tsx

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -31,7 +31,7 @@ export default class MyDocument extends Document {
 
   render() {
     return (
-      <Html>
+      <Html lang='en-US'>
         <Head>
           {/* Google Tag Manager */}
           <script


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/2636 added lang tag to _document.tsx because language doesnt change on tina.io / we do not support multi-lingual 