### PR TITLE
🩹 Restore whats-new-tinacms/v3.9.1 to fix the main build

### DIFF
--- a/content/whats-new-tinacms/v3.9.1.json
+++ b/content/whats-new-tinacms/v3.9.1.json
@@ -1,0 +1,20 @@
+{
+  "versionNumber": "3.9.1",
+  "dateReleased": "2026-06-05T06:46:13Z",
+  "changesObject": [
+    {
+      "changesTitle": "Patch Changes",
+      "changesList": [
+        {
+          "changesDescription": "Skip the filesystem-backed response cache on edge runtimes (Cloudflare Workers, Vercel Edge) where Node's `fs` API is present but unusable, which could otherwise hang concurrent identical queries. Adds a `cache` option to `createClient` to force-disable the cache.",
+          "pull_request_number": "7028",
+          "pull_request_link": "https://github.com/tinacms/tinacms/pull/7028",
+          "commit_hash": "7b539b8",
+          "commit_link": "https://github.com/tinacms/tinacms/commit/7b539b8e7d7d9f4451b5fd36a04d26b734f7d78e",
+          "gitHubName": "JackDevAU",
+          "gitHubLink": "https://github.com/JackDevAU"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## TL;DR

Production builds on `main` fail prerendering `/whats-new/tinacms` with `Error querying file content/whats-new-tinacms/v3.9.1.json from collection WhatsNewTinaCMS`. This PR reverts #4631 and restores the file so the build passes.

## Why

The TinaCMS admin showed two v3.9.1 documents, but git history shows only one `v3.9.1.json` ever existed — the second was a stale TinaCloud index entry. Deleting "the duplicate" via the admin (#4631) therefore removed the only real file, leaving an orphaned index entry on the `main` branch index. Every `WhatsNewTinaCMSConnection` query now tries to resolve that entry against a file that no longer exists in git, which kills static generation of `/whats-new/tinacms` and the whole deploy.

Restoring the file gives the index entry something to resolve to. The v3.9.1 release notes content is valid and belongs on the site anyway (real release, added in #4612).

## Follow-up

The stale duplicate entry still needs a branch re-index of `main` in the TinaCloud dashboard (app.tina.io) — until then the admin may keep showing two v3.9.1 documents. Do **not** delete the file again; re-index instead.

## Links

- Deletion this reverts: #4631
- Original release notes: #4612