### PR TITLE
Add Out-Dated Warning + Fix Styling of Warning Callout

### DIFF
--- a/content/docs/reference/toolkit/fields/blocks.mdx
+++ b/content/docs/reference/toolkit/fields/blocks.mdx
@@ -3,7 +3,12 @@ consumes:
   - file: /packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
     details: Shows blocks interface
 title: Blocks Field
+last_edited: '2025-01-08T01:32:08.992Z'
+next: ''
+previous: ''
 ---
+
+<WarningCallout body="This content is out-dated for the latest versions of TinaCMS. See other docs pages for more [up to date information about Blocks](/docs/editing/blocks)" />
 
 <WarningCallout body="This is an advanced-use feature, and likely not something you'll need to configure. What you probably want is the content types reference!" />
 

--- a/utils/shortcodes.tsx
+++ b/utils/shortcodes.tsx
@@ -1,16 +1,18 @@
-import styled from 'styled-components'
-import ReactMarkdown from 'react-markdown'
-import { IoMdWarning } from 'react-icons/io'
+import styled from 'styled-components';
+import ReactMarkdown from 'react-markdown';
+import { IoMdWarning } from 'react-icons/io';
 
 export const WarningCallout = styled(({ text, ...styleProps }) => {
   return (
-    <div {...styleProps}>
-      <div>
-        <ReactMarkdown>{text}</ReactMarkdown>
+    <div className='py-2'>
+      <div {...styleProps}>
+        <div>
+          <ReactMarkdown>{text}</ReactMarkdown>
+        </div>
+        <IoMdWarning />
       </div>
-      <IoMdWarning />
     </div>
-  )
+  );
 })`
   position: relative;
   display: block;
@@ -43,4 +45,4 @@ export const WarningCallout = styled(({ text, ...styleProps }) => {
     height: auto;
     fill: var(--color-orange);
   }
-`
+`;


### PR DESCRIPTION
cc: @isaaclombardssw  

As per https://github.com/tinacms/tina.io/issues/2701 all i've done is added a warning callout and fixed the padding with a `className='py-2'` 

![Screenshot 2025-01-08 at 12 33 50 pm](https://github.com/user-attachments/assets/a8206a52-8e47-4846-8d9c-0a7c69cfd878)

**Figure: Updated UI**