### PR TITLE
docs: FAQ entry for npm Vite version-skew build failure

### DIFF
--- a/content/docs/faq.mdx
+++ b/content/docs/faq.mdx
@@ -255,7 +255,7 @@ As a workaround, you can rename media files by making the changes directly in Gi
 
 For more details, see [Renaming Media Files](/docs/reference/media/repo-based/#renaming-media-files).
 
-## 22. Why does my Astro / npm build fail with "Missing field `tsconfigPaths`" (or Vite version errors)?
+## 22. Why does my npm build fail with "Missing field `tsconfigPaths`" (or Vite version errors)?
 
 This happens under **npm** when two major versions of Vite end up in the dependency tree — for example, Vite 8 pulled in by `@tailwindcss/vite` alongside the Vite 7 that Astro uses. The mismatched rolldown bindings crash the build.
 

--- a/content/docs/faq.mdx
+++ b/content/docs/faq.mdx
@@ -254,3 +254,13 @@ As a workaround, you can rename media files by making the changes directly in Gi
 4. Wait for the addition to sync back to TinaCloud
 
 For more details, see [Renaming Media Files](/docs/reference/media/repo-based/#renaming-media-files).
+
+## 22. Why does my Astro / npm build fail with "Missing field `tsconfigPaths`" (or Vite version errors)?
+
+This happens under **npm** when two major versions of Vite end up in the dependency tree — for example, Vite 8 pulled in by `@tailwindcss/vite` alongside the Vite 7 that Astro uses. The mismatched rolldown bindings crash the build.
+
+We recommend **pnpm**, which resolves to a single Vite version automatically and avoids this class of issue. If you must use npm, delete `node_modules` and `package-lock.json`, reinstall, and pin Vite with an `overrides` block in `package.json`:
+
+```json
+"overrides": { "vite": "^7" }
+```


### PR DESCRIPTION
## What

Adds FAQ entry #22 to `content/docs/faq.mdx` covering the `Missing field tsconfigPaths` build failure npm users hit.

## Why

Under **npm**, two major versions of Vite can end up in the dependency tree (e.g. Vite 8 pulled in by `@tailwindcss/vite` alongside the Vite 7 Astro uses), and the mismatched rolldown bindings crash the build. Reported in [tina-astro-starter#58](https://github.com/tinacms/tina-astro-starter/issues/58).

The new entry recommends **pnpm** (which dedupes to a single Vite) and gives the npm `overrides` workaround. Pairs with the create-tina-app change that recommends pnpm by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)