### PR TITLE
Document environment variable scoping in the Tina admin

### DIFF
--- a/content/docs/extending-tina/custom-field-components.mdx
+++ b/content/docs/extending-tina/custom-field-components.mdx
@@ -11,6 +11,34 @@ A custom component can be passed and rendered by setting the ui.component proper
 
 This component completely overrides the original component, providing the user with the ability to fully customize the field.
 
+## Environment Variables in Custom Components
+
+Custom field components run inside the Tina admin, which is built as a **static SPA** separately from your site. Environment variables are embedded into the admin JavaScript at build time — they are not read at runtime. This means two things must be true for a variable to be available:
+
+1. **It must use an allowed prefix.** For security reasons, only these variables are included:
+   - `TINA_PUBLIC_*`
+   - `NEXT_PUBLIC_*`
+   - `NODE_ENV`
+   - `HEAD`
+
+2. **It must be set when `tinacms build` (or `tinacms dev`) runs.** If the variable isn't in the environment during the build, it won't exist in the admin regardless of its name.
+
+Any other environment variables (e.g. `process.env.MY_SECRET_KEY`) will be `undefined` in custom components.
+
+```tsx
+// This works — correct prefix AND set during build
+const apiKey = process.env.TINA_PUBLIC_MY_API_KEY
+
+// This will be undefined — no allowed prefix
+const secret = process.env.MY_API_KEY
+```
+
+<WarningCallout
+  body={<>
+    If your custom component relies on an environment variable and it's always `undefined`, check that: (1) the variable name starts with `TINA_PUBLIC_` or `NEXT_PUBLIC_`, and (2) the variable is defined in your `.env` file or CI environment when `tinacms build` runs. Note that Tina only loads `.env` files — not `.env.local` or `.env.development`. See the [config reference](/docs/reference/config#environment-variables) and [security advisory](/blog/2023-02-security-update) for details.
+  </>}
+/>
+
 ## The `ui.component` Property
 
 This should be set to a valid React component that accepts up to four props:

--- a/content/docs/reference/config.mdx
+++ b/content/docs/reference/config.mdx
@@ -382,6 +382,51 @@ export default defineConfig({
 });
 ```
 
+### Environment Variables
+
+TinaCMS uses environment variables in two contexts: the **site build** (your Next.js/SSG app) and the **admin build** (the TinaCMS editor at `/admin`). These have different scoping rules.
+
+#### Build-Time Embedding
+
+The Tina admin is a **statically built SPA**. Environment variables are embedded into the admin's JavaScript at build time (during `tinacms build` or `tinacms dev`). They are not read at runtime. This means a variable must be present in the environment when the build runs — setting it afterwards has no effect.
+
+#### `.env` File Support
+
+Tina's build process only picks up variables from `.env` files. Variables defined in `.env.local`, `.env.development`, or other dotenv variants are **not** loaded by the TinaCMS build. If you're deploying to a hosting provider (Vercel, Netlify, etc.), make sure the variables are also configured in that provider's environment settings.
+
+#### Admin-Exposed Variables
+
+For security, only a subset of environment variables are included in the admin build. This prevents sensitive credentials from leaking into the publicly served admin `index.js`.
+
+The allowed variables are:
+
+| Pattern | Description |
+|---------|-------------|
+| `TINA_PUBLIC_*` | TinaCMS-specific public variables |
+| `NEXT_PUBLIC_*` | Next.js public variables |
+| `NODE_ENV` | The current environment (`development`, `production`, etc.) |
+| `HEAD` | The current branch (used by Netlify) |
+
+Any other environment variable accessed via `process.env` inside the admin — including [custom field components](/docs/extending-tina/custom-field-components), `beforeSubmit` hooks, or other admin-side code — will be `undefined`.
+
+<WarningCallout
+  body={<>
+    For an environment variable to work in the admin, it must: (1) use the `TINA_PUBLIC_` or `NEXT_PUBLIC_` prefix, and (2) be set in the environment when `tinacms build` or `tinacms dev` runs. For example, rename `MY_API_KEY` to `TINA_PUBLIC_MY_API_KEY` and ensure it's in your `.env` file or CI/hosting environment variables.
+  </>}
+/>
+
+#### Common Environment Variables
+
+| Variable | Context | Description |
+|----------|---------|-------------|
+| `NEXT_PUBLIC_TINA_CLIENT_ID` | Site + Admin | Your TinaCloud project client ID |
+| `TINA_TOKEN` | Site build only | Read-only token for TinaCloud (not exposed in admin) |
+| `TINA_PUBLIC_IS_LOCAL` | Site + Admin | Toggle between local and production backends in self-hosted setups |
+| `NEXT_PUBLIC_TINA_BRANCH` | Site + Admin | Override the branch for content fetching |
+| `TINA_SEARCH_TOKEN` | Site build only | Token for TinaCloud search indexing |
+
+> For more on deploying with environment variables, see [Going to Production with TinaCloud](/docs/tinacloud/overview). For the security background on admin variable scoping, see the [February 2023 security advisory](/blog/2023-02-security-update).
+
 ### Imports with Typescript Path Aliases
 
 TinaCMS supports TypeScript path aliases in the `tina/config.{ts,js,tsx}` file and collections.

--- a/content/docs/tinacloud/deployment-options/netlify.mdx
+++ b/content/docs/tinacloud/deployment-options/netlify.mdx
@@ -18,3 +18,9 @@ In Netlify, your build configuration can be updated at **Settings** > **Build & 
 ## Environment variables
 
 Assuming that your Tina `clientID` and `token` are setup as environment variables, you will need to add those to the Netlify UI for your project. You can learn more about [Netlify environment variables](https://docs.netlify.com/environment-variables/overview/).
+
+<WarningCallout
+  body={<>
+    `tinacms build` requires environment variables like `TINA_TOKEN` and `NEXT_PUBLIC_TINA_CLIENT_ID` to be available at build time. Make sure these are configured in Netlify's environment settings. If you use a monorepo tool like Turborepo, you may also need to explicitly forward these variables (e.g. via the `env` key in `turbo.json`) — otherwise `tinacms build` may not receive them even if they are set in Netlify. See the [Environment Variables reference](/docs/reference/config#environment-variables) for details.
+  </>}
+/>

--- a/content/docs/tinacloud/deployment-options/vercel.mdx
+++ b/content/docs/tinacloud/deployment-options/vercel.mdx
@@ -26,6 +26,12 @@ Whatever environment variables you have defined locally in your `.env` file will
 
 Mandatory environment variables include the NEXT\_PUBLIC\_TINA\_CLIENT\_ID and the TINA\_TOKEN, both of which can be found in your [TinaCloud project](https://app.tina.io)
 
+<WarningCallout
+  body={<>
+    `tinacms build` requires environment variables like `TINA_TOKEN` and `NEXT_PUBLIC_TINA_CLIENT_ID` to be available at build time. Make sure these are configured in Vercel's environment settings. If you use a monorepo tool like Turborepo, you may also need to explicitly forward these variables (e.g. via the `env` key in `turbo.json`) — otherwise `tinacms build` may not receive them even if they are set in Vercel. See the [Environment Variables reference](/docs/reference/config#environment-variables) for details.
+  </>}
+/>
+
 ## Your First Deployment
 
 Once ready, select `Deploy` and wait for your first build to run. Once it succeeds, visit your new Tina site by selecting `Inspect Deployment`.

--- a/content/docs/tinacloud/overview.mdx
+++ b/content/docs/tinacloud/overview.mdx
@@ -129,6 +129,12 @@ The next step is to update your deployment configuration, so the TinaCMS admin g
 
 In general, you'll want to make sure that your build command is running `tinacms build` before your site's build command. This will build the TinaCMS admin alongside your site. You'll also want to make sure that your Tina `NEXT_PUBLIC_TINA_CLIENT_ID` and `TINA_TOKEN` are setup as environment variables on your host.
 
+<WarningCallout
+  body={<>
+    The TinaCMS admin is a statically built SPA — environment variables are embedded into its JavaScript at build time. Any variable you need in the admin (including in [custom field components](/docs/extending-tina/custom-field-components)) must: (1) use the `TINA_PUBLIC_` or `NEXT_PUBLIC_` prefix, and (2) be configured in your hosting provider's environment settings so it's available when `tinacms build` runs. See the [Environment Variables reference](/docs/reference/config#environment-variables) for the full list of allowed prefixes.
+  </>}
+/>
+
 We have docs for some popular deployment options:
 
 * [Vercel](/docs/tinacloud/deployment-options/vercel)


### PR DESCRIPTION
## Summary

Documents the `TINA_PUBLIC_` / `NEXT_PUBLIC_` environment variable prefix requirement and build-time embedding behavior, which has been undocumented since [tinacms/tinacms#3584](https://github.com/tinacms/tinacms/pull/3584) (Feb 2023).

**Changes across 5 files:**

- **`extending-tina/custom-field-components.mdx`** — New "Environment Variables in Custom Components" section explaining: allowed prefixes, build-time embedding requirement, code example, and a `WarningCallout` with troubleshooting steps
- **`reference/config.mdx`** — New "Environment Variables" subsection covering: build-time embedding, `.env` file support, admin-exposed variable prefix table, common env vars table, and links to security advisory
- **`tinacloud/overview.mdx`** — `WarningCallout` in the "Deploying your site" section reminding users to configure env vars in their hosting provider
- **`tinacloud/deployment-options/vercel.mdx`** — `WarningCallout` under "Environment variables" about build-time embedding and prefix requirements
- **`tinacloud/deployment-options/netlify.mdx`** — Same `WarningCallout` for Netlify deployments

### Why this matters

The TinaCMS admin is a statically built SPA. Environment variables are baked into its JavaScript at build time — not read at runtime. This creates a common "works locally, breaks in production" scenario: a developer has `TINA_PUBLIC_MY_KEY` in `.env.local` (which Next.js reads but TinaCMS doesn't), everything works in dev, they deploy, and the admin's custom field components silently get `undefined`.

## Test plan

- [ ] Verify custom field components page renders at `/docs/extending-tina/custom-field-components`
- [ ] Verify config reference page renders at `/docs/reference/config`
- [ ] Verify TinaCloud overview page renders at `/docs/tinacloud/overview`
- [ ] Verify Vercel deployment page renders at `/docs/tinacloud/deployment-options/vercel`
- [ ] Verify Netlify deployment page renders at `/docs/tinacloud/deployment-options/netlify`
- [ ] Confirm all `WarningCallout` components render properly
- [ ] Confirm internal links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)