### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/content/blog/custom-field-components.mdx
+++ b/content/blog/custom-field-components.mdx
@@ -329,7 +329,7 @@ function AboutMe(props) {
         {/* This is the image that will get the treatment */}
         <img
           alt="random-unsplash"
-          src="https://source.unsplash.com/random/800x600"
+          src="https://picsum.photos/800/600"
         />
       </section>
       {/* Pass in the image_saturation value */}


### PR DESCRIPTION
`content/blog/custom-field-components.mdx` references the deprecated `source.unsplash.com/*` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` (and related endpoints like `/featured`, `/collection/<id>`) was deprecated by Unsplash in mid-2024. These URLs now return HTTP 503 instead of an image, so browsers render a broken-image icon in place of the intended visual.

Verify in any shell:

```
curl -sI https://source.unsplash.com/random/800x600 | head -1
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Updates the `<img>` in the `custom-field-components` blog post on tina.io so the blog's inline screenshot renders for readers.

#### Replacement details

Docs/content-only change on the live tinacms.io site. Dimensions 800×600 preserved. The blog post uses the image to illustrate a custom-field-component pattern; a 503 here undermines the point.

#### Background

I'm tracking the deprecated `source.unsplash.com/*` endpoints across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg isn't introduced as a dependency by this PR — the diff is dependency-free `picsum.photos`. If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights this same broken-URL pattern in any landing page — useful for verifying the fix lands and for finding other places `source.unsplash.com/random` slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering ~16,500 files across ~885 unique repos that still hotlink the deprecated endpoint: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
