### PR TITLE
Fixing delete method in Netlify functions example

### DIFF
--- a/content/docs/reference/media/external/authentication.mdx
+++ b/content/docs/reference/media/external/authentication.mdx
@@ -127,10 +127,19 @@ router.get('/cloudinary/media', mediaHandler)
 
 router.post('/cloudinary/media', mediaHandler)
 
-router.delete('/cloudinary/media/:media', (req, res) => {
-  req.query.media = ['media', req.params.media]
-  return mediaHandler(req, res)
-})
+router.delete("/cloudinary/media/:media", (req, res) => {
+  Object.defineProperty(
+    req,
+    'query',
+    {
+      ...Object.getOwnPropertyDescriptor(req, 'query'),
+      value: { ...req.query,  media: [ "media", req.params.media ] },
+      writable: true
+    }
+  );
+
+  return mediaHandler(req, res);
+});
 
 app.use('/api/', router)
 app.use('/.netlify/functions/api/', router)


### PR DESCRIPTION
### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

- [x] Title is short & specific
- [ ] Headers are logically ordered & consistent
- [x] Purpose of document is explained in the first paragraph
- [ ] Procedures are tested and work
- [x] Any technical concepts are explained or linked to
- [ ] Document follows structure from templates
- [ ] All links work
- [ ] The spelling and grammar checker has been run
- [ ] Graphics and images are clear and useful
- [ ] Any prerequisites and next steps are defined.


When trying to use the Express Server code provided within the [Netlify functions media handler](https://tina.io/docs/reference/media/external/authentication#option-3-netlify-functions) docs, the DELETE method always runs into an error.

I managed to debug this on my local server, and I found that the in `app.delete` in the provided code, `req.query.media = ['media', req.params.media]` wasn’t actually doing anything.

According to a [StackOverflow post](https://stackoverflow.com/questions/79597051/express-v5-is-there-any-way-to-modify-req-query) on the same topic, Express V5 made the `req.query` property immutable, meaning that this (rather ugly) workaround is required with redefining the property entirely.

For completeness, the error which arises from using the original code is:
```log
Oct 23, 06:24:52 PM: ca358ca0 ERROR  TypeError: media is not iterableOct 23, 06:24:52 PM: ca358ca0 ERROR      at deleteAsset (/var/task/netlify/functions/api/api.js:95680:29)Oct 23, 06:24:52 PM: ca358ca0 ERROR      at /var/task/netlify/functions/api/api.js:95578:20Oct 23, 06:24:52 PM: ca358ca0 ERROR      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

Which is based upon an attempt to desctructure `req.query.media` in `node_modules/next-tinacms-cloudinary/dist/handlers.js`