### PR TITLE
🐛 Fix release notes parser dropping single-space markdown bullets

### DIFF
--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -147,7 +147,7 @@ export function Footer({ footerData }: { footerData: FooterData }) {
               <TinaIcon color="white" />
             </div>
             <div className="flex-1 grid grid-cols-2 py-2 lg:py-0 md:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-4">
-              {currentFooterNav.map((item, columnIndex) => {
+              {currentFooterNav.map((item, _columnIndex) => {
                 const { header, footerItem } = item;
                 return (
                   <div

--- a/content/whats-new-tinacms/v3.9.1.json
+++ b/content/whats-new-tinacms/v3.9.1.json
@@ -3,10 +3,16 @@
   "dateReleased": "2026-06-05T06:46:13Z",
   "changesObject": [
     {
-      "changesTitle": "Release Notes",
+      "changesTitle": "Patch Changes",
       "changesList": [
         {
-          "changesDescription": ""
+          "changesDescription": "Skip the filesystem-backed response cache on edge runtimes (Cloudflare Workers, Vercel Edge) where Node's `fs` API is present but unusable, which could otherwise hang concurrent identical queries. Adds a `cache` option to `createClient` to force-disable the cache.",
+          "pull_request_number": "7028",
+          "pull_request_link": "https://github.com/tinacms/tinacms/pull/7028",
+          "commit_hash": "7b539b8",
+          "commit_link": "https://github.com/tinacms/tinacms/commit/7b539b8e7d7d9f4451b5fd36a04d26b734f7d78e",
+          "gitHubName": "JackDevAU",
+          "gitHubLink": "https://github.com/JackDevAU"
         }
       ]
     }

--- a/scripts/create-release-notes.sh
+++ b/scripts/create-release-notes.sh
@@ -56,7 +56,7 @@ else
   echo "$RELEASE_NOTES" > "$temp_md"
   
   # Check if markdown contains "Updated dependencies" pattern
-  if grep -qE "^[-*]   Updated dependencies" "$temp_md"; then
+  if grep -qE "^[-*][[:space:]]+Updated dependencies" "$temp_md"; then
     # Use awk to parse markdown and build JSON structure
     # This handles sections (## and ### headers) and converts "Updated dependencies" into its own section
     awk -v version="$trimmedVersionNumber" -v date="$DATE_RELEASED" '
@@ -92,7 +92,7 @@ else
       next
     }
     
-    /^[-*]   Updated dependencies/ {
+    /^[-*][[:space:]]+Updated dependencies/ {
       # Save previous section
       if (section != "" && items != "") {
         if (!first_section) sections = sections ","
@@ -114,9 +114,9 @@ else
       next
     }
     
-    in_updated_deps && /^    -/ {
-      dep_name = substr($0, 6)
-      gsub(/^[[:space:]]+/, "", dep_name)
+    in_updated_deps && /^[[:space:]]+-[[:space:]]/ {
+      dep_name = $0
+      gsub(/^[[:space:]]*-[[:space:]]*/, "", dep_name)
       gsub(/"/, "\\\"", dep_name)
       if (items != "") items = items ","
       item_json = "\n          {\n            \"changesDescription\": \"" dep_name "\""
@@ -129,9 +129,9 @@ else
       next
     }
     
-    /^[-*]   / && !in_updated_deps {
-      item_text = substr($0, 5)
-      gsub(/^[[:space:]]+/, "", item_text)
+    /^[-*][[:space:]]/ && !in_updated_deps {
+      item_text = $0
+      gsub(/^[-*][[:space:]]+/, "", item_text)
       
       # Parse the markdown line to extract PR, commit, GitHub info, and description
       pr_number = ""
@@ -328,15 +328,9 @@ else
       }
       
       /^[-*][[:space:]]/ {
-        # Match both "-   " (dash + spaces) and "* " (asterisk + space) patterns
-        if (/^-[[:space:]]{3}/) {
-          item_text = substr($0, 5)
-        } else if (/^\*[[:space:]]/) {
-          item_text = substr($0, 3)
-        } else {
-          next
-        }
-        gsub(/^[[:space:]]+/, "", item_text)
+        # Match dash or asterisk bullets with any amount of whitespace after the marker
+        item_text = $0
+        gsub(/^[-*][[:space:]]+/, "", item_text)
         
         # Parse the markdown line to extract PR, commit, GitHub info, and description
         pr_number = ""
@@ -503,6 +497,20 @@ else
   fi
 fi
 
+
+# Fail loudly if parsing produced no items or any empty descriptions, so the
+# workflow errors instead of opening a PR with an empty release notes page.
+itemCount=$(jq '[.changesObject // [] | .[] | .changesList // [] | .[]] | length' "$releaseNotesFile")
+emptyCount=$(jq '[.changesObject // [] | .[] | .changesList // [] | .[] | .changesDescription
+  | if type == "object" then ([.. | .text? // empty] | join("")) else tostring end
+  | select(gsub("\\s"; "") == "")] | length' "$releaseNotesFile")
+if [ "$itemCount" -eq 0 ] || [ "$emptyCount" -gt 0 ]; then
+  echo "❌ Release notes parsing produced $itemCount items ($emptyCount with empty descriptions)."
+  echo "The RELEASE_NOTES input could not be parsed:"
+  echo "$RELEASE_NOTES"
+  rm -f "$releaseNotesFile"
+  exit 1
+fi
 
 echo "✅ File created"
 cat $releaseNotesFile

--- a/scripts/create-release-notes.test.ts
+++ b/scripts/create-release-notes.test.ts
@@ -1,7 +1,8 @@
-import { execFileSync } from 'node:child_process';
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
+// biome-ignore-all lint/style/useNodejsImportProtocol: Jest 25 cannot load node: builtin specifiers.
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 const SCRIPT = path.resolve(__dirname, 'create-release-notes.sh');
 

--- a/scripts/create-release-notes.test.ts
+++ b/scripts/create-release-notes.test.ts
@@ -1,0 +1,190 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const SCRIPT = path.resolve(__dirname, 'create-release-notes.sh');
+
+interface ChangeItem {
+  changesDescription: string;
+  pull_request_number?: string;
+  pull_request_link?: string;
+  commit_hash?: string;
+  commit_link?: string;
+  gitHubName?: string;
+  gitHubLink?: string;
+}
+
+interface ChangesSection {
+  changesTitle: string;
+  changesList: ChangeItem[];
+}
+
+interface ReleaseNotes {
+  versionNumber: string;
+  dateReleased: string;
+  changesObject: ChangesSection[];
+}
+
+function runScript(env: {
+  PROJECT_NAME: string;
+  VERSION_NUMBER: string;
+  DATE_RELEASED: string;
+  RELEASE_NOTES: string;
+}): { releaseNotes: ReleaseNotes | null; exitCode: number; output: string } {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'release-notes-test-'));
+  fs.mkdirSync(
+    path.join(cwd, `content/whats-new-${env.PROJECT_NAME.toLowerCase()}`),
+    { recursive: true },
+  );
+
+  let exitCode = 0;
+  let output = '';
+  try {
+    output = execFileSync(SCRIPT, {
+      cwd,
+      env: { ...process.env, ...env },
+      encoding: 'utf-8',
+    });
+  } catch (e: any) {
+    exitCode = e.status ?? 1;
+    output = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+  }
+
+  const file = path.join(
+    cwd,
+    `content/whats-new-${env.PROJECT_NAME.toLowerCase()}`,
+    `${env.VERSION_NUMBER.toLowerCase()}.json`,
+  );
+  const releaseNotes = fs.existsSync(file)
+    ? JSON.parse(fs.readFileSync(file, 'utf-8'))
+    : null;
+  fs.rmSync(cwd, { recursive: true, force: true });
+  return { releaseNotes, exitCode, output };
+}
+
+describe('create-release-notes.sh', () => {
+  it('parses changeset bullets with a single space after the dash (v3.9.1 format)', () => {
+    // Verbatim input from the v3.9.1 release that produced an empty page (PR #4612)
+    const { releaseNotes, exitCode } = runScript({
+      PROJECT_NAME: 'TinaCMS',
+      VERSION_NUMBER: 'v3.9.1',
+      DATE_RELEASED: '2026-06-05T06:46:13Z',
+      RELEASE_NOTES: `### Patch Changes
+
+- [#7028](https://github.com/tinacms/tinacms/pull/7028) [\`7b539b8\`](https://github.com/tinacms/tinacms/commit/7b539b8e7d7d9f4451b5fd36a04d26b734f7d78e) Thanks [@JackDevAU](https://github.com/JackDevAU)! - Skip the filesystem-backed response cache on edge runtimes (Cloudflare Workers, Vercel Edge) where Node's \`fs\` API is present but unusable, which could otherwise hang concurrent identical queries. Adds a \`cache\` option to \`createClient\` to force-disable the cache.`,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(releaseNotes?.versionNumber).toBe('3.9.1');
+    expect(releaseNotes?.changesObject).toEqual([
+      {
+        changesTitle: 'Patch Changes',
+        changesList: [
+          expect.objectContaining({
+            changesDescription: expect.stringContaining(
+              'Skip the filesystem-backed response cache on edge runtimes',
+            ),
+            pull_request_number: '7028',
+            pull_request_link: 'https://github.com/tinacms/tinacms/pull/7028',
+            commit_hash: '7b539b8',
+            gitHubName: 'JackDevAU',
+            gitHubLink: 'https://github.com/JackDevAU',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('still parses changeset bullets with three spaces after the dash (v3.9.0 format)', () => {
+    const { releaseNotes, exitCode } = runScript({
+      PROJECT_NAME: 'TinaCMS',
+      VERSION_NUMBER: 'v3.9.0',
+      DATE_RELEASED: '2026-06-03T02:27:22Z',
+      RELEASE_NOTES: `### Minor Changes
+
+-   [#7009](https://github.com/tinacms/tinacms/pull/7009) [\`a8dd9af\`](https://github.com/tinacms/tinacms/commit/a8dd9af056b17a8faeaa621bbf7722a62b396cf8) Thanks [@JackDevAU](https://github.com/JackDevAU)! - chore: remove deprecated code`,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(releaseNotes?.changesObject).toEqual([
+      {
+        changesTitle: 'Minor Changes',
+        changesList: [
+          expect.objectContaining({
+            changesDescription: 'chore: remove deprecated code',
+            pull_request_number: '7009',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('parses single-space "Updated dependencies" bullets and their nested deps', () => {
+    const { releaseNotes, exitCode } = runScript({
+      PROJECT_NAME: 'TinaCMS',
+      VERSION_NUMBER: 'v9.9.9',
+      DATE_RELEASED: '2026-01-01T00:00:00Z',
+      RELEASE_NOTES: `### Patch Changes
+
+- Updated dependencies [[\`e27c017\`](https://github.com/tinacms/tinacms/commit/e27c017abc123)]:
+  - @tinacms/cli@1.2.3
+  - tinacms@2.3.4`,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(releaseNotes?.changesObject).toEqual([
+      {
+        changesTitle: 'Updated Dependencies',
+        changesList: [
+          expect.objectContaining({
+            changesDescription: '@tinacms/cli@1.2.3',
+            commit_hash: 'e27c017',
+          }),
+          expect.objectContaining({
+            changesDescription: 'tinacms@2.3.4',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('parses TinaCloud-style asterisk bullets', () => {
+    const { releaseNotes, exitCode } = runScript({
+      PROJECT_NAME: 'TinaCloud',
+      VERSION_NUMBER: '2026.06.1',
+      DATE_RELEASED: '2026-06-01T00:00:00Z',
+      RELEASE_NOTES: `## What's Changed
+### ✨ Features
+* ✨ Add CLI Cognito app client (PKCE) to IdentityStack by @joshbermanssw`,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(releaseNotes?.changesObject).toEqual([
+      {
+        changesTitle: '✨ Features',
+        changesList: [
+          expect.objectContaining({
+            changesDescription:
+              '✨ Add CLI Cognito app client (PKCE) to IdentityStack',
+            gitHubName: 'joshbermanssw',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('fails loudly instead of writing a page with empty descriptions', () => {
+    // Headers but no parseable bullet items at all
+    const { exitCode } = runScript({
+      PROJECT_NAME: 'TinaCMS',
+      VERSION_NUMBER: 'v9.9.8',
+      DATE_RELEASED: '2026-01-01T00:00:00Z',
+      RELEASE_NOTES: `### Patch Changes
+
+some prose that is not a list item`,
+    });
+
+    expect(exitCode).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## TL;DR

The auto-generated release notes page for TinaCMS v3.9.1 (#4612) was published empty — the parser silently dropped every bullet and fell back to `"changesDescription": ""`. The bullet matcher in `create-release-notes.sh` now accepts any whitespace after the list marker, and the script fails loudly instead of writing an empty page.

**Files to review (3, +223 / -19):**

| File | Why |
|---|---|
| `scripts/create-release-notes.sh` *(start here)* | Relaxed bullet matching in both awk blocks + new empty-output guard. |
| `scripts/create-release-notes.test.ts` *(new)* | Jest tests that shell out to the script, including the verbatim v3.9.1 input that broke. |
| `content/whats-new-tinacms/v3.9.1.json` | Regenerated with the fixed script from the original workflow input — restores the missing page content. |

## Why

The awk parser only accepted bullets shaped exactly like `-␣␣␣item` (dash + three spaces, changesets' prettier-formatted style) or `*␣item`. The v3.9.1 release notes arrived with standard single-space bullets (`-␣item`), so the only item hit the `else next` branch and was discarded; with zero items parsed, the script printed its hardcoded empty fallback, exited 0, and the workflow happily opened (and auto-merged) a PR with a blank page. Compare [run 26860023803](https://github.com/tinacms/tina.io/actions/runs/26860023803) (v3.9.0, three-space bullets, parsed fine) with [run 27000040038](https://github.com/tinacms/tina.io/actions/runs/27000040038) (v3.9.1, single-space bullets, empty output).

## How

- Both awk blocks now match `^[-*][[:space:]]` and strip the marker with `gsub` instead of fixed-offset `substr`, so any bullet indentation parses.
- The same relaxation applies to the `Updated dependencies` detection and its nested dep lines, which had the identical rigid pattern.
- A post-write guard counts items and empty descriptions with `jq`; if nothing parsed, the script deletes the file, echoes the raw input, and exits 1 — so the workflow fails visibly instead of auto-merging an empty page.

## Reviewer notes

- **Guard covers both fallback shapes.** Empty descriptions appear as plain `""` or as rich-text objects with empty `text` nodes depending on the code path; the jq check normalizes both.
- **v3.9.1.json regenerated, not hand-written.** Output of the fixed script run with the exact `RELEASE_NOTES` input captured from the original workflow logs.

## Tests

5 new Jest tests in `scripts/create-release-notes.test.ts` run the script end-to-end in a temp dir: single-space bullets (the v3.9.1 regression), three-space bullets (v3.9.0 format), single-space `Updated dependencies` with nested deps, TinaCloud asterisk bullets, and the fail-loudly guard. Run with `npx jest scripts/create-release-notes.test.ts`; full suite (45 tests) passes.

## Links

- [PR #4612 — the empty release notes page this fixes](https://github.com/tinacms/tina.io/pull/4612)
- [Workflow run that produced the empty page](https://github.com/tinacms/tina.io/actions/runs/27000040038)