### PR TITLE
📝 Credit human co-author over bot for docs last-updated

### DIFF
--- a/components/PageMetadata/authorUtils.test.ts
+++ b/components/PageMetadata/authorUtils.test.ts
@@ -5,7 +5,11 @@ const makeCommit = (authorName: string, message: string): GitHubCommit => ({
   sha: 'abc123',
   commit: {
     author: { name: authorName, email: 'a@example.com', date: '2026-06-01' },
-    committer: { name: 'GitHub', email: 'noreply@github.com', date: '2026-06-01' },
+    committer: {
+      name: 'GitHub',
+      email: 'noreply@github.com',
+      date: '2026-06-01',
+    },
     message,
   },
   author: null,
@@ -48,9 +52,9 @@ describe('parseCoAuthors', () => {
 
 describe('resolveDisplayAuthor', () => {
   it('substitutes the co-author when the author is a bot', () => {
-    expect(resolveDisplayAuthor(makeCommit('tinacloud-app[bot]', BOT_MESSAGE))).toBe(
-      'Eli Kent [SSW]',
-    );
+    expect(
+      resolveDisplayAuthor(makeCommit('tinacloud-app[bot]', BOT_MESSAGE)),
+    ).toBe('Eli Kent [SSW]');
   });
 
   it('handles the dashed bot name variant', () => {
@@ -60,9 +64,9 @@ describe('resolveDisplayAuthor', () => {
   });
 
   it('keeps a human author and ignores any co-author trailer', () => {
-    expect(resolveDisplayAuthor(makeCommit('Eli Kent [SSW]', BOT_MESSAGE))).toBe(
-      'Eli Kent [SSW]',
-    );
+    expect(
+      resolveDisplayAuthor(makeCommit('Eli Kent [SSW]', BOT_MESSAGE)),
+    ).toBe('Eli Kent [SSW]');
   });
 
   it('falls back to the bot name when a bot commit has no co-author', () => {

--- a/components/PageMetadata/authorUtils.test.ts
+++ b/components/PageMetadata/authorUtils.test.ts
@@ -1,0 +1,73 @@
+import { parseCoAuthors, resolveDisplayAuthor } from './authorUtils';
+import type { GitHubCommit } from './type';
+
+const makeCommit = (authorName: string, message: string): GitHubCommit => ({
+  sha: 'abc123',
+  commit: {
+    author: { name: authorName, email: 'a@example.com', date: '2026-06-01' },
+    committer: { name: 'GitHub', email: 'noreply@github.com', date: '2026-06-01' },
+    message,
+  },
+  author: null,
+  committer: null,
+});
+
+const BOT_MESSAGE =
+  '📝 Docs - Add troubleshooting section\n\n' +
+  'Co-authored-by: Eli Kent [SSW] <69125238+kulesy@users.noreply.github.com>';
+
+describe('parseCoAuthors', () => {
+  it('extracts a single co-author trailer', () => {
+    expect(parseCoAuthors(BOT_MESSAGE)).toEqual([
+      {
+        name: 'Eli Kent [SSW]',
+        email: '69125238+kulesy@users.noreply.github.com',
+      },
+    ]);
+  });
+
+  it('extracts multiple co-author trailers', () => {
+    const message =
+      'Some change\n\n' +
+      'Co-authored-by: Alice <alice@example.com>\n' +
+      'Co-authored-by: Bob <bob@example.com>';
+    expect(parseCoAuthors(message)).toEqual([
+      { name: 'Alice', email: 'alice@example.com' },
+      { name: 'Bob', email: 'bob@example.com' },
+    ]);
+  });
+
+  it('returns an empty array when there are no trailers', () => {
+    expect(parseCoAuthors('just a normal commit message')).toEqual([]);
+  });
+
+  it('returns an empty array for an undefined message', () => {
+    expect(parseCoAuthors(undefined)).toEqual([]);
+  });
+});
+
+describe('resolveDisplayAuthor', () => {
+  it('substitutes the co-author when the author is a bot', () => {
+    expect(resolveDisplayAuthor(makeCommit('tinacloud-app[bot]', BOT_MESSAGE))).toBe(
+      'Eli Kent [SSW]',
+    );
+  });
+
+  it('handles the dashed bot name variant', () => {
+    expect(
+      resolveDisplayAuthor(makeCommit('tina-cloud-app[bot]', BOT_MESSAGE)),
+    ).toBe('Eli Kent [SSW]');
+  });
+
+  it('keeps a human author and ignores any co-author trailer', () => {
+    expect(resolveDisplayAuthor(makeCommit('Eli Kent [SSW]', BOT_MESSAGE))).toBe(
+      'Eli Kent [SSW]',
+    );
+  });
+
+  it('falls back to the bot name when a bot commit has no co-author', () => {
+    expect(
+      resolveDisplayAuthor(makeCommit('tinacloud-app[bot]', 'no trailer here')),
+    ).toBe('tinacloud-app[bot]');
+  });
+});

--- a/components/PageMetadata/authorUtils.ts
+++ b/components/PageMetadata/authorUtils.ts
@@ -1,0 +1,44 @@
+import type { GitHubCommit } from './type';
+
+export interface CoAuthor {
+  name: string;
+  email: string;
+}
+
+// Matches `Co-authored-by: Name <email>` trailer lines in a commit message.
+const CO_AUTHOR_RE = /^\s*Co-authored-by:\s*(.+?)\s*<([^>]*)>\s*$/gim;
+
+/** Parse all `Co-authored-by:` trailers out of a commit message body. */
+export function parseCoAuthors(message: string | undefined): CoAuthor[] {
+  if (!message) {
+    return [];
+  }
+
+  const coAuthors: CoAuthor[] = [];
+  // Use exec in a loop (rather than matchAll iteration) to stay compatible
+  // with the project's lower TS compile target under ts-jest.
+  CO_AUTHOR_RE.lastIndex = 0;
+  let match = CO_AUTHOR_RE.exec(message);
+  while (match !== null) {
+    coAuthors.push({ name: match[1], email: match[2] });
+    match = CO_AUTHOR_RE.exec(message);
+  }
+  return coAuthors;
+}
+
+/**
+ * GitHub bot accounts always carry a `[bot]` suffix on their author name
+ * (e.g. `tinacloud-app[bot]`, `tina-cloud-app[bot]`). When one of our bots
+ * authors a commit, the real human is recorded in a `Co-authored-by:` trailer,
+ * so we surface that co-author instead of the bot.
+ */
+export function resolveDisplayAuthor(commit: GitHubCommit): string {
+  const authorName = commit.commit.author.name;
+
+  if (!authorName.endsWith('[bot]')) {
+    return authorName;
+  }
+
+  const [coAuthor] = parseCoAuthors(commit.commit.message);
+  return coAuthor?.name ?? authorName;
+}

--- a/components/PageMetadata/github-metadata.tsx
+++ b/components/PageMetadata/github-metadata.tsx
@@ -4,6 +4,7 @@ import { formatDate } from 'date-fns';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { FaHistory } from 'react-icons/fa';
+import { resolveDisplayAuthor } from './authorUtils';
 import { getRelativeTime } from './timeUtils';
 import type { GitHubMetadataProps, GitHubMetadataResponse } from './type';
 
@@ -94,7 +95,7 @@ export default function GitHubMetadata({
         <span>
           Last updated by{' '}
           <span className="font-bold text-black">
-            {latestCommit.commit.author.name}
+            {resolveDisplayAuthor(latestCommit)}
           </span>
           {` ${lastUpdateInRelativeTime}.`}
         </span>


### PR DESCRIPTION
## TL;DR

The docs "Last updated by" widget read `commit.author.name` directly, so any page whose latest commit was authored by `tinacloud-app[bot]` credited the bot instead of the real editor named in the `Co-authored-by:` trailer. This PR substitutes the co-author when the commit author is a bot.

## Why

TinaCloud editorial-workflow commits are authored by the GitHub App (`tinacloud-app[bot]`), with the human recorded as a co-author. For example, `/docs/tinacloud/troubleshooting` currently shows **"Last updated by tinacloud-app[bot]"** when the actual editor was Eli Kent. The metadata route never parsed co-author trailers, so the human was dropped before reaching the UI.

## How

New `resolveDisplayAuthor` substitutes the first `Co-authored-by:` name when the commit author ends in `[bot]` — matching by suffix rather than a literal string so it covers both `tinacloud-app[bot]` and the older `tina-cloud-app[bot]` seen in history. Human-authored commits are returned unchanged (their co-authors, if any, are ignored). The widget now calls this instead of reading `commit.author.name`.

## Reviewer notes

- **Suffix match, not literal.** Catches both bot name spellings + future bots. Tighten to an exact string if you'd rather be strict.
- **Component, not API.** The commit `message` is already in the response, so no API/response-type change was needed; resolver is pure and unit-tested.

## Tests

`components/PageMetadata/authorUtils.test.ts` — 8 Jest cases: trailer parsing (single/multiple/none/undefined) and author resolution (bot→co-author, dashed-bot variant, human unchanged, bot with no co-author falls back to the bot name).

```
Tests: 8 passed, 8 total
```