### PR TITLE
💄 Docs – Adding some padding to the bottom of the layout grid

### DIFF
--- a/components/layout/DocsLayout.tsx
+++ b/components/layout/DocsLayout.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import styled from 'styled-components';
+import { LeftHandSideParentContainer } from 'components/docsSearch/SearchNavigation';
 import { DefaultSeo } from 'next-seo';
 import { useRouter } from 'next/router';
-import { Footer } from './Footer';
-import { DocsTextWrapper } from './DocsTextWrapper';
+import React from 'react';
+import styled from 'styled-components';
 import { Overlay } from '../ui';
-import { Navbar } from './Navbar';
+import { DocsTextWrapper } from './DocsTextWrapper';
+import { Footer } from './Footer';
 import { Layout } from './Layout';
-import { LeftHandSideParentContainer } from 'components/docsSearch/SearchNavigation';
+import { Navbar } from './Navbar';
 
 interface DocsLayoutProps {
   navItems: any;
@@ -28,8 +28,7 @@ export const DocsLayout = React.memo(
             <DocsMain>
               <DocsTextWrapper>{children}</DocsTextWrapper>
             </DocsMain>
-            <DocsFooterWrapper>
-            </DocsFooterWrapper>
+            <DocsFooterWrapper></DocsFooterWrapper>
           </DocsLayoutGrid>
         </Layout>
       </>
@@ -38,6 +37,7 @@ export const DocsLayout = React.memo(
 );
 
 const DocsLayoutGrid = styled.div`
+  padding-bottom: 2rem;
   display: grid;
   min-height: 100vh; /* Ensure grid stretches to viewport height */
   grid-template-columns: min(33vw, 20rem) minmax(0, 1fr);
@@ -77,5 +77,5 @@ const DocsFooterWrapper = styled.div`
   grid-area: footer;
   z-index: 1;
   position: relative;
-  margin-top: auto; 
+  margin-top: auto;
 `;


### PR DESCRIPTION
### Desc.

From adam's email...

1. See image – Left Nav when you go to the bottom, there should still be a little bit of white space before the orange footer

### Screenshots

![image](https://github.com/user-attachments/assets/827a2c90-343b-41eb-bc9a-fd37f17391a5)
**Figure – Before change**

<img width="1285" alt="SCR-20241224-jirb" src="https://github.com/user-attachments/assets/fd177485-2cc8-465e-b695-94ce176e4dfa" />

**Figure – After change**

### General Contributing:

- [ ] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

- [ ] Title is short & specific
- [ ] Headers are logically ordered & consistent
- [ ] Purpose of document is explained in the first paragraph
- [ ] Procedures are tested and work
- [ ] Any technical concepts are explained or linked to
- [ ] Document follows structure from templates
- [ ] All links work
- [ ] The spelling and grammar checker has been run
- [ ] Graphics and images are clear and useful
- [ ] Any prerequisites and next steps are defined.
