### PR TITLE
Update TinaDocs Vercel link

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ require('dotenv').config();
 
 const isStatic = process.env.EXPORT_MODE === 'static';
 
-const TINA_DOCS_URL = 'https://tina-docs-red.vercel.app';
+const TINA_DOCS_URL = 'https://tina-docs-zeta-one.vercel.app';
 const TINA_DOCS_LANDING_URL = 'https://tina-docs-landing.vercel.app';
 
 /**


### PR DESCRIPTION
Tina-docs Vercel deployment was accidentally deleted. Repointing to the re-deployed version.

* Updated the URL to the new tina-docs deployment

