### PR TITLE
Fix "Book a Chat" button on Pricing page to use modal instead of empty meetings page

### DIFF
--- a/content/blocksPages/pricing.json
+++ b/content/blocksPages/pricing.json
@@ -526,10 +526,9 @@
             {
               "label": "Book a Chat",
               "icon": false,
-              "variant": "blue",
               "size": "medium",
-              "url": "/meetings",
-              "_template": "actions"
+              "modal": "BookDemo.tsx",
+              "_template": "modalButton"
             }
           ],
           "media": [


### PR DESCRIPTION
## Summary
- Changes the "Book a Chat" button in the Pricing page llama section from a direct link (`/meetings`) to a modal dialog (`BookDemo.tsx`)
- This matches the same fly-in interaction used by "Schedule Call" buttons elsewhere on the site
- The modal shows HubSpot booking links for 3 regions (Oceania & Asia, Europe + Americas, USA West + Pacific)

Closes #4385

## Test plan
- [ ] Navigate to the Pricing page and scroll to the llama section
- [ ] Click "Book a Chat" — should open a fly-in modal (not navigate to `/meetings`)
- [ ] Verify modal contains 3 booking cards with HubSpot links
- [ ] Verify behaviour matches "Schedule Call" buttons on other pages (e.g. Professional Services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)