### PR TITLE
🐛 Fixed 500 error on githubstar fetch

### DIFF
--- a/app/api/githubstar/route.ts
+++ b/app/api/githubstar/route.ts
@@ -13,15 +13,17 @@ export async function GET(request: Request) {
   }
 
   try {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github.v3+json',
+    };
+
+    if (process.env.GITHUB_STAR_TOKEN) {
+      headers.Authorization = `Bearer ${process.env.GITHUB_STAR_TOKEN}`;
+    }
+
     const response = await fetch(
       `https://api.github.com/repos/${owner}/${repo}`,
-      {
-        headers: {
-          // Token
-          Authorization: `Bearer ${process.env.GITHUB_STAR_TOKEN}`,
-          Accept: 'application/vnd.github.v3+json',
-        },
-      },
+      { headers },
     );
 
     if (!response.ok) {


### PR DESCRIPTION
### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

- [x] Title is short & specific
- [x] Headers are logically ordered & consistent
- [x] Purpose of document is explained in the first paragraph
- [x] Procedures are tested and work
- [x] Any technical concepts are explained or linked to
- [x] Document follows structure from templates
- [x] All links work
- [ ] The spelling and grammar checker has been run
- [x] Graphics and images are clear and useful
- [ ] Any prerequisites and next steps are defined.

### Description

There was an error locally where githubstar was causing a 500 error - see **figure** below
The 500 error occurred because the GitHub star API route required GITHUB_STAR_TOKEN, which wasn’t set locally. Without it, the GitHub request failed and returned 500.

### Solution
Updated app/api/githubstar/route.ts to make the token optional:
- If GITHUB_STAR_TOKEN is set, use it (higher rate limit).
- If not, make unauthenticated requests (60/hour).
That fixed the 500 - see **figure** below

<img width="3840" height="2280" alt="image" src="https://github.com/user-attachments/assets/cedbbf8e-fa75-41c2-812e-9d0ddbd24b8c" />

**Figure: 500 error locally due to githubstar** 

<img width="3840" height="2170" alt="image" src="https://github.com/user-attachments/assets/8bbbd975-f4a4-4de2-9de5-09f7e53e938d" />

**Figure: No more 500**
