### PR TITLE
fixed imports to app router components and data mapping

### DIFF
--- a/components/AppRouterMigrationComponents/Docs/docsMain/directoryOverflowButton.tsx
+++ b/components/AppRouterMigrationComponents/Docs/docsMain/directoryOverflowButton.tsx
@@ -1,4 +1,4 @@
-import { DocsNavigationList } from 'components/DocumentationNavigation/DocsNavigationList';
+import { DocsNavigationList } from '../DocumentationNavigation/DocsNavigationList';
 import { useState, useEffect, useRef } from 'react';
 import { MdMenu } from 'react-icons/md';
 

--- a/components/AppRouterMigrationComponents/Docs/docsMain/docsMainBody.tsx
+++ b/components/AppRouterMigrationComponents/Docs/docsMain/docsMainBody.tsx
@@ -4,11 +4,11 @@ import { Breadcrumbs } from '../DocumentationNavigation/Breadcrumbs';
 import DocsMobileHeader from './docsMobileHeader';
 
 const MainDocsBodyHeader = ({ DocumentTitle, NavigationDocsItems, allData, screenResizing }) => {
+  
   return (
     <div>
-      {/* Uncomment these lines if needed */}
       {screenResizing && (
-        <DocsMobileHeader data={allData}></DocsMobileHeader>
+        <DocsMobileHeader data={NavigationDocsItems}></DocsMobileHeader>
       )}
 
       <Breadcrumbs navItems={NavigationDocsItems} />

--- a/components/AppRouterMigrationComponents/Docs/docsMain/docsMobileHeader.tsx
+++ b/components/AppRouterMigrationComponents/Docs/docsMain/docsMobileHeader.tsx
@@ -1,4 +1,4 @@
-import { DocsSearchBarHeader } from 'components/docsSearch/SearchNavigation';
+import { DocsSearchBarHeader } from '../docsSearch/SearchNavigation';
 import { useState } from 'react';
 import { FaChevronRight } from 'react-icons/fa';
 import DirectoryOverflowButton from './directoryOverflowButton';
@@ -60,6 +60,7 @@ export const MobileVersionSelect = () => {
 };
 
 const DocsMobileHeader = (data) => {
+  
   return (
     <div className="relative pb-20">
       <DocsSearchBarHeader
@@ -69,7 +70,7 @@ const DocsMobileHeader = (data) => {
         searchMargin=""
         searchBarPadding="py-3"
       />
-      <DirectoryOverflowButton tocData={data.data.data.navDocData.data} />
+      <DirectoryOverflowButton tocData={data.data} />
     </div>
   );
 };


### PR DESCRIPTION
cc: @bradystroud @isaaclombardssw 

Brady found an issue where tina docs were not loading on his phone (see screenshot) 

I investigated it and it came from the PR on Friday https://github.com/tinacms/tina.io/pull/2712 of moving from the pages to app router for the docs. 

The primary issue was that the way data was structured was changed in a parent component and not taken all the way down to the child component. The child was therefore rendering null data from an old data structure (i.e a var was `data.data.data.navDocData.data` and now is `data.data`) 

The secondary issue was that one of the new app router components was still importing a child component from the pages router implementation.

These have now been fixed

<img width="1501" alt="Screenshot 2025-01-12 at 11 39 40 am" src="https://github.com/user-attachments/assets/135841cd-9a85-4559-a491-bdad915d4410" />
**Figure: Primary issue**
