### PR TITLE
Auto Translation - Adding Manual Trigger

### DIFF
--- a/.github/workflows/auto-translate-docs.yml
+++ b/.github/workflows/auto-translate-docs.yml
@@ -1,14 +1,23 @@
 name: Auto Translate MDX to Chinese
 
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to translate'
+        required: true
+        type: number
   pull_request:
     types: [closed]
     paths:
       - 'content/docs/**.mdx'
 
+env:
+  PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+
 jobs:
   translate-mdx:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     environment: All Environments
     permissions:
@@ -34,15 +43,14 @@ jobs:
         id: get-changed-files
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
         run: node .github/scripts/get-changed-files.js
 
       - name: Create translation branch
         if: env.HAS_CHANGED_FILES == 'true'
         run: |
           TIMESTAMP=$(date +%s)
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          BRANCH_NAME="translate-pr-$PR_NUMBER-$TIMESTAMP"
+          BRANCH_NAME="translate-pr-${{ env.PR_NUMBER }}-$TIMESTAMP"
           git checkout -b $BRANCH_NAME
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
@@ -51,14 +59,12 @@ jobs:
         env:
           TINA_OPENAI_API_KEY: ${{ secrets.TINA_OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
         run: node .github/scripts/translate-mdx.js
 
       - name: Commit and push changes
         if: env.HAS_CHANGED_FILES == 'true'
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
@@ -75,14 +81,14 @@ jobs:
             exit 0
           fi
 
-          git commit -m "Add Chinese translation for docs from PR $PR_NUMBER"
+          git commit -m "Add Chinese translation for docs from PR ${{ env.PR_NUMBER }}"
           git push origin $BRANCH_NAME
 
       - name: Create Pull Request
         if: env.HAS_CHANGED_FILES == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           REPO: ${{ github.repository }}
         run: node .github/scripts/create-pr.js


### PR DESCRIPTION
Fixed #3588 


To streamline this process and avoid creating numerous PRs for each broken pipeline, I'm implementing a manual trigger for the translation flow. This trigger would accept the pull request number as an input, allowing you to re-translate a specific page directly without needing to merge a new PR. This enhancement will significantly ease the burden of re-triggering translations and improve the overall efficiency of the workflow.