### PR TITLE
Update TOC DOC structure

### DIFF
--- a/content/docs-toc/docs-toc.json
+++ b/content/docs-toc/docs-toc.json
@@ -206,16 +206,91 @@
               "_template": "items"
             },
             {
-              "title": "Custom Fields",
+              "title": "React Components",
+              "slug": "content/docs/extending-tina/custom-field-components.mdx",
+              "_template": "item"
+            },
+            {
+              "title": "Plug-in Components",
               "items": [
                 {
-                  "title": "React Components",
-                  "slug": "content/docs/extending-tina/custom-field-components.mdx",
+                  "title": "Overview",
+                  "slug": "content/docs/reference/toolkit/fields/built-in-plugins.mdx",
                   "_template": "item"
                 },
                 {
-                  "title": "Plug-in Components",
-                  "slug": "content/docs/reference/toolkit/fields/built-in-plugins.mdx",
+                  "title": "Text Input",
+                  "slug": "content/docs/reference/toolkit/fields/text.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Text Area",
+                  "slug": "content/docs/reference/toolkit/fields/textarea.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Number Input",
+                  "slug": "content/docs/reference/toolkit/fields/number.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Image Input",
+                  "slug": "content/docs/reference/toolkit/fields/image.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Color Input",
+                  "slug": "content/docs/reference/toolkit/fields/color.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Toggle Input",
+                  "slug": "content/docs/reference/toolkit/fields/toggle.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Radio Group",
+                  "slug": "content/docs/reference/toolkit/fields/radio-group.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Select Input",
+                  "slug": "content/docs/reference/toolkit/fields/select.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Tags Input",
+                  "slug": "content/docs/reference/toolkit/fields/tags.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "List Input",
+                  "slug": "content/docs/reference/toolkit/fields/list.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Group Input",
+                  "slug": "content/docs/reference/toolkit/fields/group.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Group List Input",
+                  "slug": "content/docs/reference/toolkit/fields/group-list.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Date Input",
+                  "slug": "content/docs/reference/toolkit/fields/date.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "Markdown Input",
+                  "slug": "content/docs/reference/toolkit/fields/markdown.mdx",
+                  "_template": "item"
+                },
+                {
+                  "title": "HTML Input",
+                  "slug": "content/docs/reference/toolkit/fields/html.mdx",
                   "_template": "item"
                 }
               ],


### PR DESCRIPTION
As per my conversation with @18-th we have moved the plugins out to a list in the TOC for Documentation since they were referenced in the overview but not directly in the list. Making them hard to find. 

<img width="392" height="768" alt="Screenshot 2025-12-08 at 3 17 27 pm" src="https://github.com/user-attachments/assets/a10c68af-91ad-4b91-84fe-08c38e6fdfe9" />

**Figure: Updated List**