### PR TITLE
📑 docs - hide date if it is null

### DIFF
--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -78,12 +78,14 @@ function _DocTemplate(props) {
   const title = doc_data.seo?.title || doc_data.title;
   const { activeIds, contentRef } = useTocListener(doc_data);
   const lastEdited = props.new.results.data.doc.last_edited;
-  const date = new Date(lastEdited);
-  const formattedDate = date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+  const date = lastEdited === null ? null : new Date(lastEdited);
+  const formattedDate = date
+    ? date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : '';
 
   const isScreenSmallerThan1200 = screenResizer().isScreenSmallerThan1200;
   const isScreenSmallerThan840 = screenResizer().isScreenSmallerThan840;
@@ -149,9 +151,14 @@ function _DocTemplate(props) {
                   content={doc_data.body}
                   components={docAndBlogComponents}
                 />
-                <span className="text-slate-500 text-md">
-                  Last Edited: {formattedDate}
-                </span>
+
+                {formattedDate && (
+                  <span className="text-slate-500 text-md">
+                    {' '}
+                    Last Edited: {formattedDate}
+                  </span>
+                )}
+
                 <DocsPagination prevPage={previousPage} nextPage={nextPage} />
               </div>
             </div>


### PR DESCRIPTION
As per #2668 some of the docs pages that havent been updated were displaying a last edited date of January 1970. This is because the date was null and it was being parsed into a default date with `Date`.

To combat this i've hidden dates if they are null 