### PR TITLE
Correct and expand docs for renaming media files

### DIFF
--- a/content/docs/reference/media/repo-based.mdx
+++ b/content/docs/reference/media/repo-based.mdx
@@ -132,17 +132,21 @@ Repo-based media is designed to be used around a single-branch workflow. If your
 * Images cannot be altered. Once uploaded, any subsequent changes to an asset will not be reflected.
 * If you only have a single branch with media enabled, the media store will source/upload images to/from that branch.
 * If you have multiple branches with media enabled, then all media will be sourced/uploaded to/from the repository's default branch.
-* Media files cannot be renamed through the Media Manager. See [Renaming Media Files](#renaming-media-files) below for a workaround.
 
 If you are configuring Tina on a non-default branch (and the Tina config has not yet been merged to your default branch), the automatic media sync on project creation may not be able to locate your media configuration. In this case, the **Media** tab in your TinaCloud project dashboard will show that media has not yet been synced. Once your Tina config has been merged to the default branch, you can trigger a sync manually from that tab.
 
-### Renaming Media Files
+## Renaming Media Files
 
-Repo-based media does not support renaming files through the Media Manager. Because media only tracks a single branch, there is no branching functionality available for media operations like renaming.
+Repo-based media does not support renaming files through the Media Manager — the UI has no rename action today. To rename a file, you need to delete-and-re-upload via the Media Library, or make the change directly in GitHub.
 
-If the tracked branch has branch protection rules enabled, attempting to upload a renamed version of a file will save the file to the media storage (S3) but the change will **not** be committed to the protected branch. This results in the new file being stored but not reflected in your repository.
+> **Prevention:** Avoid filenames with spaces, accents, or special characters. Lowercase ASCII with hyphens (e.g. `my-image.jpg`) is the safest bet — filenames with special characters have been seen to break downstream builds (e.g. Astro). First-class filename sanitisation on upload is tracked in [tinacms#6359](https://github.com/tinacms/tinacms/issues/6359).
 
-**Workaround:** To rename a media file, perform the following steps directly in GitHub:
+**Workaround 1 — Delete and re-upload via the Media Library:**
+
+1. Delete the file from the Media Library in TinaCMS
+2. Re-upload the file with the new filename
+
+**Workaround 2 — Rename directly in GitHub:**
 
 1. Navigate to your repository on GitHub and locate the media file in your media directory (e.g. `public/uploads/`)
 2. Delete the old file directly in GitHub
@@ -150,4 +154,6 @@ If the tracked branch has branch protection rules enabled, attempting to upload 
 4. Add the file with the new name directly in GitHub
 5. Wait for the new file to sync back to TinaCloud
 
-> This workaround is necessary because changes made directly in GitHub will sync back to TinaCloud, bypassing the single-branch media limitation.
+> If the tracked branch has branch protection rules enabled, attempting to upload via the Media Library will save the file to the media storage (S3) but the change will **not** be committed to the protected branch. In that setup, use Workaround 2.
+
+> First-class rename support in the Media Library is tracked in [tinacms#6722](https://github.com/tinacms/tinacms/issues/6722).


### PR DESCRIPTION
## Summary

- Promote **Renaming Media Files** out from under the Branching section — the limitation is a missing UI action, not a branching constraint
- Rewrite the diagnosis to accurately describe why rename is missing (no UI rename action in the Media Manager), rather than the previous "because media only tracks a single branch" framing, which wasn't the real cause
- Add a second workaround: **delete + re-upload via the Media Library**, alongside the existing GitHub-UI delete-then-add path
- Add filename-sanitisation prevention guidance (links [tinacms#6359](https://github.com/tinacms/tinacms/issues/6359))
- Forward-reference [tinacms#6722](https://github.com/tinacms/tinacms/issues/6722) as the tracked proper fix (Media Library rename action)
- Keep the branch-protection caveat but reframe it as a note about which workaround to use in that setup

### Why

A Discord user recently hit this exact confusion: they uploaded an image with special characters, Astro failed to build, they searched the docs for "how do I rename", and landed on a branching-scoped answer that didn't match their direct-push setup.

The GitHub → S3 sync actually handles renames correctly today (an earlier bug in this area has been fixed), so no workaround documentation needs to change — just the diagnosis, the discoverability, and the prevention guidance.

Resolves [tina.io#4479](https://github.com/tinacms/tina.io/issues/4479).

## Test plan

- [ ] `pnpm dev` and open http://localhost:3001/docs/reference/media/repo-based
- [ ] Confirm **Renaming Media Files** appears as a top-level `##` heading in the page TOC (not nested under Branching)
- [ ] Confirm both workarounds, the Prevention note, and the branch-protection caveat all render cleanly
- [ ] Confirm the forward-reference link to [tinacms#6722](https://github.com/tinacms/tinacms/issues/6722) resolves
- [ ] Confirm the `#renaming-media-files` anchor still works (no existing docs link to it that I could find, but worth a spot-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)