### PR TITLE
✨ added copy button to the prism code block for docs

### DIFF
--- a/components/tinaMarkdownComponents/docAndBlogComponents.tsx
+++ b/components/tinaMarkdownComponents/docAndBlogComponents.tsx
@@ -11,6 +11,8 @@ import { Components, TinaMarkdown } from 'tinacms/dist/rich-text';
 import { getDocId } from 'utils/docs/getDocIds';
 import { WarningCallout } from 'utils/shortcodes';
 import { Prism } from '../styles/Prism';
+import React from 'react';
+import { CheckIcon, ClipboardIcon } from '@heroicons/react/24/outline';
 const ScrollBasedShowcase = dynamic(
   () => import('./templateComponents/scrollBasedShowcase'),
   {
@@ -313,16 +315,32 @@ export const docAndBlogComponents: Components<{
   ),
   // @ts-ignore TODO: fix this in TinaCMS
   code_block: ({ value, lang, children }) => {
+    const [hasCopied, setHasCopied] = React.useState(false);
+  
+    const handleCopy = () => {
+      navigator.clipboard.writeText(children || value || "");
+      setHasCopied(true);
+      setTimeout(() => setHasCopied(false), 2000);
+    };
+  
     return (
-      <div className="py-3 word-break white-space overflow-x-hidden rounded-xl">
+      <div className="relative py-3 word-break white-space overflow-x-hidden rounded-xl">
+        <button
+          onClick={handleCopy}
+          className="absolute top-6 right-3 z-10 h-6 w-6 flex items-center justify-center text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50 rounded"
+        >
+          {hasCopied ? <CheckIcon className="h-4 w-4" /> : <ClipboardIcon className="h-4 w-4" />}
+          <span className="sr-only">Copy</span>
+        </button>
         <Prism
-          value={children || value || ''}
-          lang={lang || 'jsx'}
+          value={children || value || ""}
+          lang={lang || "jsx"}
           theme="nightOwl"
         />
       </div>
     );
   },
+  
   GraphQLCodeBlock: ({ query, response, preselectResponse }) => {
     return (
       <GraphQLQueryResponseTabs


### PR DESCRIPTION
Prompted from email (see below)

For #2811 

Added button (UI from ShadCN - https://github.com/shadcn-ui/ui/blob/main/apps/www/components/copy-button.tsx) to the prismjs docs 

Uploading Screen Recording 2025-01-29 at 5.49.31 pm.mov…

**Figure: Screen Recording - Copy!**

-------

From Dan M

Hey Nick,
 
I’m catching up on some of my CTFs and am doing an older TinaCMS one today. Seeing as this CTF was done ages ago, I’m sending my feedback via email.
 
When following a starter, there are commands I need to run in a terminal. Normally I would expect there to be a ‘copy’ widget that allows me to easy copy and paste commands between the browser and terminal. However, in the TinaCMS docs this seems to be missing.
 
Please add a ‘copy’ feature to all code snippets throughout the site