### PR TITLE
Add CloudFlare Pages Documentation

### DIFF
--- a/components/tinaMarkdownComponents/docAndBlogComponents.tsx
+++ b/components/tinaMarkdownComponents/docAndBlogComponents.tsx
@@ -174,7 +174,7 @@ export const docAndBlogComponents: Components<{
   },
   code: (props) => (
     <code
-      className="px-1 text-orange-500 py-0.5 border-y-stone-600 bg-white/50 rounded font-source-code-pro"
+      className="px-1 text-orange-500 p-0.5  bg-orange-500/5 rounded font-source-code-pro"
       {...props}
     />
   ),

--- a/content/docs-toc/docs-toc.json
+++ b/content/docs-toc/docs-toc.json
@@ -603,6 +603,11 @@
               "_template": "item"
             },
             {
+              "title": "Cloudflare Pages",
+              "slug": "content/docs/tinacloud/deployment-options/cloudflare-pages.mdx",
+              "_template": "item"
+            },
+            {
               "title": "Alibaba Cloud",
               "slug": "content/docs/tinacloud/deployment-options/alibaba-cloud.mdx",
               "_template": "item"

--- a/content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
+++ b/content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
@@ -2,7 +2,7 @@
 title: Deploying to Alibaba Cloud
 last_edited: '2025-07-11T07:03:10.826Z'
 next: content/docs/tinacloud/api-versioning.mdx
-previous: content/docs/tinacloud/deployment-options/github-pages.mdx
+previous: content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
 ---
 
 ## Alternative Deployment for Chinese Users

--- a/content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
+++ b/content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
@@ -1,0 +1,75 @@
+---
+id: /docs/tinacloud/deployment-options/cloudflare-pages
+title: Deploying to Cloudflare Pages
+last_edited: '2026-05-15T07:24:35.115Z'
+next: content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
+previous: content/docs/tinacloud/deployment-options/github-pages.mdx
+---
+
+TinaCMS works well with Cloudflare Pages when your site is deployed as a **static export**: content is rendered at build time, while visual editing remains fully live in the browser via Tina's client-side data layer.
+
+## Why static export works well with Tina
+
+Tina's live editing experience is client-side. Pages are pre-rendered at build time, and the `useTina()` hook in your client components hydrates with the build-time data for visitors. 
+
+When you open `/admin` and edit a page, Tina swaps live data into the React tree, no server required. Saving commits to GitHub, which triggers a new Cloudflare build, which deploys the updated static site.
+
+## Configure your project for static export
+
+In your `next.config.ts` (or `next.config.js`), add `output: 'export'` and disable image optimization (static exports cannot use the Next.js image optimizer):
+
+```ts
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  output: 'export',
+  images: {
+    unoptimized: true,
+    // your remotePatterns, etc.
+  },
+}
+
+export default nextConfig
+```
+
+<WarningCallout
+  body={<>
+    `next.config` `headers()` and `rewrites()` functions do not run in static exports. Move any custom headers (CSP, X-Frame-Options, etc.) into a `public/_headers` file, Cloudflare Pages reads this automatically. URL rewrites need to be handled via Cloudflare's [\_redirects](https://developers.cloudflare.com/pages/configuration/redirects/) file.
+  </>}
+/>
+
+## Remove server-only route options
+
+Static exports do not have a server, so per-route options like `export const revalidate` (ISR) or `export const dynamic = 'force-dynamic'` have no effect and should be removed from your route segments. The rebuild itself serves as your "revalidation."
+
+## Cloudflare Pages build settings
+
+In the Cloudflare dashboard, go to **Workers & Pages** > **Create application** > **Pages** > **Connect to Git** and select your repository.
+
+Configure the build:
+
+* **Framework preset:** Next.js (Static HTML Export), or "None"
+* **Build command:** `pnpm build` (or your package manager)
+* **Build output directory:** `out`
+* **Root directory:** leave blank unless your project is in a subdirectory
+
+Cloudflare auto-detects pnpm from your `pnpm-lock.yaml`. If it doesn't pick it up, add an environment variable `PACKAGE_MANAGER=pnpm`.
+
+Your `package.json` build script should run TinaCMS before the framework build, for example:
+
+```json
+{
+  "scripts": {
+    "build": "tinacms build && next build"
+  }
+}
+```
+
+## Environment variables
+
+`tinacms build` requires your TinaCloud credentials at build time. Add the following to **Settings** > **Environment variables** in your Cloudflare Pages project:
+
+* `NEXT_PUBLIC_TINA_CLIENT_ID` : your TinaCloud client ID
+* `TINA_TOKEN` : a content token from TinaCloud
+
+Both can be found in your [TinaCloud project](https://app.tina.io). Add them to both Production and Preview environments.

--- a/content/docs/tinacloud/deployment-options/github-pages.mdx
+++ b/content/docs/tinacloud/deployment-options/github-pages.mdx
@@ -2,7 +2,7 @@
 id: /docs/tinacloud/deployment-options/github-pages
 title: Deploying to GitHub Pages
 last_edited: '2025-02-19T01:57:36.552Z'
-next: content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
+next: content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
 previous: content/docs/tinacloud/deployment-options/netlify.mdx
 ---
 


### PR DESCRIPTION
As per Discord comment: 

<img width="915" height="73" alt="Screenshot 2026-05-15 at 5 30 03 pm" src="https://github.com/user-attachments/assets/a5c54460-b521-4ab6-9992-fe83bcd516a9" />

and PBI https://github.com/tinacms/tinacms/issues/6892