### PR TITLE
🐛 fix recent posts styling and remove styled jsx

### DIFF
--- a/components/blocks/RecentPosts/RecentPosts.tsx
+++ b/components/blocks/RecentPosts/RecentPosts.tsx
@@ -3,11 +3,9 @@ import { DynamicLink } from 'components/ui';
 import { formatDate } from 'utils/blog_helpers';
 import { getExcerpt } from 'utils/getExcerpt';
 import { Container } from '../Container';
-import { styled } from 'styled-components';
 
 export const RecentPostsBlock = ({ data, index, recentPosts }) => {
   return (
-
     <section
       key={'recent-posts-' + index}
       className={'bg-white relative z-10 py-20 lg:py-28'}
@@ -31,14 +29,13 @@ export const RecentPostsBlock = ({ data, index, recentPosts }) => {
                     {post.title}
                   </h3>
                   <RichTextWrapper>
-                    <BlogMeta>
-                      <MetaBit>
-                        <strong>{formatDate(post.date)}</strong>
-                      </MetaBit>
-                      <MetaBit>
-                        <span>By</span> <strong>{post.author}</strong>
-                      </MetaBit>
-                    </BlogMeta>
+                    <div className="flex flex-row mb-3 text-center justify-between">
+                      <strong>{formatDate(post.date)}</strong>
+                      <div className="flex">
+                        <span className="opacity-70 mr-1">By</span>{' '}
+                        <strong>{post.author}</strong>
+                      </div>
+                    </div>
                     {getExcerpt(post.body, 200)}
                   </RichTextWrapper>
                 </div>
@@ -50,37 +47,3 @@ export const RecentPostsBlock = ({ data, index, recentPosts }) => {
     </section>
   );
 };
-
-/*
- ** STYLES ---------------------------------------------------------
- */
-
- const BlogMeta = styled.div`
- width: 100%;
- justify-content: center;
- align-items: center;
- display: flex;
- flex-direction: row;
- margin-bottom: 3rem;
- margin-top: -0.5rem;
- text-align: center;
- @media (min-width: 550px) {
-   flex-direction: row;
- }
-`
-
-const MetaWrap = styled.span`
- opacity: 0.8;
- display: flex;
- flex-direction: column;
- align-items: center;
-`
-
-const MetaBit = styled.p`
- display: flex;
- margin: 0 !important;
- span {
-   opacity: 0.7;
-   margin-right: 0.25rem;
- }
-`


### PR DESCRIPTION
Fixed the styling of the Recent Posts block - aswell as removing styled jsx. As per [🐛 UI Issue on Homepage | Recent Posts](https://github.com/tinacms/tina.io/issues/2798)

![Screenshot 2025-01-29 at 9 22 09 am](https://github.com/user-attachments/assets/ff30c487-463d-470b-8873-71137a893d70)

**Figure: Fixed UI**

<img width="1172" alt="Screenshot 2025-01-29 at 9 22 24 am" src="https://github.com/user-attachments/assets/380e8496-030b-4b70-b8c2-de6a790ded36" />

**Figure: Old bugged UI**
