### PR TITLE
🐛 Fix Release Notes auto-merge permission error

### DIFF
--- a/.github/workflows/auto-merge-release-notes.yml
+++ b/.github/workflows/auto-merge-release-notes.yml
@@ -41,11 +41,11 @@ jobs:
               --body "Auto-approving release notes PR (deterministic content, bot-authored)."
           done
 
-      - name: Enable auto-merge
+      - name: Merge PRs
         if: steps.find.outputs.numbers != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_NOTES_APPROVAL_TOKEN }}
         run: |
           for pr in ${{ steps.find.outputs.numbers }}; do
-            gh pr merge "$pr" --repo "$GITHUB_REPOSITORY" --auto --squash
+            gh pr merge "$pr" --repo "$GITHUB_REPOSITORY" --squash --delete-branch
           done

--- a/.github/workflows/auto-merge-release-notes.yml
+++ b/.github/workflows/auto-merge-release-notes.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           for pr in ${{ steps.find.outputs.numbers }}; do
             gh pr review "$pr" --repo "$GITHUB_REPOSITORY" --approve \
-              --body "Auto-approving release notes PR (deterministic content, bot-authored)."
+              --body "Auto-approving Release Notes PR - From GitHub Action/ Workflow ${{ github.workflow }}"
           done
 
       - name: Merge PRs


### PR DESCRIPTION
## TL;DR

The first run of the auto-merge workflow approved 7 backlog PRs successfully but failed at the merge step with \`User is not authorized for this protected branch (enablePullRequestAutoMerge)\` ([failed run](https://github.com/tinacms/tina.io/actions/runs/25895824403)). The default \`GITHUB_TOKEN\` (running as \`github-actions[bot]\`) isn't authorized to merge into protected \`main\`; this PR switches the merge step to the same PAT the approve step uses.

## How

- Merge step now uses \`RELEASE_NOTES_APPROVAL_TOKEN\` instead of \`GITHUB_TOKEN\`.
- Dropped \`--auto\` in favor of an immediate \`--squash --delete-branch\` merge — PRs are already approved by the prior step and \`main\` has no required status checks, so there's nothing for \`--auto\` to wait on.

## Reviewer notes

- **Same user for approve + merge is fine.** GitHub blocks self-*approval* (author == approver), not approver == merger. The PR author is still \`github-actions[bot]\`, so the PAT user can both approve and merge.
- **The 7 backlog PRs are already approved.** Once this merges, the next workflow run (manual dispatch or 6-hour cron) will merge them with no re-approval needed.

## Links

- [Failed run](https://github.com/tinacms/tina.io/actions/runs/25895824403)
- [Original PR](https://github.com/tinacms/tina.io/pull/4540)