### PR TITLE
Added Migration Url

### DIFF
--- a/content/main/forestry.json
+++ b/content/main/forestry.json
@@ -13,7 +13,7 @@
           "icon": false,
           "variant": "blue",
           "size": "small",
-          "url": "https://tina.io/docs/forestry/migrate",
+          "url": "/docs/forestry/migrate",
           "_template": "actions"
         },
         {

--- a/content/main/forestry.json
+++ b/content/main/forestry.json
@@ -13,7 +13,7 @@
           "icon": false,
           "variant": "blue",
           "size": "small",
-          "url": "/",
+          "url": "https://tina.io/docs/forestry/migrate",
           "_template": "actions"
         },
         {


### PR DESCRIPTION
A very tiny update where I just added the Url of the migration guide for Forestry into the main button on the [Forestry redirect](https://tina.io/forestry). Ran into this myself as I was trying to find the migration
