### PR TITLE
♻️ Refactor ToC Overflow Button on Mobile 

### DIFF
--- a/components/docsMain/tocOverflowButton.tsx
+++ b/components/docsMain/tocOverflowButton.tsx
@@ -32,7 +32,10 @@ const TocOverflowButton = (tocData) => {
 
   useEffect(() => {
     const handleClickOutside = (event) => {
-      if (containerRef.current && !containerRef.current.contains(event.target)) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target)
+      ) {
         setIsTableOfContentsOpen(false);
       }
     };
@@ -44,19 +47,23 @@ const TocOverflowButton = (tocData) => {
   }, []);
 
   return (
-    <div className="py-6 w-full" ref={containerRef}>
-      <div
-        className="py-2 px-4 border-slate-400 bg-gradient-to-r from-white/50 to-white/30 rounded-lg shadow-lg cursor-pointer"
-        onClick={() => setIsTableOfContentsOpen(!isTableOfContentsOpen)}
-      >
-        <span className="flex items-center space-x-2">
-          <MdMenu size={20} className="text-orange-500" />
-          <span className="text-slate-600 py-1">Table of Contents</span>
-        </span>
-      </div>
-      {isTableOfContentsOpen && (
-        <div className="w-full relative">
-          <TocOverflow tocData={tocData} />
+    <div>
+      {tocData.tocData.length !== 0 && (
+        <div className="py-6 w-full" ref={containerRef}>
+          <div
+            className="py-2 px-4 border-slate-400 bg-gradient-to-r from-white/50 to-white/30 rounded-lg shadow-lg cursor-pointer"
+            onClick={() => setIsTableOfContentsOpen(!isTableOfContentsOpen)}
+          >
+            <span className="flex items-center space-x-2">
+              <MdMenu size={20} className="text-orange-500" />
+              <span className="text-slate-600 py-1">Table of Contents</span>
+            </span>
+          </div>
+          {isTableOfContentsOpen && (
+            <div className="w-full relative">
+              <TocOverflow tocData={tocData} />
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
As per [🐛 Docs – Weird Conditional Behaviour on Mobile](https://github.com/tinacms/tina.io/issues/2634) the `ToCOverflow` button was acting strangely on mobile. The problem was if the ToC was emtpy the overflow was also empty and this looked bad (figure 1).

**Changes**
- [ ] added a conditional statement which hides the `ToCOverflow` button if the length of the ToC === 0 

![Screenshot 2025-01-08 at 12 46 45 pm](https://github.com/user-attachments/assets/2d37975f-4d32-4f4d-84c4-16d1f794a600)

**Figure: Problematic Empty Overflow**

![Screenshot 2025-01-08 at 12 45 29 pm](https://github.com/user-attachments/assets/3ebd984d-0391-47c9-a5ec-a691dda53021)

**Figure: Updated UI - no ToC button if it is empty**