### PR TITLE
🐛 Fixed 404 on global.css and tailwind.css

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -78,8 +78,6 @@ export default async function RootLayout({
           type="font/woff2"
           crossOrigin="anonymous"
         />
-        <link rel="preload" href="/styles/tailwind.css" as="style" />
-        <link rel="preload" href="/app/global.css" as="style" />
       </head>
       <body>
         <StyledComponentsRegistry>


### PR DESCRIPTION
### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

- [x] Title is short & specific
- [x] Headers are logically ordered & consistent
- [x] Purpose of document is explained in the first paragraph
- [x] Procedures are tested and work
- [x] Any technical concepts are explained or linked to
- [x] Document follows structure from templates
- [x] All links work
- [ ] The spelling and grammar checker has been run
- [ ] Graphics and images are clear and useful
- [ ] Any prerequisites and next steps are defined.

### Description
On [tina.io](https://tina.io/), in Devtools | Network, the global.css and tailwind.css are 404'ing - see **figure** below.

### Solution
The preload links were trying to fetch /styles/tailwind.css and /app/global.css as static assets.
These files don't exist at those URL paths because they're CSS modules that should be imported, not served as static files.
Next.js handles CSS imports automatically through the import statements, so the preload links were unnecessary and causing 404 errors.
✅ It's now fixed - see **figure** below.

<img width="3568" height="1527" alt="image" src="https://github.com/user-attachments/assets/003d42ae-96ff-4ae3-b04a-71b5514ce1d8" />

**Figure: global.css and tailwind.css are 404'ing**

<img width="3839" height="2168" alt="image" src="https://github.com/user-attachments/assets/16980a8a-1559-498c-ac7b-ed38526f99bd" />

**Figure: global.css and tailwind.css are fixed**