### PR TITLE
docs(contributing): add 'How to File a Good Bug Report' guide

### DIFF
--- a/content/docs-toc/docs-toc.json
+++ b/content/docs-toc/docs-toc.json
@@ -104,6 +104,11 @@
           "title": "FAQ",
           "slug": "content/docs/faq.mdx",
           "_template": "item"
+        },
+        {
+          "title": "Filing a Bug Report",
+          "slug": "content/docs/contributing/bug-reports.mdx",
+          "_template": "item"
         }
       ]
     },

--- a/content/docs/contributing/bug-reports.mdx
+++ b/content/docs/contributing/bug-reports.mdx
@@ -6,7 +6,7 @@ next: ''
 previous: ''
 ---
 
-A good bug report is the single biggest factor in how quickly we can fix your issue — for both humans on our team and the AI tooling we use to triage. Five extra minutes of writing can turn "doesn't work" into something we can act on inside one session.
+A good bug report is the single biggest factor in how quickly we can fix your issue - for both humans on our team and the AI tooling we use to triage. Five extra minutes of writing can turn "doesn't work" into something we can act on inside one session.
 
 This page is the canonical checklist. The same list is enforced as the post guidelines in our Discord `#ask-for-help` channel and as the fields in our [GitHub bug report template](https://github.com/tinacms/tinacms/issues/new?template=bug-report.yml).
 
@@ -20,15 +20,15 @@ Copy-paste it, don't paraphrase. The exact string is what we grep for, and what 
 
 ### 2. Steps to reproduce
 
-What you clicked, in order. Even a numbered text list is enough — you don't need a video.
+What you clicked, in order. Even a numbered text list is enough - you don't need a video.
 
-**❌ Bad example — vague description we can't act on**
+**❌ Bad example - vague description we can't act on**
 
 ```
 The image insert is broken, it just crashes.
 ```
 
-**✅ Good example — numbered click-by-click sequence**
+**✅ Good example - numbered click-by-click sequence**
 
 ```
 1. Open TinaCMS admin
@@ -46,14 +46,14 @@ A single sentence each is fine. Tells us whether you've hit a bug or a misunders
 
 **Actual:** TinaCMS admin goes blank/white screen. Console shows `React error #31`.
 
-### 4. Your environment — including anything non-default
+### 4. Your environment - including anything non-default
 
 This is the one most people forget, and the one that most often points us straight at the root cause. Include:
 
 - Version of `tinacms` and `@tinacms/cli`
 - Framework (Next.js, Astro, Remix, etc.)
 - TinaCloud or self-hosted
-- **Anything non-default** — custom `MediaStore`, custom auth, custom adapters, self-hosted setup, etc.
+- **Anything non-default** - custom `MediaStore`, custom auth, custom adapters, self-hosted setup, etc.
 
 ### 5. A way for us to reproduce
 
@@ -64,11 +64,11 @@ A minimal reproduction repo we can clone and run is the gold standard. `npx crea
 If your issue involves the schema or TinaCloud, also include:
 
 - **Relevant sections of your schema file** (you don't have to paste the whole thing)
-- **Client ID** — for any TinaCloud-related issue
+- **Client ID** - for any TinaCloud-related issue
 
 ## A real-world example
 
-[Issue #6679 — React Error #31 when inserting image from Media Library with custom MediaStore](https://github.com/tinacms/tinacms/issues/6679) is what a good report looks like in practice. It includes:
+[Issue #6679 - React Error #31 when inserting image from Media Library with custom MediaStore](https://github.com/tinacms/tinacms/issues/6679) is what a good report looks like in practice. It includes:
 
 - The exact error string ("React Error #31: Objects are not valid as a React child")
 - A numbered list of steps to reproduce
@@ -80,8 +80,8 @@ That report was investigated, fixed, tested and merged in a single session becau
 
 ## Where to file
 
-- **Discord** — `#ask-for-help` in the [TinaCMS Discord server](https://discord.com/invite/zumN63Ybpf). Best for "is this a bug or am I doing something wrong?" questions, and for community help.
-- **GitHub Issues** — [tinacms/tinacms/issues](https://github.com/tinacms/tinacms/issues/new/choose) for confirmed bugs. Our GitHub issue template prompts you with the same checklist as this page.
+- **Discord** - `#ask-for-help` in the [TinaCMS Discord server](https://discord.com/invite/zumN63Ybpf). Best for "is this a bug or am I doing something wrong?" questions, and for community help.
+- **GitHub Issues** - [tinacms/tinacms/issues](https://github.com/tinacms/tinacms/issues/new/choose) for confirmed bugs. Our GitHub issue template prompts you with the same checklist as this page.
 
 ## Why this works
 
@@ -89,9 +89,9 @@ The format isn't arbitrary. Each item maps to something a human or AI agent does
 
 | Item | Why it matters |
 | --- | --- |
-| Exact error | The grep target — points at the right file and line within seconds |
+| Exact error | The grep target - points at the right file and line within seconds |
 | Repro steps | Tells us *when* the code path is taken |
-| Environment + custom adapters | The biggest source of "works for me but not for them" — calls out the variable to test |
+| Environment + custom adapters | The biggest source of "works for me but not for them" - calls out the variable to test |
 | Repro repo | Removes the gap between "we think we've fixed it" and "we've actually fixed it for you" |
 
 Five minutes of your writing saves hours of back-and-forth, and lets the agents we use triage your report instead of waiting on it.

--- a/content/docs/contributing/bug-reports.mdx
+++ b/content/docs/contributing/bug-reports.mdx
@@ -22,13 +22,10 @@ Copy-paste it, don't paraphrase. The exact string is what we grep for, and what 
 
 What you clicked, in order. Even a numbered text list is enough - you don't need a video.
 
-**❌ Bad example - vague description we can't act on**
-
 ```
 The image insert is broken, it just crashes.
 ```
-
-**✅ Good example - numbered click-by-click sequence**
+**❌ Figure: Bad example - vague description we can't act on**
 
 ```
 1. Open TinaCMS admin
@@ -37,6 +34,7 @@ The image insert is broken, it just crashes.
 4. Select any image from the media library
 5. Click "Insert"
 ```
+**✅ Figure: Good example - numbered click-by-click sequence**
 
 ### 3. Expected vs actual behaviour
 

--- a/content/docs/contributing/bug-reports.mdx
+++ b/content/docs/contributing/bug-reports.mdx
@@ -1,0 +1,124 @@
+---
+id: /docs/contributing/bug-reports
+title: How to File a Good Bug Report
+last_edited: '2026-06-04'
+next: ''
+previous: ''
+---
+
+A good bug report is the single biggest factor in how quickly we can fix your issue — for both humans on our team and the AI tooling we use to triage. Five extra minutes of writing can turn "doesn't work" into something we can act on inside one session.
+
+This page is the canonical checklist. The same list is enforced as the post guidelines in our Discord `#ask-for-help` channel and as the fields in our [GitHub bug report template](https://github.com/tinacms/tinacms/issues/new?template=bug-report.yml).
+
+## The Checklist
+
+When you file a TinaCMS bug, include all of the following that are relevant:
+
+### 1. The exact error message
+
+Copy-paste it, don't paraphrase. The exact string is what we grep for, and what AI agents pattern-match on. A report that says "React error" is much harder to act on than one that says "React Error #31: Objects are not valid as a React child".
+
+### 2. Steps to reproduce
+
+What you clicked, in order. Even a numbered text list is enough — you don't need a video. Example:
+
+```
+1. Open TinaCMS admin
+2. Navigate to any page with an image field (e.g., a Hero Banner block)
+3. Click the image field → "Media Library" tab
+4. Select any image from the media library
+5. Click "Insert"
+```
+
+### 3. Expected vs. actual behaviour
+
+A single sentence each is fine. Tells us whether you've hit a bug or a misunderstanding:
+
+> **Expected:** The selected image is inserted into the field and the src string is saved.
+>
+> **Actual:** TinaCMS admin goes blank/white screen. Console shows `React error #31: Objects are not valid as React children`.
+
+### 4. Your environment — including anything non-default
+
+This is the one most people forget, and the one that most often points us straight at the root cause. Include:
+
+- Version of `tinacms` and `@tinacms/cli`
+- Framework (Next.js, Astro, Remix, etc.)
+- TinaCloud or self-hosted
+- **Anything non-default** — custom `MediaStore`, custom auth, custom adapters, self-hosted setup, etc.
+
+Example:
+
+```
+- TinaCMS v3.7.2
+- Self-hosted TinaCMS with custom GitHubMediaStore (stores images in private GitHub repo)
+- Netlify deployment with serverless functions
+```
+
+### 5. A way for us to reproduce — a link to a GH repo is the gold standard
+
+A minimal reproduction repo we can clone and run is the single most valuable thing you can include. `npx create-tina-app@latest` is a good starting point if you need a skeleton.
+
+### Tina-specific
+
+If your issue involves the schema or TinaCloud, also include:
+
+- **Relevant sections of your schema file** (you don't have to paste the whole thing)
+- **Client ID** — for any TinaCloud-related issue
+
+## Bad example vs. good example
+
+**Bad — hard to act on:**
+
+> I can't login. Help?
+
+**Good — actionable:**
+
+> **React Error #31 when inserting image from custom MediaStore into image fields**
+>
+> When using a custom MediaStore (e.g. a GitHubMediaStore for self-hosted setups), selecting an image from the Media Library and clicking "Insert" causes the TinaCMS admin to go blank with a white screen. The browser console shows:
+>
+> ```
+> React error #31: Objects are not valid as React children
+> ```
+>
+> The error shows a Media object with keys `{id, src, filename, directory, type, thumbnails}` being passed directly as a React child.
+>
+> **Environment:**
+>
+> - TinaCMS v3.7.2
+> - Self-hosted TinaCMS with custom MediaStore
+> - Netlify deployment with serverless functions
+>
+> **Steps to reproduce:**
+>
+> 1. Set up TinaCMS with a custom `MediaStore` that does not implement a `parse()` method
+> 2. Open TinaCMS admin
+> 3. Navigate to any page with an image field
+> 4. Click the image field → "Media Library" tab
+> 5. Select any image
+> 6. Click "Insert"
+>
+> **Expected:** The selected image is inserted into the field and the src string is saved.
+>
+> **Actual:** TinaCMS admin goes blank/white screen.
+
+For the full real-world example, see [issue #6679](https://github.com/tinacms/tinacms/issues/6679) — that report was investigated, fixed, tested and merged in a single session because every piece of the checklist was there.
+
+## Where to file
+
+- **Discord** — `#ask-for-help` in the [TinaCMS Discord server](https://discord.com/invite/zumN63Ybpf). Best for "is this a bug or am I doing something wrong?" questions, and for getting community help.
+- **GitHub Issues** — [tinacms/tinacms/issues](https://github.com/tinacms/tinacms/issues/new/choose) for confirmed bugs. Our GitHub issue template prompts you with the same checklist as this page.
+
+## Why this works
+
+The four-detail format isn't arbitrary. Each item maps to something a human or AI agent does when investigating:
+
+| Item | Why it matters |
+| --- | --- |
+| Exact error | The grep target — points at the right file and line within seconds |
+| Repro steps | Tells us *when* the code path is taken |
+| Environment + custom adapters | The biggest source of "works for me but not for them" — calls out the variable to test |
+| Repro repo | Removes the gap between "we think we've fixed it" and "we've actually fixed it for you" |
+
+Five minutes of your writing saves hours of back-and-forth, and lets the agents we use triage your report instead of waiting on it.

--- a/content/docs/contributing/bug-reports.mdx
+++ b/content/docs/contributing/bug-reports.mdx
@@ -20,7 +20,15 @@ Copy-paste it, don't paraphrase. The exact string is what we grep for, and what 
 
 ### 2. Steps to reproduce
 
-What you clicked, in order. Even a numbered text list is enough — you don't need a video. Example:
+What you clicked, in order. Even a numbered text list is enough — you don't need a video.
+
+**Bad** — we can't act on this:
+
+```
+The image insert is broken, it just crashes.
+```
+
+**Good** — we can:
 
 ```
 1. Open TinaCMS admin

--- a/content/docs/contributing/bug-reports.mdx
+++ b/content/docs/contributing/bug-reports.mdx
@@ -6,7 +6,7 @@ next: ''
 previous: ''
 ---
 
-A good bug report is the single biggest factor in how quickly we can fix your issue — for both humans on our team and the AI tooling we use to triage. Five extra minutes of writing can turn "doesn't work" into something we can act on inside one session.
+A good bug report is the single biggest factor in how quickly we can fix your issue - for both humans on our team and the AI tooling we use to triage. Five extra minutes of writing can turn "doesn't work" into something we can act on inside one session.
 
 This page is the canonical checklist. The same list is enforced as the post guidelines in our Discord `#ask-for-help` channel and as the fields in our [GitHub bug report template](https://github.com/tinacms/tinacms/issues/new?template=bug-report.yml).
 
@@ -20,7 +20,7 @@ Copy-paste it, don't paraphrase. The exact string is what we grep for, and what 
 
 ### 2. Steps to reproduce
 
-What you clicked, in order. Even a numbered text list is enough — you don't need a video. Example:
+What you clicked, in order. Even a numbered text list is enough - you don't need a video. Example:
 
 ```
 1. Open TinaCMS admin
@@ -55,7 +55,7 @@ Example:
 - Netlify deployment with serverless functions
 ```
 
-### 5. A way for us to reproduce — a link to a GH repo is the gold standard
+### 5. A way for us to reproduce - a link to a GH repo is the gold standard
 
 A minimal reproduction repo we can clone and run is the single most valuable thing you can include. `npx create-tina-app@latest` is a good starting point if you need a skeleton.
 
@@ -66,13 +66,13 @@ If your issue involves the schema or TinaCloud, also include:
 - **Relevant sections of your schema file** (you don't have to paste the whole thing)
 - **Client ID** — for any TinaCloud-related issue
 
-## Bad example vs. good example
+## Bad example vs Good example
 
-**Bad — hard to act on:**
+**Bad - hard to act on:**
 
 > I can't login. Help?
 
-**Good — actionable:**
+**Good - actionable:**
 
 > **React Error #31 when inserting image from custom MediaStore into image fields**
 >
@@ -103,12 +103,10 @@ If your issue involves the schema or TinaCloud, also include:
 >
 > **Actual:** TinaCMS admin goes blank/white screen.
 
-For the full real-world example, see [issue #6679](https://github.com/tinacms/tinacms/issues/6679) — that report was investigated, fixed, tested and merged in a single session because every piece of the checklist was there.
-
 ## Where to file
 
-- **Discord** — `#ask-for-help` in the [TinaCMS Discord server](https://discord.com/invite/zumN63Ybpf). Best for "is this a bug or am I doing something wrong?" questions, and for getting community help.
-- **GitHub Issues** — [tinacms/tinacms/issues](https://github.com/tinacms/tinacms/issues/new/choose) for confirmed bugs. Our GitHub issue template prompts you with the same checklist as this page.
+- **Discord** - `#ask-for-help` in the [TinaCMS Discord server](https://discord.com/invite/zumN63Ybpf). Best for "is this a bug or am I doing something wrong?" questions, and for getting community help.
+- **GitHub Issues** - [tinacms/tinacms/issues](https://github.com/tinacms/tinacms/issues/new/choose) for confirmed bugs. Our GitHub issue template prompts you with the same checklist as this page.
 
 ## Why this works
 

--- a/content/docs/contributing/bug-reports.mdx
+++ b/content/docs/contributing/bug-reports.mdx
@@ -6,7 +6,7 @@ next: ''
 previous: ''
 ---
 
-A good bug report is the single biggest factor in how quickly we can fix your issue - for both humans on our team and the AI tooling we use to triage. Five extra minutes of writing can turn "doesn't work" into something we can act on inside one session.
+A good bug report is the single biggest factor in how quickly we can fix your issue — for both humans on our team and the AI tooling we use to triage. Five extra minutes of writing can turn "doesn't work" into something we can act on inside one session.
 
 This page is the canonical checklist. The same list is enforced as the post guidelines in our Discord `#ask-for-help` channel and as the fields in our [GitHub bug report template](https://github.com/tinacms/tinacms/issues/new?template=bug-report.yml).
 
@@ -20,7 +20,7 @@ Copy-paste it, don't paraphrase. The exact string is what we grep for, and what 
 
 ### 2. Steps to reproduce
 
-What you clicked, in order. Even a numbered text list is enough - you don't need a video. Example:
+What you clicked, in order. Even a numbered text list is enough — you don't need a video. Example:
 
 ```
 1. Open TinaCMS admin
@@ -55,7 +55,7 @@ Example:
 - Netlify deployment with serverless functions
 ```
 
-### 5. A way for us to reproduce - a link to a GH repo is the gold standard
+### 5. A way for us to reproduce — a link to a GH repo is the gold standard
 
 A minimal reproduction repo we can clone and run is the single most valuable thing you can include. `npx create-tina-app@latest` is a good starting point if you need a skeleton.
 
@@ -66,13 +66,13 @@ If your issue involves the schema or TinaCloud, also include:
 - **Relevant sections of your schema file** (you don't have to paste the whole thing)
 - **Client ID** — for any TinaCloud-related issue
 
-## Bad example vs Good example
+## Bad example vs. good example
 
-**Bad - hard to act on:**
+**Bad — hard to act on:**
 
 > I can't login. Help?
 
-**Good - actionable:**
+**Good — actionable:**
 
 > **React Error #31 when inserting image from custom MediaStore into image fields**
 >
@@ -103,10 +103,12 @@ If your issue involves the schema or TinaCloud, also include:
 >
 > **Actual:** TinaCMS admin goes blank/white screen.
 
+For the full real-world example, see [issue #6679](https://github.com/tinacms/tinacms/issues/6679) — that report was investigated, fixed, tested and merged in a single session because every piece of the checklist was there.
+
 ## Where to file
 
-- **Discord** - `#ask-for-help` in the [TinaCMS Discord server](https://discord.com/invite/zumN63Ybpf). Best for "is this a bug or am I doing something wrong?" questions, and for getting community help.
-- **GitHub Issues** - [tinacms/tinacms/issues](https://github.com/tinacms/tinacms/issues/new/choose) for confirmed bugs. Our GitHub issue template prompts you with the same checklist as this page.
+- **Discord** — `#ask-for-help` in the [TinaCMS Discord server](https://discord.com/invite/zumN63Ybpf). Best for "is this a bug or am I doing something wrong?" questions, and for getting community help.
+- **GitHub Issues** — [tinacms/tinacms/issues](https://github.com/tinacms/tinacms/issues/new/choose) for confirmed bugs. Our GitHub issue template prompts you with the same checklist as this page.
 
 ## Why this works
 

--- a/content/docs/contributing/bug-reports.mdx
+++ b/content/docs/contributing/bug-reports.mdx
@@ -22,13 +22,13 @@ Copy-paste it, don't paraphrase. The exact string is what we grep for, and what 
 
 What you clicked, in order. Even a numbered text list is enough — you don't need a video.
 
-**Bad example — vague description we can't act on**
+**❌ Bad example — vague description we can't act on**
 
 ```
 The image insert is broken, it just crashes.
 ```
 
-**Good example — numbered click-by-click sequence**
+**✅ Good example — numbered click-by-click sequence**
 
 ```
 1. Open TinaCMS admin

--- a/content/docs/contributing/bug-reports.mdx
+++ b/content/docs/contributing/bug-reports.mdx
@@ -1,7 +1,7 @@
 ---
 id: /docs/contributing/bug-reports
 title: How to File a Good Bug Report
-last_edited: '2026-06-04'
+last_edited: '2026-06-04T10:00:00.000Z'
 next: ''
 previous: ''
 ---
@@ -30,13 +30,13 @@ What you clicked, in order. Even a numbered text list is enough — you don't ne
 5. Click "Insert"
 ```
 
-### 3. Expected vs. actual behaviour
+### 3. Expected vs actual behaviour
 
-A single sentence each is fine. Tells us whether you've hit a bug or a misunderstanding:
+A single sentence each is fine. Tells us whether you've hit a bug or a misunderstanding.
 
-> **Expected:** The selected image is inserted into the field and the src string is saved.
->
-> **Actual:** TinaCMS admin goes blank/white screen. Console shows `React error #31: Objects are not valid as React children`.
+**Expected:** The selected image is inserted into the field and the src string is saved.
+
+**Actual:** TinaCMS admin goes blank/white screen. Console shows `React error #31`.
 
 ### 4. Your environment — including anything non-default
 
@@ -47,72 +47,37 @@ This is the one most people forget, and the one that most often points us straig
 - TinaCloud or self-hosted
 - **Anything non-default** — custom `MediaStore`, custom auth, custom adapters, self-hosted setup, etc.
 
-Example:
+### 5. A way for us to reproduce
 
-```
-- TinaCMS v3.7.2
-- Self-hosted TinaCMS with custom GitHubMediaStore (stores images in private GitHub repo)
-- Netlify deployment with serverless functions
-```
+A minimal reproduction repo we can clone and run is the gold standard. `npx create-tina-app@latest` is a good starting point if you need a skeleton.
 
-### 5. A way for us to reproduce — a link to a GH repo is the gold standard
-
-A minimal reproduction repo we can clone and run is the single most valuable thing you can include. `npx create-tina-app@latest` is a good starting point if you need a skeleton.
-
-### Tina-specific
+### For Tina-specific issues
 
 If your issue involves the schema or TinaCloud, also include:
 
 - **Relevant sections of your schema file** (you don't have to paste the whole thing)
 - **Client ID** — for any TinaCloud-related issue
 
-## Bad example vs. good example
+## A real-world example
 
-**Bad — hard to act on:**
+[Issue #6679 — React Error #31 when inserting image from Media Library with custom MediaStore](https://github.com/tinacms/tinacms/issues/6679) is what a good report looks like in practice. It includes:
 
-> I can't login. Help?
+- The exact error string ("React Error #31: Objects are not valid as a React child")
+- A numbered list of steps to reproduce
+- The shape of the data being passed (object with keys `{id, src, filename, directory, type, thumbnails}`)
+- The environment, including the custom GitHub-backed `MediaStore` adapter
+- A guess at the root cause
 
-**Good — actionable:**
-
-> **React Error #31 when inserting image from custom MediaStore into image fields**
->
-> When using a custom MediaStore (e.g. a GitHubMediaStore for self-hosted setups), selecting an image from the Media Library and clicking "Insert" causes the TinaCMS admin to go blank with a white screen. The browser console shows:
->
-> ```
-> React error #31: Objects are not valid as React children
-> ```
->
-> The error shows a Media object with keys `{id, src, filename, directory, type, thumbnails}` being passed directly as a React child.
->
-> **Environment:**
->
-> - TinaCMS v3.7.2
-> - Self-hosted TinaCMS with custom MediaStore
-> - Netlify deployment with serverless functions
->
-> **Steps to reproduce:**
->
-> 1. Set up TinaCMS with a custom `MediaStore` that does not implement a `parse()` method
-> 2. Open TinaCMS admin
-> 3. Navigate to any page with an image field
-> 4. Click the image field → "Media Library" tab
-> 5. Select any image
-> 6. Click "Insert"
->
-> **Expected:** The selected image is inserted into the field and the src string is saved.
->
-> **Actual:** TinaCMS admin goes blank/white screen.
-
-For the full real-world example, see [issue #6679](https://github.com/tinacms/tinacms/issues/6679) — that report was investigated, fixed, tested and merged in a single session because every piece of the checklist was there.
+That report was investigated, fixed, tested and merged in a single session because every piece of the checklist was there. With a vague "images are broken" report, it would have sat untouched.
 
 ## Where to file
 
-- **Discord** — `#ask-for-help` in the [TinaCMS Discord server](https://discord.com/invite/zumN63Ybpf). Best for "is this a bug or am I doing something wrong?" questions, and for getting community help.
+- **Discord** — `#ask-for-help` in the [TinaCMS Discord server](https://discord.com/invite/zumN63Ybpf). Best for "is this a bug or am I doing something wrong?" questions, and for community help.
 - **GitHub Issues** — [tinacms/tinacms/issues](https://github.com/tinacms/tinacms/issues/new/choose) for confirmed bugs. Our GitHub issue template prompts you with the same checklist as this page.
 
 ## Why this works
 
-The four-detail format isn't arbitrary. Each item maps to something a human or AI agent does when investigating:
+The format isn't arbitrary. Each item maps to something a human or AI agent does when investigating:
 
 | Item | Why it matters |
 | --- | --- |

--- a/content/docs/contributing/bug-reports.mdx
+++ b/content/docs/contributing/bug-reports.mdx
@@ -22,13 +22,13 @@ Copy-paste it, don't paraphrase. The exact string is what we grep for, and what 
 
 What you clicked, in order. Even a numbered text list is enough — you don't need a video.
 
-**Bad** — we can't act on this:
+**Bad example — vague description we can't act on**
 
 ```
 The image insert is broken, it just crashes.
 ```
 
-**Good** — we can:
+**Good example — numbered click-by-click sequence**
 
 ```
 1. Open TinaCMS admin


### PR DESCRIPTION
## What hurts

The "how to file a good bug report" lesson currently lives in three places — Discord post guidelines, the GitHub form, and our internal team knowledge — with no single URL we can link to. Every blog post, error page, video, or agent prompt that wants to reference it has to duplicate the checklist locally.

## What this does

Adds `/docs/contributing/bug-reports` as the canonical version, linked under **Introduction → Filing a Bug Report** in the sidebar. Discord guidelines, the GitHub form (tinacms/tinacms#7026), and forthcoming agent guidance (tinacms/tinacms#7027) all link back here.

**Squash on merge** — branch has a noisy commit history (initial upload was mangled, recovered via re-uploads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)