### PR TITLE
Rework Agenda Section

### DIFF
--- a/app/conference/ConferenceClient.tsx
+++ b/app/conference/ConferenceClient.tsx
@@ -305,62 +305,6 @@ function formatTime(time: number) {
   return `${formattedHour}:${formattedMinutes} ${ampm}`;
 }
 
-function SessionCard({ session }: { session: Session }) {
-  return (
-    <div className="border p-5 rounded-xl shadow-xl flex w-full max-w-2xl text-start">
-      <div className="flex flex-col sm:flex-row" style={{ width: '100%' }}>
-        {session.talkSpeakerImage && (
-          <div
-            className="hidden sm:flex flex-col pr-4"
-            style={{ flex: '0 0 20%' }}
-          >
-            <Image
-              src={session.talkSpeakerImage}
-              alt={session.talkSpeakerName || 'Unknown Speaker'}
-              width={1000}
-              height={1000}
-              className="rounded-full w-full h-auto"
-            />
-          </div>
-        )}
-        <div className="flex flex-col" style={{ flex: '0 0 80%' }}>
-          <span
-            className={`text-sm rounded-full text-center px-2 mb-2 -ml-1 ${
-              session.sessionType === 'Break'
-                ? 'bg-gradient-to-br from-orange-100 to-orange-100 w-14 text-orange-500'
-                : session.sessionType === 'Workshop'
-                ? 'bg-gradient-to-br from-seafoam-200 to-seafoam-200 w-[5.5rem] text-seafoam-700'
-                : session.sessionType === 'Talk'
-                ? 'bg-gradient-to-br from-blue-100 to-blue-100 w-11 text-blue-500'
-                : 'text-gray-700'
-            }`}
-          >
-            {session.sessionType}
-          </span>
-          <h3 className="text-lg font-bold">{session.speechTitle || 'TBD'}</h3>
-          {session.talkSpeakerName && (
-            <span className="flex items-center gap-2 text-gray-600">
-              <FaRegUser />
-              <p className="text-sm text-gray-600 text-center flex items-center">
-                {session.talkSpeakerName}
-              </p>
-            </span>
-          )}
-          <span className="flex items-center gap-2 text-gray-600">
-            <FaRegClock />
-            <p className="text-sm">
-              {formatTime(session.talkTimeStart)}
-              {session?.talkTimeEnd && ` - ${formatTime(session.talkTimeEnd)}`}
-            </p>
-          </span>
-          <p className="text-gray-600 text-sm pt-2">
-            {session.speechDescription || 'TBD'}
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 function Agenda({
   filteredSessions,
@@ -436,7 +380,7 @@ function Agenda({
                 
               >
                 <td className="border p-4 align-top text-left">
-                  <div className="font-bold">
+                  <div className="font-bold leading-6">
                     {formatTime(slot.timeStart)} -
                     <br />
                     {slot.timeEnd ? formatTime(slot.timeEnd) : ''}

--- a/app/conference/ConferenceClient.tsx
+++ b/app/conference/ConferenceClient.tsx
@@ -450,7 +450,7 @@ function Agenda({
                         <h3 className="text-lg font-bold">
                           {breakSession.speechTitle}
                         </h3>
-                        <p className="text-gray-600 text-sm pt-2">
+                        <p className="text-gray-600 text-sm">
                           {breakSession.speechDescription}
                         </p>
                       </div>
@@ -550,7 +550,7 @@ function Agenda({
                     <h3 className="text-lg leading-5 font-bold">
                       {breakSession.speechTitle}
                     </h3>
-                    <p className="text-gray-600 text-sm pt-2">
+                    <p className="text-gray-600 text-sm pt-1">
                       {breakSession.speechDescription}
                     </p>
                   </div>

--- a/app/conference/ConferenceClient.tsx
+++ b/app/conference/ConferenceClient.tsx
@@ -411,7 +411,7 @@ function Agenda({
   );
 
   return (
-    <div className="flex flex-col items-center p-10" ref={agendaRef}>
+    <div className="flex flex-col items-center md:p-10" ref={agendaRef}>
       <h2
         id="agenda"
         className="text-3xl font-bold pt-16 pb-8 bg-gradient-to-br from-blue-600/80 via-blue-800/80 to-blue-1000 text-transparent bg-clip-text"
@@ -425,15 +425,15 @@ function Agenda({
           <thead>
             <tr className="bg-blue-100">
               <th className="border p-4 w-1/6 text-left">Time</th>
-              <th className="border p-4 w-2/5 text-left">Talks</th>
-              <th className="border p-4 w-2/5 text-left">Workshops</th>
+              <th className="border p-4 w-2/5 text-center">Talks</th>
+              <th className="border p-4 w-2/5 text-center">Workshops</th>
             </tr>
           </thead>
           <tbody>
             {timeSlots.map((slot, index) => (
               <tr
                 key={index}
-                className={index % 2 === 0 ? 'bg-gray-50' : 'bg-white'}
+                
               >
                 <td className="border p-4 align-top text-left">
                   <div className="font-bold">
@@ -463,7 +463,7 @@ function Agenda({
                       {slot.talks.map((talk, idx) => (
                         <div key={idx} className="mb-4 last:mb-0 flex">
                           <div>
-                            <h3 className="text-lg leading-5 font-bold">
+                            <h3 className="text-lg leading-6 font-bold">
                               {talk.speechTitle}
                             </h3>
                             {talk.talkSpeakerName && (
@@ -496,7 +496,7 @@ function Agenda({
                         <div key={idx} className="mb-4 last:mb-0 flex">
                           <div className="mr-3 mt-1"></div>
                           <div>
-                            <h3 className="text-lg leading-5 font-bold">
+                            <h3 className="text-lg leading-6 font-bold">
                               {workshop.speechTitle}
                             </h3>
                             {workshop.talkSpeakerName && (
@@ -534,20 +534,20 @@ function Agenda({
       <div className="w-full max-w-6xl md:hidden text-left">
         {timeSlots.map((slot, slotIndex) => (
           <div key={slotIndex} className="mb-8">
-            <div className="bg-blue-100 p-3 rounded-t-lg font-bold">
+            <div className="bg-blue-100 py-3 px-4 rounded-t-lg font-bold">
               {formatTime(slot.timeStart)} -{' '}
               {slot.timeEnd ? formatTime(slot.timeEnd) : ''}
             </div>
 
             {/* Break sessions */}
             {slot.breaks.length > 0 && (
-              <div className="border border-t-0 p-4 bg-white">
+              <div className="border border-t-0 p-4">
                 {slot.breaks.map((breakSession, idx) => (
                   <div key={idx} className="mb-4 last:mb-0">
                     <div className="bg-orange-100 text-orange-500 text-sm rounded-full px-2 w-14 mb-2">
                       Break
                     </div>
-                    <h3 className="text-lg font-bold">
+                    <h3 className="text-lg leading-5 font-bold">
                       {breakSession.speechTitle}
                     </h3>
                     <p className="text-gray-600 text-sm pt-2">
@@ -560,7 +560,7 @@ function Agenda({
 
             {/* Talks and Workshops */}
             {slot.breaks.length === 0 && (
-              <div className="border border-t-0 p-4 bg-white space-y-6">
+              <div className="border border-t-0 p-4  space-y-6">
                 {/* Talks */}
                 {slot.talks.map((talk, idx) => (
                   <div
@@ -570,7 +570,7 @@ function Agenda({
                     <div className="bg-blue-100 text-blue-500 text-sm rounded-full px-2 w-11 mb-2">
                       Talk
                     </div>
-                    <h3 className="text-lg font-bold">{talk.speechTitle}</h3>
+                    <h3 className="text-lg font-bold leading-5">{talk.speechTitle}</h3>
                     {talk.talkSpeakerName && (
                       <div className="flex items-center gap-2 text-gray-600 mt-1">
                         <div className="w-6 h-6 overflow-hidden rounded-full flex items-center justify-center">
@@ -600,7 +600,7 @@ function Agenda({
                     <div className="bg-seafoam-200 text-seafoam-700 text-sm rounded-full px-2 w-[5.5rem] mb-2">
                       Workshop
                     </div>
-                    <h3 className="text-lg font-bold">
+                    <h3 className="text-lg font-bold leading-5">
                       {workshop.speechTitle}
                     </h3>
                     {workshop.talkSpeakerName && (

--- a/app/conference/ConferenceClient.tsx
+++ b/app/conference/ConferenceClient.tsx
@@ -411,7 +411,7 @@ function Agenda({
   );
 
   return (
-    <div className="flex flex-col items-center md:p-10" ref={agendaRef}>
+    <div className="flex flex-col items-center" ref={agendaRef}>
       <h2
         id="agenda"
         className="text-3xl font-bold pt-16 pb-8 bg-gradient-to-br from-blue-600/80 via-blue-800/80 to-blue-1000 text-transparent bg-clip-text"

--- a/app/conference/ConferenceClient.tsx
+++ b/app/conference/ConferenceClient.tsx
@@ -25,7 +25,7 @@ const TopBanner = ({ tinaData }: { tinaData: any }) => {
           className="text-white"
         />
       </div>
-      <div className="w-full relative rounded-xl overflow-hidden">
+      <div className="w-full relative rounded-t-xl overflow-hidden">
         <div className="absolute inset-0 bg-orange-500"></div>
         <div
           className="absolute inset-0 bg-blue-900 hidden lg:block"
@@ -364,7 +364,7 @@ function Agenda({
       </h2>
 
       {/* Desktop view (table) */}
-      <div className="w-full max-w-6xl overflow-x-auto hidden md:block">
+      <div className="w-full max-w-6xl overflow-x-auto hidden md:block rounded-xl">
         <table className="w-full border-collapse">
           <thead>
             <tr className="bg-blue-100">

--- a/content/conference/TinaCon2025.mdx
+++ b/content/conference/TinaCon2025.mdx
@@ -122,7 +122,7 @@ speakerSchedule:
   - speechTitle: TBD
     speechDescription: TBD
     talkSpeakerName: TBD
-    talkSpeakerImage: /img/people/Mystery.png
+    talkSpeakerImage: /img/people/TBD.png
     talkTimeStart: 11
     talkTimeEnd: 12
     sessionType: Talk
@@ -140,7 +140,7 @@ speakerSchedule:
   - speechTitle: TBD
     speechDescription: TBD
     talkSpeakerName: TBD
-    talkSpeakerImage: /img/people/Mystery.png
+    talkSpeakerImage: /img/people/TBD.png
     talkTimeStart: 14
     talkTimeEnd: 15
     sessionType: Talk


### PR DESCRIPTION
As per adams request, the big change in this PR is to make the agenda section a singular 2d table so users can view all items occurring at once 


<img width="1134" alt="Screenshot 2025-03-24 at 10 33 09 am" src="https://github.com/user-attachments/assets/d6cde5e6-301d-4e92-9aa2-3a0c41ee5824" />

**Figure: > Md view**

<img width="708" alt="Screenshot 2025-03-24 at 10 33 17 am" src="https://github.com/user-attachments/assets/3bd4d3a5-ec3e-4393-9e7a-5bfd54393ca9" />

**Figure: < Md view**
