### PR TITLE
🐛 drop height of left-hand-container to fix scroll height 

### DIFF
--- a/components/AppRouterMigrationComponents/Docs/docsSearch/SearchNavigation.tsx
+++ b/components/AppRouterMigrationComponents/Docs/docsSearch/SearchNavigation.tsx
@@ -273,7 +273,7 @@ export const LeftHandSideParentContainer = ({ tableOfContents }) => {
         searchMargin="mx-3"
         searchBarPadding=""
       />
-      <div className="overflow-y-scroll overflow-x-hidden h-5/6 2xl:max-h-[75vh] pl-4 2xl:pl-0">
+      <div className="overflow-y-scroll overflow-x-hidden h-[78%] 2xl:max-h-[75vh] pl-4 2xl:pl-0">
         <DocsNavigationList navItems={tableOfContents} />
       </div>
     </div>

--- a/components/AppRouterMigrationComponents/Docs/docsSearch/SearchNavigation.tsx
+++ b/components/AppRouterMigrationComponents/Docs/docsSearch/SearchNavigation.tsx
@@ -265,7 +265,7 @@ export const DocsSearchBarHeader = ({
 
 export const LeftHandSideParentContainer = ({ tableOfContents }) => {
   return (
-    <div className="rounded-2xl shadow-xl w-full bg-white/50">
+    <div className="rounded-2xl shadow-xl w-full bg-white/50 h-5/6">
       <DocsSearchBarHeader
         paddingGlobal="p-4"
         headerColour="blue"
@@ -273,7 +273,7 @@ export const LeftHandSideParentContainer = ({ tableOfContents }) => {
         searchMargin="mx-3"
         searchBarPadding=""
       />
-      <div className="overflow-y-scroll overflow-x-hidden max-h-[62vh] 2xl:max-h-[75vh] pl-4 2xl:pl-0">
+      <div className="overflow-y-scroll overflow-x-hidden h-5/6 2xl:max-h-[75vh] pl-4 2xl:pl-0">
         <DocsNavigationList navItems={tableOfContents} />
       </div>
     </div>

--- a/components/AppRouterMigrationComponents/Docs/docsSearch/SearchNavigation.tsx
+++ b/components/AppRouterMigrationComponents/Docs/docsSearch/SearchNavigation.tsx
@@ -273,7 +273,7 @@ export const LeftHandSideParentContainer = ({ tableOfContents }) => {
         searchMargin="mx-3"
         searchBarPadding=""
       />
-      <div className="overflow-y-scroll overflow-x-hidden h-[78%] 2xl:max-h-[75vh] pl-4 2xl:pl-0">
+      <div className="overflow-y-scroll overflow-x-hidden h-[76%] 2xl:max-h-[75vh] pl-4 2xl:pl-0">
         <DocsNavigationList navItems={tableOfContents} />
       </div>
     </div>


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/2790

I have dropped the height of the `LeftHandSideParentContainer` so that it doesnt hug the bottom of the page when the user is scrolling down the page. See video 


https://github.com/user-attachments/assets/f5760a5c-5846-454e-9b0f-db53aba68672

**Figure: Left hand bar doesnt hug bottom anymore**