### PR TITLE
docs(astro): note dev live content refresh needs Astro 6+

### DIFF
--- a/content/docs/frameworks/astro.mdx
+++ b/content/docs/frameworks/astro.mdx
@@ -96,6 +96,8 @@ http://localhost:4321/admin/index.html
 
 You should see the TinaCMS admin, be able to select a post, save, and watch changes persist to your local content files.
 
+> **Astro 6+ for live content refresh:** when you create a new entry, its page appears in the running dev site without a restart. This needs **Astro 6 or newer**. On Astro 5 a newly created entry can 404 until you restart `pnpm dev`; the integration prints a reminder in your terminal when it detects Astro 5.
+
 ![TinaCMS Admin](/img/hugo-tina-admin-screenshot.png)
 
 ## Enabling Visual Editing


### PR DESCRIPTION
Adds a note to the Astro framework guide's "Running TinaCMS" section: live dev refresh of newly created entries (appearing without a manual restart) requires Astro 6+. On Astro 5 a new entry can 404 until the dev server is restarted, and the integration now prints a terminal reminder.

Documents the limitation behind tinacms/tinacms#7069 (the fix for tinacms/tinacms#5611), which adds both the dev refresh and the in-terminal Astro 5 warning this note refers to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
