### PR TITLE
Add: Overriding Media Docs

### DIFF
--- a/content/docs-toc/docs-toc.json
+++ b/content/docs-toc/docs-toc.json
@@ -228,6 +228,11 @@
               "_template": "item"
             },
             {
+              "title": "Overriding Default Media Types",
+              "slug": "content/docs/reference/media/overriding-accepted-media-types.mdx",
+              "_template": "item"
+            },
+            {
               "title": "External Media Providers",
               "items": [
                 {

--- a/content/docs/reference/media/overriding-accepted-media-types.mdx
+++ b/content/docs/reference/media/overriding-accepted-media-types.mdx
@@ -1,0 +1,42 @@
+---
+title: Overriding Accepted Media Types
+last_edited: '2025-06-11T02:00:32.510Z'
+next: ''
+previous: ''
+---
+
+Based on the supported types table shown on the [previous page,](/docs/reference/media/repo-based) you can modify the accepted media types.
+
+If you would like to specify your own allowed file types, add the following property to the media property in your defineConfig function. 
+
+```javascript
+//tina/config.{ts, js}
+
+export default defineConfig({
+  //...
+  media: {
+    tina: {
+      //...
+    },
+    accept: ['image/jpeg', 'video/mp4'],
+  },
+})
+```
+
+### accept: List\<String>
+
+This property determines the filetypes that can be uploaded
+
+### next/image
+
+If you are using Next images, you will need to add the following to your next.config.js file to allow access to external images hosted on the Tina media hostname 
+
+```javascript
+//next.config.js
+
+module.exports = {
+  images: {
+    domains: ['assets.tina.io'],
+  },
+}
+```

--- a/content/docs/reference/types/image.mdx
+++ b/content/docs/reference/types/image.mdx
@@ -1,6 +1,6 @@
 ---
 title: Image Fields
-last_edited: '2025-03-13T04:53:47.012Z'
+last_edited: '2025-06-11T02:03:24.455Z'
 next: ''
 previous: ''
 ---
@@ -11,6 +11,8 @@ It supports [external media library integration](http://localhost:3000/docs/refe
 
 Images can be uploaded to the image component with drag-and-drop actions, or with the dedicated media manager that comes with the CMS.
 
+> To modify which types of files can be uploaded to the media manager, find the [list of supported file types](/docs/reference/media/repo-based#supported-media-types) and [how to override the default accepted media types](/docs/reference/media/overriding-accepted-media-types)
+
 ![](/img/docs/reference/SCR-20250313-nzft.png)
 
 ## Type Definition
@@ -20,17 +22,17 @@ Images can be uploaded to the image component with drag-and-drop actions, or wit
 <apiReference
   property={[
     {
-      name: 'type',
-      type: 'string',
+      name: "type",
+      type: "string",
       description: 'Set this to `"image"` to use the Image Field.\n',
-      required: true,
+      required: true
     },
     {
-      name: 'name',
-      description: 'The name of the field for internal use.\n',
-      type: 'string',
-      required: true,
-    },
+      name: "name",
+      description: "The name of the field for internal use.\n",
+      type: "string",
+      required: true
+    }
   ]}
 />
 


### PR DESCRIPTION
**Changes**
- [ ] new doc for ovverriding accepted media types
- [ ] links added for the image field doc to new docs for instructions


--------

**Email:** 
As per our conversation, when I looked into the docs about how to upload video files, I couldn’t find the media changes straight away.
 
It turns out they were in /docs/reference/media/repo-based which didn’t make it clear that it works for other media providers as well.
 
On /docs/reference/media/repo-based
Move “Overriding the default accepted media types” section to it’s own page
It should be after Reference | Media | Overview
 
On /docs/reference/types/images Add a section about what file types are supported (link to new page from #1)