### PR TITLE
Embed Vibe Coding videos on the Vibe Coding with TinaCMS docs page

### DIFF
--- a/content/docs/vibe-coding.mdx
+++ b/content/docs/vibe-coding.mdx
@@ -7,6 +7,10 @@ previous: content/docs/content-model-intro.mdx
 
 AI coding assistants work best with TinaCMS when you stay in control. This guide shows how to collaborate with AI as a partner, not a pilot.
 
+Watch the full workflow in action:
+
+<Youtube embedSrc="https://www.youtube.com/embed/buaXi8Hh420" caption="Vibe Blogging with GitHub Copilot and TinaCMS | Hark Singh" minutes="9" />
+
 ## 1. Set the Stage
 
 Set up an environment where your AI assistant can shine:
@@ -142,6 +146,10 @@ This defines scope and structure, helping AI produce accurate, context-aware cod
 ### 4.2 Iterate Feature by Feature
 
 Once one component or schema works, move on to the next logical piece. By building one feature at a time, your AI assistant learns your project’s structure progressively and builds on a solid foundation.
+
+Watch this approach used to build custom TinaCMS components with AI:
+
+<Youtube embedSrc="https://www.youtube.com/embed/TE72AZQODaw" caption="Vibe Coding TinaCMS Custom Components | Thomas Sepanosian" minutes="7" />
 
 ### 4.3 Validate Early
 


### PR DESCRIPTION
## Summary

Embeds the two correct YouTube videos on the **Vibe Coding with TinaCMS** docs page (`content/docs/vibe-coding.mdx`), per #4548:

- **Top of page** — `Vibe Blogging with GitHub Copilot and TinaCMS` by **Hark Singh** ([buaXi8Hh420](https://youtu.be/buaXi8Hh420))
- **"Build in Bite-Sized Pieces" → "Iterate Feature by Feature"** (the section about adding more components) — `Vibe Coding TinaCMS Custom Components` by **Thomas Sepanosian** ([TE72AZQODaw](https://youtu.be/TE72AZQODaw))

Closes #4548

## Implementation notes / decisions

- Used the standard `<Youtube embedSrc=... caption=... minutes=... />` component (registered on the Docs collection at `tina/collectionsSchema/docs.tsx`). The component auto-renders `Video: {caption} ({minutes} minutes)`.
- `embedSrc` uses the canonical `https://www.youtube.com/embed/{id}` form — matches the schema field's own documented format and the dominant convention across the docs. (Deliberately avoided the `watch?v=` form used in `content/blog/customblog_tinacmsai.mdx`, which does not embed in an iframe.)
- `caption` follows the existing `Title | Author` convention (see `content/blog/2025-09-23-markdown-editor-upgrade.mdx`).
- `minutes` is numeric (`9`, `7`), verified against actual video length (537s ≈ 9 min, 408s ≈ 7 min). Avoided the `minutes="9 minutes"` double-render bug present in `customblog_tinacmsai.mdx`.

## Test plan

- [x] Ran `pnpm dev` (TinaCMS local mode) and loaded `/docs/vibe-coding`
- [x] Confirmed both `<iframe>`s render with correct `src`, and captions read `Video: Vibe Blogging with GitHub Copilot and TinaCMS | Hark Singh (9 minutes)` and `Video: Vibe Coding TinaCMS Custom Components | Thomas Sepanosian (7 minutes)`
- [x] Verified thumbnails match the intended videos/authors
- [ ] Reviewer: confirm rendered embeds in the Vercel preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)