### PR TITLE
🤖 Auto-merge bot-authored Release Notes PRs

### DIFF
--- a/.github/workflows/auto-merge-release-notes.yml
+++ b/.github/workflows/auto-merge-release-notes.yml
@@ -1,0 +1,51 @@
+name: Auto-merge Release Notes PRs
+
+on:
+  workflow_run:
+    workflows: ["Create What's New Page for TinaCMS or TinaCloud"]
+    types: [completed]
+  # Backup trigger in case workflow_run misses one (manual re-run, etc.)
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find open release notes PRs
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBERS=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --search 'is:open is:pr author:app/github-actions head:releaseNotes/' \
+            --json number \
+            --jq '[.[].number] | join(" ")')
+          echo "numbers=$PR_NUMBERS" >> "$GITHUB_OUTPUT"
+          echo "Found PRs: $PR_NUMBERS"
+
+      - name: Approve PRs
+        if: steps.find.outputs.numbers != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_NOTES_APPROVAL_TOKEN }}
+        run: |
+          for pr in ${{ steps.find.outputs.numbers }}; do
+            gh pr review "$pr" --repo "$GITHUB_REPOSITORY" --approve \
+              --body "Auto-approving release notes PR (deterministic content, bot-authored)."
+          done
+
+      - name: Enable auto-merge
+        if: steps.find.outputs.numbers != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for pr in ${{ steps.find.outputs.numbers }}; do
+            gh pr merge "$pr" --repo "$GITHUB_REPOSITORY" --auto --squash
+          done


### PR DESCRIPTION
## TL;DR

Release Notes PRs from \`github-actions[bot]\` are deterministic (consistent author, branch prefix \`releaseNotes/\`, title prefix \`Release Notes - Add\`) and currently require manual approval + merge each release. This workflow approves and auto-merges them automatically.

## How

Triggers on \`workflow_run\` after a successful "Create What's New Page" run (plus a 6-hour cron and \`workflow_dispatch\` as safety nets). Finds open PRs matching \`author:app/github-actions head:releaseNotes/\`, approves each with a PAT (\`RELEASE_NOTES_APPROVAL_TOKEN\`), then enables \`--auto --squash\` merge using the default token.

## Reviewer notes

- **`workflow_run`, not `pull_request`.** PRs opened with the default `GITHUB_TOKEN` (as the producer workflow does) don't fire `pull_request` events on other workflows — confirmed `nodejs.yml` never ran on recent release-notes PRs. `workflow_run` sidesteps that.
- **Two tokens by design.** GitHub blocks self-approval, so the approve step uses a PAT from a different identity; the merge step uses the default token. The PAT (`RELEASE_NOTES_APPROVAL_TOKEN`) has been added as a repo secret with `Pull requests: Read & write` + `Contents: Read` scoped to this repo only.
- **No required status checks on `main` today.** Branch protection requires 1 approval but `required_status_checks.contexts` is empty, so `--auto` merges as soon as the approval lands. If required checks get added later, behavior shifts to "merge when checks pass" — still automatic.
- **Backup cron is cheap insurance.** The 6-hour schedule catches any PR the `workflow_run` trigger misses (e.g., producer re-runs, network blips). No-op when nothing matches.

## Tests

No automated tests — workflow correctness will be verified by the next real Release Notes dispatch. \`workflow_dispatch\` is enabled so the auto-merge job can be re-run manually from the Actions tab if needed.