### PR TITLE
Roadmap: docs framework adapters (v4.1, Coming Soon)

### DIFF
--- a/content/main/roadmap.json
+++ b/content/main/roadmap.json
@@ -274,7 +274,7 @@
         {
           "icon": "FaRegClock",
           "heading": "TinaCMS v4.1 - MDX plugin adaptors\n",
-          "content": "We are bringing MDX plugin adaptors to TinaCMS. This will allow users to bring their favourite tools with their own flavours of Markdown and still use TinaCMS' visual editing, getting the best of both worlds.\n",
+          "content": "We’re adding MDX plugin adapters so teams can use their preferred Markdown tools and Markdown flavors while keeping TinaCMS Visual Editing. Fumadocs is planned as the first supported adapter.\n",
           "actions": [
             {
               "label": "GitHub Discussion 🔗",

--- a/content/main/roadmap.json
+++ b/content/main/roadmap.json
@@ -273,8 +273,8 @@
       "items": [
         {
           "icon": "FaRegClock",
-          "heading": "TinaCMS v4.1 - Visual editing for docs frameworks\n",
-          "content": "Most docs frameworks (Fumadocs, Nextra, VitePress and more) have no visual editor, so content is edited by hand in code. We're bringing TinaCMS visual editing to them, starting with Fumadocs.\n",
+          "heading": "TinaCMS v4.1 - MDX plugin adaptors\n",
+          "content": "We are bringing MDX plugin adaptors to TinaCMS. This will allow users to bring their favourite tools with their own flavours of Markdown and still use TinaCMS' visual editing, getting the best of both worlds.\n",
           "actions": [
             {
               "label": "GitHub Discussion 🔗",

--- a/content/main/roadmap.json
+++ b/content/main/roadmap.json
@@ -273,6 +273,20 @@
       "items": [
         {
           "icon": "FaRegClock",
+          "heading": "TinaCMS v4.1 - Docs framework adapters\n",
+          "content": "Most docs frameworks (Fumadocs, Nextra, VitePress and more) have no visual editor, so content is edited by hand in code. We're bringing TinaCMS visual editing to them, starting with Fumadocs.\n",
+          "actions": [
+            {
+              "label": "GitHub Discussion 🔗",
+              "icon": false,
+              "variant": "default",
+              "size": "medium",
+              "url": "https://github.com/tinacms/tinacms/discussions/6973"
+            }
+          ]
+        },
+        {
+          "icon": "FaRegClock",
           "heading": "Improved PR workflow\n",
           "status": "",
           "content": "We are making some improvements to Tina's Editorial Workflow that will allow you to merge Pull Requests from within the CMS UI.\n",

--- a/content/main/roadmap.json
+++ b/content/main/roadmap.json
@@ -273,7 +273,7 @@
       "items": [
         {
           "icon": "FaRegClock",
-          "heading": "TinaCMS v4.1 - Docs framework adapters\n",
+          "heading": "TinaCMS v4.1 - Visual editing for docs frameworks\n",
           "content": "Most docs frameworks (Fumadocs, Nextra, VitePress and more) have no visual editor, so content is edited by hand in code. We're bringing TinaCMS visual editing to them, starting with Fumadocs.\n",
           "actions": [
             {


### PR DESCRIPTION
## Context

Triggered by yesterday's conversation with **Adam, Ivan and Wicksy**: add a public roadmap item for bringing TinaCMS visual editing to other documentation frameworks, starting with Fumadocs.

## Change

Adds one item to the **Coming Soon** section of the public roadmap (`content/main/roadmap.json`):

> **TinaCMS v4.1 - MDX plugin adaptors**
> We are bringing MDX plugin adaptors to TinaCMS. This will allow users to bring their favourite tools with their own flavours of Markdown and still use TinaCMS' visual editing, getting the best of both worlds.

Links to discussion [#6973](https://github.com/tinacms/tinacms/discussions/6973) (Jack's Fumadocs + TinaCMS proposal).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
