### PR TITLE
🐛 Bug | Md Menu Not Closing when Item Clicked

### DIFF
--- a/components/AppRouterMigrationComponents/AppNavBar.tsx
+++ b/components/AppRouterMigrationComponents/AppNavBar.tsx
@@ -342,7 +342,7 @@ export function AppNavBar({ sticky = true }) {
                           key={`${index}-${subIndex}`}
                           className={`group ${navLinkClasses} py-2`}
                         >
-                          <Link href={subItem.href}>
+                          <Link href={subItem.href} onClick={toggleMenu}>
                             <span className="">
                               {subItem.label}
                               {subItem.href.startsWith('https://') && (
@@ -355,7 +355,11 @@ export function AppNavBar({ sticky = true }) {
                     )
                   ) : 'href' in item ? (
                     <li key={index} className={`group ${navLinkClasses}`}>
-                      <Link href={item.href} className="py-2">
+                      <Link
+                        href={item.href}
+                        className="py-2"
+                        onClick={toggleMenu}
+                      >
                         {item.label}
                       </Link>
                     </li>
@@ -369,6 +373,7 @@ export function AppNavBar({ sticky = true }) {
                         target="_blank"
                         rel="noopener noreferrer"
                         className="flex items-center"
+                        onClick={toggleMenu}
                       >
                         <span className="flex items-center">
                           <svg
@@ -492,7 +497,11 @@ export function AppNavBar({ sticky = true }) {
                     case stringItemString:
                       return (
                         <li key={index} className={`group ${navLinkClasses}`}>
-                          <Link href={item.href} className="py-2 w-max">
+                          <Link
+                            href={item.href}
+                            className="py-2 w-max"
+                            onClick={toggleMenu}
+                          >
                             {item.label}
                           </Link>
                         </li>
@@ -501,7 +510,10 @@ export function AppNavBar({ sticky = true }) {
                       return (
                         <li key={index} className={`group ${navLinkClasses}`}>
                           <div className="relative group">
-                            <span className="flex items-center cursor-pointer">
+                            <span
+                              className="flex items-center cursor-pointer"
+                              onClick={toggleMenu}
+                            >
                               {item.label}
                               <BiChevronDown
                                 className={`ml-1 text-blue-200 group-hover:text-blue-400`}
@@ -515,7 +527,10 @@ export function AppNavBar({ sticky = true }) {
                                   key={subIndex}
                                   className="py-2 px-2 flex items-center"
                                 >
-                                  <Link href={subItem.href}>
+                                  <Link
+                                    href={subItem.href}
+                                    onClick={toggleMenu}
+                                  >
                                     <span className="text-gray-600 hover:text-blue-500 transition text-md ease-out duration-150">
                                       {subItem.label}
                                       {subItem.href.startsWith('https://') && (
@@ -540,6 +555,7 @@ export function AppNavBar({ sticky = true }) {
                             target="_blank"
                             rel="noopener noreferrer"
                             className="flex items-center"
+                            onClick={toggleMenu}
                           >
                             <span className="flex items-center">
                               <svg


### PR DESCRIPTION
some users reported the nav bar on devices <1024px felt bugged because when they clicked on a component to navigate the navbar never closed. This fixes that 