### PR TITLE
Replace font-light with font-normal

### DIFF
--- a/app/blog/page/[page_index]/BlogIndexPageClient.tsx
+++ b/app/blog/page/[page_index]/BlogIndexPageClient.tsx
@@ -64,7 +64,7 @@ export default function BlogIndexPageClient({
                   {formatDate(post.date || '')}
                 </time>
               </div>
-              <div className=" font-light mb-6">
+              <div className=" font-normal mb-6">
                 <MarkdownContent
                   skipHtml={true}
                   content={extractTextFromBody(post.body)}

--- a/app/zh/blog/page/[page_index]/BlogIndexPageClient.tsx
+++ b/app/zh/blog/page/[page_index]/BlogIndexPageClient.tsx
@@ -64,7 +64,7 @@ export default function BlogIndexPageClient({
                   {formatDate(post.date || '')}
                 </time>
               </div>
-              <div className=" font-light mb-6">
+              <div className=" font-normal mb-6">
                 <MarkdownContent
                   skipHtml={true}
                   content={extractTextFromBody(post.body)}

--- a/components/Docs/docsSearch/SearchComponent.tsx
+++ b/components/Docs/docsSearch/SearchComponent.tsx
@@ -50,7 +50,7 @@ export const SearchHeader = ({ query }: { query: string }) => {
               {filterOptions.map((option) => (
                 <div
                   key={option}
-                  className="py-2 text-left cursor-pointer font-light"
+                  className="py-2 text-left cursor-pointer font-normal"
                   onClick={() => {
                     setIsFilterOpen(false);
                   }}
@@ -75,7 +75,7 @@ export const SearchHeader = ({ query }: { query: string }) => {
               {sortOptions.map((option) => (
                 <div
                   key={option}
-                  className="py-2 cursor-pointer font-light text-left"
+                  className="py-2 cursor-pointer font-normal text-left"
                   onClick={() => {
                     
                     setIsSortOpen(false);
@@ -198,7 +198,7 @@ export const SearchBody = ({
             <h2 className="text-xl font-inter font-semibold bg-linear-to-br from-blue-600/80 via-blue-800/80 to-blue-1000 bg-clip-text text-transparent group-hover:from-orange-300 group-hover:via-orange-400 group-hover:to-orange-600 break-words">
               {highlightText(item._highlightResult.title.value)}
             </h2>
-            <p className="text-gray-600 group-hover:text-gray-800 text-sm font-light line-clamp-3 break-words">
+            <p className="text-gray-600 group-hover:text-gray-800 text-sm font-normal line-clamp-3 break-words">
               {highlightText(item._highlightResult.excerpt?.value || '')}
             </p>
           </Link>

--- a/components/Docs/docsSearch/SearchNavigation.tsx
+++ b/components/Docs/docsSearch/SearchNavigation.tsx
@@ -65,7 +65,7 @@ export const SearchResultsOverflowBody = ({
             <h2 className="text-md font-inter font-semibold bg-linear-to-br from-blue-600/80 via-blue-800/80 to-blue-1000 bg-clip-text text-transparent group-hover:from-orange-300 group-hover:via-orange-400 group-hover:to-orange-600 break-words">
               {highlightText(item._highlightResult.title.value)}
             </h2>
-            <p className="text-gray-600 group-hover:text-gray-800 text-xs font-light line-clamp-2 break-words mt-1">
+            <p className="text-gray-600 group-hover:text-gray-800 text-xs font-normal line-clamp-2 break-words mt-1">
               {highlightText(item._highlightResult.excerpt?.value || '')}
             </p>
           </Link>

--- a/components/blocks-v2/featureCard/featureCard.tsx
+++ b/components/blocks-v2/featureCard/featureCard.tsx
@@ -103,7 +103,7 @@ function FeatureCardItem(data: {
         >
           {featureHeadline}
         </h4>
-        <p className="text-neutral-text-secondary font-light leading-relaxed text-lg max-w-[62ch] py-4">
+        <p className="text-neutral-text-secondary font-normal leading-relaxed text-lg max-w-[62ch] py-4">
           {featureText}
         </p>
         <div className="flex flex-col sm:flex-row gap-2 gap-y-2">

--- a/components/blocks/CallToAction/call-to-action.tsx
+++ b/components/blocks/CallToAction/call-to-action.tsx
@@ -36,7 +36,7 @@ export default function CallToAction(data: any) {
 
         <div className="relative z-10 flex flex-col gap-6 items-start text-left max-w-full">
           <h2 className={`${BLOCK_HEADINGS_SIZE} font-ibm-plex`}>{title}</h2>
-          <p className="text-neutral-text-secondary max-w-md font-light leading-relaxed text-lg">
+          <p className="text-neutral-text-secondary max-w-md font-normal leading-relaxed text-lg">
             {description}
           </p>
           <div className="flex flex-row gap-4">

--- a/components/blocks/Events/Events.tsx
+++ b/components/blocks/Events/Events.tsx
@@ -216,7 +216,7 @@ const EventsBlock = () => {
         {eventsData.title}
       </h2>
       <div className="max-w-[62ch] mx-auto">
-        <p className="text-center text-neutral-text-secondary font-light leading-relaxed text-lg">
+        <p className="text-center text-neutral-text-secondary font-normal leading-relaxed text-lg">
           {eventsData.byLine}
         </p>
       </div>

--- a/components/blocks/ProfessionalServices/ProfessionalServices.tsx
+++ b/components/blocks/ProfessionalServices/ProfessionalServices.tsx
@@ -40,7 +40,7 @@ export function ProfessionalServices({
           </h2>
         )}
         {description && (
-          <p className="max-w-[62ch] text-center text-neutral-text-secondary font-light leading-relaxed text-lg">
+          <p className="max-w-[62ch] text-center text-neutral-text-secondary font-normal leading-relaxed text-lg">
             {description}
           </p>
         )}

--- a/components/blocks/Recipe.tsx
+++ b/components/blocks/Recipe.tsx
@@ -105,7 +105,7 @@ export const RecipeBlock = ({ data }) => {
         <h2 className="font-ibm-plex text-orange-500 text-2xl">
           {title || 'Default Title'}
         </h2>
-        <p className="font-light py-2 text-base">
+        <p className="font-normal py-2 text-base">
           {description || 'Default Description'}
         </p>
       </div>

--- a/components/blocks/Table/table.tsx
+++ b/components/blocks/Table/table.tsx
@@ -29,7 +29,7 @@ const TableHeader = ({ data, scrollData }) => {
               {headerItem.columnHeader} {headerItem.isReccomended ? '⭐️' : ''}
             </Link>
           </div>
-          <div className="text-center font-light text-xs text-slate-400">
+          <div className="text-center font-normal text-xs text-slate-400">
             {headerItem.columnByLine}
           </div>
         </div>


### PR DESCRIPTION
Improves accessibility and visual consistency by replacing all uses of `font-light` at smaller font sizes with `font-normal`.

<img width="1104" height="501" alt="tina io_ (1)" src="https://github.com/user-attachments/assets/cb659205-2bdb-41f2-bb11-e3a818145c1c" />

**Figure: Before - `font-light` text is hard to read, especially on non-retina screens.**

<img width="1104" height="501" alt="tina io_" src="https://github.com/user-attachments/assets/72407d53-12ab-4060-bd95-70bb6bbd2355" />

**Figure: After - `font-normal` text is easy to read.**


### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?