### PR TITLE
Fix command syntax for starting TinaCMS

### DIFF
--- a/content/docs/frameworks/11ty.mdx
+++ b/content/docs/frameworks/11ty.mdx
@@ -33,7 +33,7 @@ Learn more about content modelling [here](/docs/schema/)
 You can start TinaCMS with:
 
 ```bash
-npx tinacms dev -c "@11ty/eleventy --serve"
+npx tinacms dev -c "npx @11ty/eleventy --serve"
 ```
 
 > `@11ty/eleventy --serve`can be replaced with your site's custom dev command.


### PR DESCRIPTION
npx was missing in the command to start TinaCMS with 11ty

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

Issue: https://github.com/tinacms/tina.io/issues/4233
