### PR TITLE
adding rewrite for tinadocs/docs api

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -65,6 +65,10 @@ const config = {
         destination: `${TINA_DOCS_URL}/tinadocs/docs`,
       },
       {
+        source: '/tinadocs/api/:path*',
+        destination: `${TINA_DOCS_URL}/tinadocs/api/:path*`,
+      },
+      {
         source: '/tinadocs/docs/:path*',
         destination: `${TINA_DOCS_URL}/tinadocs/docs/:path*`,
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,17 +2,35 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "lenis/react": ["node_modules/lenis/dist/lenis-react"],
-      "@/public/*": ["./public/*"],
-      "@/content/*": ["./content/*"],
-      "@/styles/*": ["./styles/*"],
-      "@/utils/*": ["./utils/*"],
-      "@/component/*": ["./components/*"] // The alias '@/components/*' conflicts with the Marquee component in 'Testimonials.tsx'.
+      "@/*": [
+        "./src/*"
+      ],
+      "lenis/react": [
+        "node_modules/lenis/dist/lenis-react"
+      ],
+      "@/public/*": [
+        "./public/*"
+      ],
+      "@/content/*": [
+        "./content/*"
+      ],
+      "@/styles/*": [
+        "./styles/*"
+      ],
+      "@/utils/*": [
+        "./utils/*"
+      ],
+      "@/component/*": [
+        "./components/*"
+      ] // The alias '@/components/*' conflicts with the Marquee component in 'Testimonials.tsx'.
       // To avoid this issue, we are standardizing the import path to '@/component/*' instead.
     },
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -32,6 +50,14 @@
     ],
     "strictNullChecks": false
   },
-  "exclude": ["node_modules"],
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"]
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ]
 }


### PR DESCRIPTION
As per the title - currently any route call in the tina.io/tinadocs/docs is 405'ing - initially thought a basePath fix could be due however it seems to be that the route call just wasn't being rewritten properly 

This PR fixes that 