### PR TITLE
Fix MdMenu Pullout Location 

### DIFF
--- a/components/AppRouterMigrationComponents/AdminLink.tsx
+++ b/components/AppRouterMigrationComponents/AdminLink.tsx
@@ -25,7 +25,7 @@ const AdminLink = () => {
   return (
     <>
       {showAdminLink && (
-        <div className="fixed top-4 right-4 flex items-center justify-between bg-blue-500 text-white px-3 py-1 rounded-full z-50">
+        <div className="fixed top-[88px] right-16 flex items-center justify-between bg-blue-500 text-white px-3 py-1 rounded-full z-50">
           <a
             href={`/admin/index.html#/~${window.location.pathname}`}
             className="text-xs"

--- a/components/AppRouterMigrationComponents/AppNavBar.tsx
+++ b/components/AppRouterMigrationComponents/AppNavBar.tsx
@@ -294,7 +294,7 @@ export function AppNavBar({ sticky = true }) {
             } `}
           >
             <button
-              className="absolute top-6 left-0 -translate-x-full transition duration-150 ease-out rounded-l-full flex items-center font-tuner whitespace-nowrap leading-tight hover:shadow active:shadow-none text-orange-500 hover:text-orange-400 border border-gray-100/60 bg-linear-to-br from-white to-gray-50 pr-3 pl-4 pt-[8px] pb-[6px] text-sm font-medium cursor-pointer"
+              className="absolute top-20 left-0 -translate-x-full transition duration-150 ease-out rounded-l-full flex items-center font-tuner whitespace-nowrap leading-tight hover:shadow active:shadow-none text-orange-500 hover:text-orange-400 border border-gray-100/60 bg-linear-to-br from-white to-gray-50 pr-3 pl-4 pt-[8px] pb-[6px] text-sm font-medium cursor-pointer"
               onClick={toggleMenu}
             >
               <BiMenu

--- a/components/AppRouterMigrationComponents/AppNavBar.tsx
+++ b/components/AppRouterMigrationComponents/AppNavBar.tsx
@@ -322,7 +322,7 @@ export function AppNavBar({ sticky = true }) {
                   <button
                     className={`outline-hidden hover:animate-jelly ${
                       animateFlag ? 'animate-bounce' : ''
-                    } hidden max-[639px]:block`}
+                    } hidden max-[1023px]:block`}
                     onClick={() => openModal('LanguageSelect')}
                   >
                     {selectedFlag === 'en' ? (
@@ -443,7 +443,7 @@ export function AppNavBar({ sticky = true }) {
             <button
               className={`outline-hidden hover:animate-jelly ${
                 animateFlag ? 'animate-bounce' : ''
-              } hidden min-[640px]:block`}
+              } hidden min-[1024px]:block`}
               onClick={() => openModal('LanguageSelect')}
             >
               {selectedFlag === 'en' ? (


### PR DESCRIPTION
cc: @micsblank 

As per https://github.com/tinacms/tina.io/issues/2759 we have made a few minor changes
- [ ] Align MdMenu pullout with the Logo in the navBar
- [ ] Moved the Edit this Page button to be nexto the MdMenu pullout 
- [ ] Moved Language selector to inside MdMenu on Medium Screens

![Screenshot 2025-06-10 at 10 29 39 am](https://github.com/user-attachments/assets/4bde505d-dbb0-490a-bf7a-761f8479c00b)

**Figure: Before**

![Screenshot 2025-06-10 at 10 42 03 am](https://github.com/user-attachments/assets/2ee8de6d-a5c0-4f20-b617-b6b9e5c46b9c)

**Figure: After**
