### PR TITLE
Wrap long lines in code blocks instead of clipping

### DIFF
--- a/components/styles/Prism.tsx
+++ b/components/styles/Prism.tsx
@@ -31,6 +31,9 @@ export const Prism = (props: {
             border: 'none',
             marginBottom: 0,
             borderRadius: '12px',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            overflowWrap: 'anywhere',
           }}
         >
           {tokens.map((line, i) => (


### PR DESCRIPTION
cc @adamcogan @0xharkirat @calumjs 

Done with Claude Code 🤖

## Summary

Long content inside `<pre>` blocks rendered by `components/styles/Prism.tsx` currently gets clipped at the right edge — `Prism` inherits the theme's `white-space: pre` and the wrapping div in `docAndBlogComponents.tsx` (`code_block`) uses `overflow-x-hidden`, so any line longer than the container is hidden rather than wrapped or scrollable.

This change adds `white-space: pre-wrap`, `word-break: break-word`, and `overflow-wrap: anywhere` to the `<pre>` element so long lines wrap to the next line. Indentation and intentional line breaks in code samples are preserved (still `pre-wrap`, not `normal`).

Fixing it at the `Prism` component covers every place it's used: blog/docs MDX code blocks, `Features`, `Story`, `GraphQLQueryResponseTabs`, and `MarkdownContent`.

## Test plan

- [ ] Open a blog/docs page with a long single-line code sample or sentence inside a code block (e.g. the example shown in the AI-onboarding article). Confirm the line wraps to the next line instead of being clipped on the right.
- [ ] Confirm short multi-line code samples still render with their original indentation and line breaks.
- [ ] Spot-check `Features` and `Story` blocks that use `<Prism>` to make sure layout still looks right.

> Note: I haven't run the site locally to visually verify; the change is small but a maintainer running `pnpm dev` should confirm the wrap behavior in the browser.
