### PR TITLE
Fix typo in navigation bar label

### DIFF
--- a/content/navigationBar/navMenu.json
+++ b/content/navigationBar/navMenu.json
@@ -57,7 +57,7 @@
           "href": "https://app.tina.io/quickstart"
         },
         {
-          "label": "Whats New in TinaCloud",
+          "label": "What's New in TinaCloud",
           "href": "/whats-new/tinacloud"
         }
       ],


### PR DESCRIPTION
Fixed missing apostrophe

<img width="380" height="322" alt="Screenshot 2026-04-10 at 5 09 57 PM" src="https://github.com/user-attachments/assets/0a4ccd49-28ce-4379-8e4a-b319bb6a1a10" />
