### PR TITLE
Community page styling fixes

### DIFF
--- a/app/community/community-client.tsx
+++ b/app/community/community-client.tsx
@@ -101,9 +101,9 @@ export default function CommunityPageClient(data) {
       </div>
 
       {/* Newsletter Section */}
-      <div className="bg-green-100 py-12">
+      <div className="py-12">
         <div className="text-center px-6 lg:px-20">
-          <h2 className="text-4xl font-ibm-plexbg-linear-to-br from-orange-400 via-orange-500 to-orange-600 text-transparent bg-clip-text">
+          <h2 className="text-3xl lg:text-4xl font-ibm-plex lg:leading-tight bg-linear-to-br from-blue-700/80 via-blue-900/90 to-blue-1000 bg-clip-text text-transparent mb-2">
             {data.newsletter_header}
           </h2>
           <p className="text-gray-600 mt-2">{data.newsletter_cta}</p>

--- a/components/AppRouterMigrationComponents/footer/subscription-form.tsx
+++ b/components/AppRouterMigrationComponents/footer/subscription-form.tsx
@@ -74,13 +74,13 @@ export const SubscriptionForm = ({ props }) => {
         onSubmit={handleSubmit}
       >
         <h2 className=" md:text-xl font-ibm-plex text-white">Join the Herd!</h2>
-        <p className="text-sm font-light text-white/80 pb-1.5">
+        <p className="text-sm text-white/80 pb-1.5">
           Join our coding community for the latest tips and news.
         </p>
         <div className="flex flex-col gap-2.5 w-full">
           <div className="flex gap-2.5">
             <input
-              className="w-full px-2 py-2 text-sm  text-white border rounded-sm border-white placeholder:text-white/70 bg-white/10"
+              className="w-full px-2 py-2 text-sm  text-white border rounded-sm border-white placeholder-white/70 bg-white/10"
               placeholder="First name"
               name="firstName"
               type="text"
@@ -90,7 +90,7 @@ export const SubscriptionForm = ({ props }) => {
               disabled={isSubmitting}
             />
             <input
-              className="w-full px-2 py-2 text-sm bg-white/10 text-white border rounded-sm border-white placeholder:text-white/70"
+              className="w-full px-2 py-2 text-sm bg-white/10 text-white border rounded-sm border-white placeholder-white/70"
               placeholder="Last name"
               name="lastName"
               type="text"
@@ -102,7 +102,7 @@ export const SubscriptionForm = ({ props }) => {
           </div>
 
           <input
-            className="w-full px-2 py-2 text-sm bg-white/10 text-white border rounded-sm border-white placeholder:text-white/70"
+            className="w-full px-2 py-2 text-sm bg-white/10 text-white border rounded-sm border-white placeholder-white/70"
             placeholder="Email"
             name="email"
             type="email"


### PR DESCRIPTION
[Relevant PBI](https://github.com/tinacms/tina.io/issues/4036)
[Relevant PBI](https://github.com/tinacms/tina.io/issues/4037)

This makes styling adjustments to the /community page based on the recommendation of @GriffenEdge .

This PR also addresses the font-weight for the footer email form.

From:

<img width="1908" height="859" alt="image" src="https://github.com/user-attachments/assets/98303c81-a9ae-43e2-86cd-1adc8c59c486" />

**Figure: Current page available at [https://tina.io/community](https://tina.io/community)**

To:

<img width="1827" height="820" alt="image" src="https://github.com/user-attachments/assets/65fe9c86-9670-419a-ab74-65654ee78c1e" />

**Figure: Updated styling**
