### PR TITLE
⚡ Edge-cache GitHub API routes, fix image cache churn, skip bot-branch preview builds

### DIFF
--- a/app/api/github-metadata/route.ts
+++ b/app/api/github-metadata/route.ts
@@ -75,13 +75,23 @@ export async function GET(request: Request) {
     const latestCommit = latestCommits[0];
     const firstCommit = allCommits.length ? allCommits.at(-1)! : null;
 
-    return NextResponse.json({
-      latestCommit,
-      firstCommit,
-      historyUrl: path
-        ? `https://github.com/${owner}/${repo}/commits/main/${path}`
-        : `https://github.com/${owner}/${repo}/commits/main`,
-    });
+    return NextResponse.json(
+      {
+        latestCommit,
+        firstCommit,
+        historyUrl: path
+          ? `https://github.com/${owner}/${repo}/commits/main/${path}`
+          : `https://github.com/${owner}/${repo}/commits/main`,
+      },
+      {
+        // Cache per (owner, repo, path) at the Vercel edge so repeat requests
+        // are served from cache instead of re-invoking the function. Mirrors
+        // the CACHE_TTL used for the upstream GitHub fetch above.
+        headers: {
+          'Cache-Control': `public, s-maxage=${CACHE_TTL}, stale-while-revalidate=86400`,
+        },
+      },
+    );
   } catch (error) {
     console.error('Error fetching GitHub metadata:', error);
     return NextResponse.json(

--- a/app/api/githubstar/route.ts
+++ b/app/api/githubstar/route.ts
@@ -31,7 +31,18 @@ export async function GET(request: Request) {
     }
 
     const data = await response.json();
-    return NextResponse.json({ stars: data.stargazers_count });
+    return NextResponse.json(
+      { stars: data.stargazers_count },
+      {
+        // Star count is identical site-wide and changes slowly. Cache the
+        // response at the Vercel edge so repeat page views are served from
+        // cache instead of re-invoking this function + hitting GitHub.
+        headers: {
+          'Cache-Control':
+            'public, s-maxage=3600, stale-while-revalidate=86400',
+        },
+      },
+    );
   } catch (error) {
     console.error('Error fetching GitHub stars:', error);
     return NextResponse.json(

--- a/next.config.js
+++ b/next.config.js
@@ -37,6 +37,13 @@ const config = {
   outputFileTracing: false,
   images: {
     unoptimized: process.env.UNOPTIMIZED_IMAGES === 'true',
+    // Cache optimized images for 31 days. Next.js defaults to 60s, which
+    // causes the optimizer to re-fetch and re-write variants constantly
+    // (the dominant Image Optimization cost was cache writes, not transforms).
+    minimumCacheTTL: 2678400,
+    // Drop the 3840px (4K) variant: it doubles the transform/cache cost of
+    // every image for a rare case, and Next falls back to 2048px gracefully.
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048],
     remotePatterns: [
       {
         protocol: 'https',

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Vercel "Ignored Build Step" command.
+#   exit 0  -> SKIP the build
+#   exit 1  -> PROCEED with the build
+#
+# Wire this up in: Vercel Project Settings -> Git -> Ignored Build Step
+#   Command:  bash scripts/vercel-ignore-build.sh
+#
+# Goal: stop spending ~7.5 min builds on PREVIEW deployments for bot-generated
+# branches that nobody reviews (Chinese translations, release-notes). Production
+# (main) and human PRs always build.
+
+set -euo pipefail
+
+echo "VERCEL_ENV=${VERCEL_ENV:-} VERCEL_GIT_COMMIT_REF=${VERCEL_GIT_COMMIT_REF:-}"
+
+# Always build production deployments.
+if [ "${VERCEL_ENV:-}" = "production" ]; then
+  echo "Production deployment — building."
+  exit 1
+fi
+
+# Skip preview builds for automated bot branches.
+case "${VERCEL_GIT_COMMIT_REF:-}" in
+  translate-pr-*|releaseNotes/*)
+    echo "Bot branch preview (${VERCEL_GIT_COMMIT_REF}) — skipping build."
+    exit 0
+    ;;
+esac
+
+echo "Building."
+exit 1

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh"
+}


### PR DESCRIPTION
## TL;DR

`tina-io`'s biggest Vercel runtime/build hotspots are uncached per-request work and redundant builds. This caches the two GitHub-backed API routes at the edge, sets `minimumCacheTTL` so optimized images stop being re-written every 60s, and adds an Ignored Build Step (wired via `vercel.json`) that skips the ~7.5 min build for bot-branch *preview* deployments. Addresses the code-level items in #4592.

**Files to review (5, +73 / -8):**

| File | Why |
|---|---|
| `app/api/githubstar/route.ts` | Was fully uncached (function + GitHub call on every page view) — adds `Cache-Control`. |
| `app/api/github-metadata/route.ts` | Cached upstream but ran a function per request — adds matching response cache. |
| `next.config.js` | `minimumCacheTTL` + drop 3840px `deviceSize`. |
| `scripts/vercel-ignore-build.sh` *(new, start here)* | Skips preview builds for `translate-pr-*` / `releaseNotes/*`. |
| `vercel.json` *(new)* | Wires the script in via `ignoreCommand` (version-controlled, overrides the dashboard field). |

## Why

The nav star widget calls `/api/githubstar` on essentially every page render, and it had no cache headers — so every visitor and every crawler hit re-invoked the function and called GitHub. Image optimization's dominant cost was **cache writes, not transforms**: Next's default `minimumCacheTTL` is 60s, so optimized variants were re-fetched and re-written constantly. And bot-generated branches (Chinese translations, release notes) were each triggering full preview builds nobody reviews.

## How

- **API routes:** wrap the success responses with `Cache-Control: public, s-maxage=…, stale-while-revalidate=86400`, so repeat requests are served from the Vercel edge (`x-vercel-cache: HIT`) instead of re-running the function. `github-metadata` reuses its existing `CACHE_TTL` (300s); `githubstar` uses 1h (the count is identical site-wide and slow-moving).
- **Images:** `minimumCacheTTL: 2678400` (31d) forces long reuse of optimized variants; dropping the 3840px variant halves transform/cache cost per image (Next falls back to 2048px).
- **Build skip:** `vercel.json` `ignoreCommand` runs the script, which exits 0 (skip) only for preview deployments on bot branches; production and human PRs always build. Smoke-tested for all four cases.

## Reviewer notes

- **Production always builds.** The script gates on `VERCEL_ENV=preview` + bot ref only; anything else proceeds.
- **Content commits still build.** tina-io builds content into the site, so the skip deliberately targets *bot preview* builds, not content changes.
- **No `qualities` config.** That's Next 15-only; this repo is on 14.2.

## Follow-up (dashboard — can't be done in-repo)

This PR makes the selective-skip work, but two settings still need flipping in Project Settings → Git for the intended preview behavior:

1. **Re-enable non-production auto deployments** (so previews run and the ignore step can selectively skip them).
2. **Enable auto-cancel of superseded deployments** (collapses rapid re-pushes / TinaCMS saves to the latest commit only).

Also out of scope: Firewall bot management, and evaluating a custom image loader for `assets.tina.io`.

## Links

- Closes part of tinacms/tina.io#4592