### PR TITLE
Addressing seo issues

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -3,6 +3,7 @@ import client from 'tina/__generated__/client';
 import BlogPageClient from './BlogPageClient';
 import { TinaMarkdownContent } from 'tinacms/dist/rich-text';
 import { BlogPost } from './BlogType';
+import { getExcerpt } from 'utils/getExcerpt';
 
 export async function generateStaticParams() {
   let allPosts = [];
@@ -47,6 +48,7 @@ export async function generateMetadata({
 
   try {
     const { data } = await client.queries.getExpandedPostDocument(vars);
+    const excerpt = getExcerpt(data.post.body, 140);
 
     if (!data?.post) {
       console.warn(`No metadata found for slug: ${slugPath}`);
@@ -55,8 +57,10 @@ export async function generateMetadata({
 
     return {
       title: `${data.post.title} | TinaCMS Blog`,
+      description: excerpt,
       openGraph: {
         title: data.post.title,
+        description: excerpt,
       },
     };
   } catch (error) {

--- a/app/docs/[...slug]/page.tsx
+++ b/app/docs/[...slug]/page.tsx
@@ -4,6 +4,7 @@ import client from 'tina/__generated__/client';
 import { getDocsNav } from 'utils/docs/getDocProps';
 import getTableOfContents from 'utils/docs/getTableOfContents';
 import DocsClient from './DocsPagesClient';
+import { getExcerpt } from 'utils/getExcerpt';
 
 export async function generateStaticParams() {
   try{
@@ -31,10 +32,11 @@ export async function generateMetadata({
   const slug = params.slug.join('/');
   try {
     const { data } = await client.queries.doc({ relativePath: `${slug}.mdx` });
+    const excerpt = getExcerpt(data.doc.body, 140);
 
     return {
       title: `${data.doc.seo?.title || data.doc.title} | TinaCMS Docs`,
-      description: data.doc.seo?.description || '',
+      description: data.doc.seo?.description || `${excerpt} || TinaCMS Docs`,
       openGraph: {
         title: data.doc.title,
         description: data.doc.seo?.description,

--- a/app/docs/[...slug]/page.tsx
+++ b/app/docs/[...slug]/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata({
       description: data.doc.seo?.description || `${excerpt} || TinaCMS Docs`,
       openGraph: {
         title: data.doc.title,
-        description: data.doc.seo?.description,
+        description: data.doc.seo?.description || `${excerpt} || TinaCMS Docs`,
       },
     };
   } catch (error) {

--- a/content/blog/tinacms-ui-whats-next.mdx
+++ b/content/blog/tinacms-ui-whats-next.mdx
@@ -64,4 +64,3 @@ Packages are scoped to `@tinacms` when they are fundamental pieces of content ma
 
 Join the [TinaCMS Discord Server](https://discord.com/invite/zumN63Ybpf) if you have any questions or comments or if you want to get involved with TinaCMS development.
 
-Learn more about [CMS alerts](/docs/reference/alerts) and the [CMS media store](/docs/reference/media).

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,7 +1,12 @@
 ---
 id: introduction
+seo:
+  title: 'TinaCMS Docs | Get Started and learn about TinaCMS '
+  description: >-
+    TinaCMS is an open-source, Git-backed CMS with real-time editing, version
+    control, and scalability, empowering developers and content creators alike.
 title: Tina Docs
-last_edited: '2024-11-08T04:50:48.321Z'
+last_edited: '2025-01-29T03:47:38.729Z'
 next: content/docs/product-tour.mdx
 previous: ''
 ---

--- a/content/siteConfig.json
+++ b/content/siteConfig.json
@@ -1,7 +1,7 @@
 {
   "title": "Tina",
   "sidebarTitle": "Tina",
-  "seoDefaultTitle": "The Markdown CMS",
+  "seoDefaultTitle": "TinaCMS – Headless CMS with GitHub & Markdown Support",
   "description": "TinaCMS is a fully open-source headless CMS that supports Git",
   "siteUrl": "https://tina.io",
   "roadmapUrl": "https://tina.io/roadmap/",


### PR DESCRIPTION
This PR seeks to improve the SEO of the tina.io site by having unique fallback SEO descriptions primarily for the docs and blogs.

It also removes 2 old references that are not available currently 

<img width="1026" alt="Screenshot 2025-01-29 at 4 42 03 pm" src="https://github.com/user-attachments/assets/9ea33bc2-3e66-4a73-a853-70dd9f8485da" />

**Figure: Pre-Change SEO**

<img width="1023" alt="Screenshot 2025-01-29 at 4 41 49 pm" src="https://github.com/user-attachments/assets/95c5dba3-ea7d-4423-8612-5534ab4b18c5" />

**Figure: Post-change SEO**

