### PR TITLE
docs: add identity-v2 and PostHog domains to CSP / network-requirements

### DIFF
--- a/content/docs-zh/guides/csp-configuration.mdx
+++ b/content/docs-zh/guides/csp-configuration.mdx
@@ -25,7 +25,7 @@ TinaCMS 需要访问其资产交付网络以加载图像：
 TinaCMS 需要连接到多个服务以进行身份验证、内容交付和媒体上传：
 
 ```javascript
-"connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com;"
+"connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com;"
 ```
 
 * **identity.tinajs.io** - 身份验证和身份服务
@@ -51,7 +51,7 @@ const baseCsp = [
     "worker-src 'self' blob:;",
     "frame-ancestors 'none';",
     "base-uri 'self';",
-    "connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com;"
+    "connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com;"
 ];
 
 /** @type {import('next').NextConfig} */
@@ -91,7 +91,7 @@ export function middleware(request: NextRequest) {
   const csp = [
     "default-src 'self'",
     "img-src 'self' data: assets.tina.io",
-    "connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com",
+    "connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com",
     // ... 其他指令
   ].join('; ');
   
@@ -109,7 +109,7 @@ export function middleware(request: NextRequest) {
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
+    Content-Security-Policy = "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
 ```
 
 ### Vercel 配置
@@ -124,7 +124,7 @@ export function middleware(request: NextRequest) {
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
+          "value": "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
         }
       ]
     }
@@ -138,7 +138,7 @@ export function middleware(request: NextRequest) {
 
 ```apache
 <IfModule mod_headers.c>
-  Header set Content-Security-Policy "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
+  Header set Content-Security-Policy "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
 </IfModule>
 ```
 
@@ -147,7 +147,7 @@ export function middleware(request: NextRequest) {
 添加到您的 nginx 配置：
 
 ```nginx
-add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';" always;
 ```
 
 ## 自托管注意事项

--- a/content/docs/guides/csp-configuration.mdx
+++ b/content/docs/guides/csp-configuration.mdx
@@ -22,16 +22,19 @@ TinaCMS needs access to load images from its asset delivery network:
 
 ### Connect Sources
 
-TinaCMS requires connections to several services for authentication, content delivery, and media uploads:
+TinaCMS requires connections to several services for authentication, content delivery, media uploads, and product analytics:
 
 ```javascript
-"connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com;"
+"connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com;"
 ```
 
-* **identity.tinajs.io** - Authentication and identity services
+* **identity.tinajs.io** - Authentication and identity services (v1)
+* **identity-v2.tinajs.io** - Authentication and identity services (v2). Both `identity.tinajs.io` and `identity-v2.tinajs.io` are required during the v1→v2 rollout; the admin UI calls both depending on the endpoint.
 * **content.tinajs.io** - Content API and data layer
 * **assets.tinajs.io** - Asset management and delivery
 * **s3.us-east-1.amazonaws.com** - Direct media uploads. The TinaCMS media manager `PUT`s files to a presigned S3 URL on this host. Without it, uploads fail with a CSP `connect-src` violation in the browser console.
+* **us.i.posthog.com** - PostHog event ingestion. The TinaCMS admin UI emits product-analytics events to help us improve the editor. Without it, you will see a CSP `connect-src` violation in the browser console for each event the editor tries to send.
+* **us-assets.i.posthog.com** - PostHog runtime assets (autocapture, session recording, feature flags). Loaded lazily by `posthog-js`; required even though the library itself is bundled in the admin UI.
 
 ## Implementation Examples
 
@@ -51,7 +54,7 @@ const baseCsp = [
     "worker-src 'self' blob:;",
     "frame-ancestors 'none';",
     "base-uri 'self';",
-    "connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com;"
+    "connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com;"
 ];
 
 /** @type {import('next').NextConfig} */
@@ -91,7 +94,7 @@ export function middleware(request: NextRequest) {
   const csp = [
     "default-src 'self'",
     "img-src 'self' data: assets.tina.io",
-    "connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com",
+    "connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com",
     // ... other directives
   ].join('; ');
   
@@ -109,7 +112,7 @@ Add CSP headers in your `netlify.toml`:
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
+    Content-Security-Policy = "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
 ```
 
 ### Vercel Configuration
@@ -124,7 +127,7 @@ Add headers in your `vercel.json`:
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
+          "value": "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
         }
       ]
     }
@@ -138,7 +141,7 @@ Add to your `.htaccess` file:
 
 ```apache
 <IfModule mod_headers.c>
-  Header set Content-Security-Policy "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
+  Header set Content-Security-Policy "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';"
 </IfModule>
 ```
 
@@ -147,7 +150,7 @@ Add to your `.htaccess` file:
 Add to your nginx configuration:
 
 ```nginx
-add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: assets.tina.io; connect-src 'self' identity.tinajs.io identity-v2.tinajs.io content.tinajs.io assets.tinajs.io s3.us-east-1.amazonaws.com us.i.posthog.com us-assets.i.posthog.com; font-src 'self' data: fonts.gstatic.com; object-src 'none'; frame-src 'none'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';" always;
 ```
 
 ## Self-Hosted Considerations

--- a/content/docs/tinacloud/network-requirements.mdx
+++ b/content/docs/tinacloud/network-requirements.mdx
@@ -15,7 +15,8 @@ TinaCloud's authentication and content services communicate with several externa
 | Domain | Purpose |
 |---|---|
 | `*.tina.io` | TinaCloud dashboard and asset delivery |
-| `identity.tinajs.io` | Authentication and identity services |
+| `identity.tinajs.io` | Authentication and identity services (v1) |
+| `identity-v2.tinajs.io` | Authentication and identity services (v2). Required alongside `identity.tinajs.io` during the v1→v2 rollout. |
 | `content.tinajs.io` | Content API and data layer |
 | `assets.tinajs.io` | Asset management and delivery |
 
@@ -45,6 +46,15 @@ If your project uses GitHub as its git provider (the default for TinaCloud):
 |---|---|
 | `github.com` | GitHub OAuth authorization and repository access |
 | `api.github.com` | GitHub API for token exchange and user info |
+
+### Product Analytics (PostHog)
+
+The TinaCMS admin UI emits product-analytics events via PostHog to help us improve the editor. On strict networks or CSPs you'll need to allow:
+
+| Domain | Purpose |
+|---|---|
+| `us.i.posthog.com` | PostHog event ingestion |
+| `us-assets.i.posthog.com` | PostHog runtime assets (autocapture, session recording, feature flags) — loaded lazily by `posthog-js` |
 
 ### Enterprise SSO (WorkOS)
 


### PR DESCRIPTION
Customers on strict CSPs hit browser-console `connect-src` violations for three domains the TinaCMS admin UI now calls but the docs never mentioned: `identity-v2.tinajs.io`, `us.i.posthog.com`, `us-assets.i.posthog.com`.

### Trigger

Customer report from DRW this week — they spent real time debugging it as CORS / auth / build before discovering the docs gap.

### What this PR does

- `csp-configuration.mdx` (en + zh): add the three domains to every `connect-src` example.
- `network-requirements.mdx`: add `identity-v2` to the TinaCloud Services table and a new "Product Analytics (PostHog)" section.
- zh narrative untouched (the new English bullets need a translation pass); zh code blocks updated so the CSP snippets are still technically correct.

### Notes worth your call

Both PostHog domains go in `connect-src` not `script-src` — `posthog-js` is bundled in the admin UI, but it still makes runtime fetches to `us-assets.i.posthog.com` for autocapture / session-recording. Matches what the customer did to unblock.

### Test plan

- [ ] `pnpm dev`, render the CSP guide, verify all 7 domains in `connect-src`
- [ ] Render Network Requirements, verify the new PostHog section appears between GitHub and Enterprise SSO

### General Contributing

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?