### PR TITLE
📝 Docs: deploy the Astro starter to Cloudflare Workers (PBI #7118)

### DIFF
--- a/content/docs/contextual-editing/astro.mdx
+++ b/content/docs/contextual-editing/astro.mdx
@@ -362,6 +362,7 @@ Everything you need ships under `@tinacms/astro`:
 ## See Also
 
 * [Astro Starter Template](https://github.com/tinacms/tina-astro-starter): reference implementation with all of the above wired up
+* [Deploy to Cloudflare Workers](/docs/tinacloud/deployment-options/cloudflare-workers): ship the site and keep this on-demand island route working at request time
 * [The Click-To-Edit API](/docs/contextual-editing/tinafield/): `tinaField()` semantics
 * [Visual Editing Router](/docs/contextual-editing/router/): wiring deep-link admin URLs to your routes
 * [Migrating from React-based Visual Editing](/docs/migrations/astro-react-free-visual-editing/)

--- a/content/docs/frameworks/astro.mdx
+++ b/content/docs/frameworks/astro.mdx
@@ -172,6 +172,7 @@ See [Visual Editing Setup → Astro](/docs/contextual-editing/astro/) for the fu
 ## Next Steps
 
 * [Visual Editing Setup → Astro](/docs/contextual-editing/astro/): the integration, per-island refetch, and custom MDX embeds
+* [Deploy to Cloudflare Workers](/docs/tinacloud/deployment-options/cloudflare-workers): the starter auto-detects the host and keeps visual editing working at request time
 * [Migrating from React-based Visual Editing](/docs/migrations/astro-react-free-visual-editing/): existing sites on the old `client:tina` path
 * [Content modeling](/docs/schema/) · [Data fetching](/docs/features/data-fetching/) · [Deploy your site](/docs/tinacloud)
 

--- a/content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
+++ b/content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
@@ -2,7 +2,7 @@
 title: Deploying to Alibaba Cloud
 last_edited: '2025-07-11T07:03:10.826Z'
 next: content/docs/tinacloud/api-versioning.mdx
-previous: content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
+previous: content/docs/tinacloud/deployment-options/cloudflare-workers.mdx
 ---
 
 ## Alternative Deployment for Chinese Users

--- a/content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
+++ b/content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
@@ -6,7 +6,13 @@ next: content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
 previous: content/docs/tinacloud/deployment-options/github-pages.mdx
 ---
 
-TinaCMS works well with Cloudflare Pages when your site is deployed as a **static export**: content is rendered at build time, while visual editing remains fully live in the browser via Tina's client-side data layer.
+TinaCMS works well with Cloudflare Pages when your site is deployed as a **static export**: content is rendered at build time, while visual editing remains fully live in the browser via Tina's client-side data layer. This page covers a **Next.js** static export.
+
+<WarningCallout
+  body={<>
+    **Using Astro?** Deploy the Astro starter to [Cloudflare Workers](/docs/tinacloud/deployment-options/cloudflare-workers), not Pages. The `@astrojs/cloudflare` adapter no longer supports Cloudflare Pages, and the starter's visual-editing route is server-rendered — a static-only Pages deploy would break click-to-edit at request time.
+  </>}
+/>
 
 ## Why static export works well with Tina
 

--- a/content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
+++ b/content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
@@ -2,7 +2,7 @@
 id: /docs/tinacloud/deployment-options/cloudflare-pages
 title: Deploying to Cloudflare Pages
 last_edited: '2026-05-15T07:24:35.115Z'
-next: content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
+next: content/docs/tinacloud/deployment-options/cloudflare-workers.mdx
 previous: content/docs/tinacloud/deployment-options/github-pages.mdx
 ---
 

--- a/content/docs/tinacloud/deployment-options/cloudflare-workers.mdx
+++ b/content/docs/tinacloud/deployment-options/cloudflare-workers.mdx
@@ -1,59 +1,94 @@
 ---
 title: Cloudflare Workers
-last_edited: '2026-06-10T00:46:42.475Z'
+last_edited: '2026-07-09T00:00:00.000Z'
 next: ''
 previous: ''
 ---
 
-TinaCMS works with Cloudflare Workers when using git-connected builds. Every push to your production branch builds the site, including the `tinacms build` step, and deploys it to the Workers runtime.
+TinaCMS works with Cloudflare Workers using git-connected builds. Every push to your production branch runs the build (including the `tinacms build` step) and deploys the result to the Workers runtime.
 
-If your site is a fully static export, [Cloudflare Pages](/docs/tinacloud/deployment-options/cloudflare-pages) is the simpler option. Use Workers when your framework needs a server runtime (SSR routes, API endpoints, redirects,  etc.).
-
-## Add the Cloudflare Adapter
-
-Your starter needs to build for the Workers runtime
-
-**Astro:**
-
-```
-npx astro add cloudflare
-```
-
-Then make sure a `wrangler.jsonc` exists at the repo root and points at the build
-
-**Next.js**
-
-Use the [OpenNext Cloudflare adapter](https://opennext.js.org/cloudflare) and follow its setup to generate the `open-next.config.ts` and `wrangler.jsonc`.
-
-## Create the Worker
-
-In the Cloudflare dashboard, go to **Workers & pages** | **Create** | **Workers** | **Import** **a repository**, connect your GitHub account and select your repo.
-
-### Build Configuration
-
-Build command: `pnpm run build` (Astro) or `npx opennextjs-cloudflare build` (Next.js)
-
-Deploy command: `npx wrangler deploy` (Astro) or `npx opennextjs-cloudflare deploy` (Next.js)
-
-### Environment Variables
-
-`tinacms build` requires your TinaCloud credentials at build time. Add the following in your Workers, **Settings **| **Build** | **Variables and Secrets**:
-
-* `PUBLIC_TINA_CLIENT_ID` (Astro) OR `NEXT_PUBLIC_TINA_CLIENT_ID` (Next.js) - Your TinaCloud client ID
-* `TINA_TOKEN` - The content token from TinaCloud | Tokens
+Workers is the right target whenever your site needs a server at request time: SSR routes, API endpoints, redirects, and — for the Astro starter — the on-demand route that powers click-to-edit visual editing.
 
 <WarningCallout
   body={<>
-    Workers keep build variables and runtime variables separate. If your site reads any of the mentioned variables during runtime, add them again under **Settings** | **Variables and Secrets**
+    **Astro users:** deploy to Workers, not [Cloudflare Pages](/docs/tinacloud/deployment-options/cloudflare-pages). The `@astrojs/cloudflare` adapter [no longer supports Cloudflare Pages](https://docs.astro.build/en/guides/integrations-guide/cloudflare/) — it targets Workers. The starter's visual-editing route (`src/pages/tina-island/[name].ts`) is server-rendered (`prerender = false`), so a static-only Pages upload would break click-to-edit at request time.
   </>}
 />
 
-## Finalising TinaCloud Setup
+## Astro (the `tina-astro-starter`)
 
-Once you have your first deployment, Cloudflare will give you a default domain URL like `https://<site-name>.<account-name>.workers.dev`, make sure to set this as a Site URL inside your TinaCloud project's configuration!
+This walks the [Astro starter](https://github.com/tinacms/tina-astro-starter) from a clean checkout to a live Workers deploy. Push your project to a GitHub repository first.
+
+### 1. Adapter and `wrangler.jsonc` (already in the starter)
+
+Nothing to configure — the starter ships this for you:
+
+* `astro.config.mjs` **auto-detects the host**. In Cloudflare's git-based Workers Builds, the `WORKERS_CI` environment variable is set automatically, which selects the `@astrojs/cloudflare` adapter. You don't run `npx astro add cloudflare`, and you don't edit the config.
+* A root **`wrangler.jsonc`** enables `nodejs_compat`. The visual-editing route uses `node:async_hooks` (`AsyncLocalStorage`); without this flag the island route fails at runtime:
+
+```jsonc
+{
+  "name": "tina-astro-starter",
+  "compatibility_date": "2026-06-01",
+  "compatibility_flags": ["nodejs_compat"]
+}
+```
+
+That minimal config is all Wrangler needs — the adapter wires up the Worker entrypoint and the static-assets binding at build time.
+
+> **Adding TinaCMS to an existing Astro site?** Run `npx astro add cloudflare`, then create a `wrangler.jsonc` at the repo root with `compatibility_flags: ["nodejs_compat"]` and a recent `compatibility_date`.
+
+### 2. Create the Worker
+
+In the Cloudflare dashboard go to **Workers & Pages** | **Create** | **Workers** | **Import a repository**, connect your GitHub account, and select your repo.
+
+Set the build under **Build configuration**:
+
+* **Build command:** `pnpm build` — the starter's `build` script runs `tinacms build` and then `astro build`.
+* **Deploy command:** `npx wrangler deploy`
+* **Build output:** `dist` (Astro's default; you don't need to change this).
+
+`DEPLOY_ADAPTER` is **not** needed here — `WORKERS_CI` is detected automatically. You only set `DEPLOY_ADAPTER=cloudflare` for a manual deploy where no host env var applies (e.g. running `npx wrangler deploy` from your own machine).
+
+### 3. Environment variables
+
+`tinacms build` needs your TinaCloud credentials at build time. Add these under the Worker's **Settings** | **Build** | **Variables and Secrets** (grab both credentials from your [TinaCloud project](https://app.tina.io)):
+
+* `PUBLIC_TINA_CLIENT_ID` — your TinaCloud client ID. **Astro uses the `PUBLIC_` prefix**, not Next.js's `NEXT_PUBLIC_`.
+* `TINA_TOKEN` — a content token from TinaCloud.
+* `SITE_URL` — your production URL (e.g. `https://your-worker.your-account.workers.dev`, or your custom domain). Cloudflare Workers injects no deploy-URL variable, so without `SITE_URL` your sitemap, RSS, and OpenGraph tags fall back to `localhost`.
+
+<WarningCallout
+  body={<>
+    Workers keep **build** variables and **runtime** variables separate. The island route reads TinaCloud config at request time, so add the same variables again under **Settings** | **Variables and Secrets** (not just the build section).
+  </>}
+/>
+
+### 4. Verify visual editing works at request time
+
+After the first deploy:
+
+1. Open `/admin` on your Worker's URL, edit a post, and save. The save commits to GitHub, which triggers a rebuild and redeploy.
+2. Open a content page and confirm **click-to-edit** works: clicking an editable region highlights it and opens its form in the sidebar. This exercises the on-demand `/tina-island/*` route running inside the Worker — if it errors, check that `nodejs_compat` is set and that your runtime variables are present.
+
+## Next.js
+
+Use the [OpenNext Cloudflare adapter](https://opennext.js.org/cloudflare) and follow its setup to generate `open-next.config.ts` and `wrangler.jsonc`.
+
+In the dashboard (**Workers & Pages** | **Create** | **Workers** | **Import a repository**), set:
+
+* **Build command:** `npx opennextjs-cloudflare build`
+* **Deploy command:** `npx opennextjs-cloudflare deploy`
+
+Add your build-time credentials under **Settings** | **Build** | **Variables and Secrets**:
+
+* `NEXT_PUBLIC_TINA_CLIENT_ID` — your TinaCloud client ID.
+* `TINA_TOKEN` — a content token from TinaCloud.
+
+## Finalising TinaCloud setup
+
+Your first deployment gives you a default domain like `https://<worker-name>.<account-name>.workers.dev`. Set this (or your custom domain) as the **Site URL** in your TinaCloud project's configuration so the editor loads against the right origin.
 
 ## Troubleshooting
 
-1. “JavaScript heap out of memory” during the build
-
-The TinaCloud indexing step can exceed Node's default 2GB heap. Raise the limit by prefixing your build command or setting a build time environment variable `NODE_OPTIONS = —max-old-space-size=4096`
+**"JavaScript heap out of memory" during the build.** The TinaCloud indexing step can exceed Node's default heap. Raise it with a build-time environment variable: `NODE_OPTIONS = --max-old-space-size=4096`.

--- a/content/docs/tinacloud/deployment-options/cloudflare-workers.mdx
+++ b/content/docs/tinacloud/deployment-options/cloudflare-workers.mdx
@@ -1,8 +1,9 @@
 ---
-title: Cloudflare Workers
+id: /docs/tinacloud/deployment-options/cloudflare-workers
+title: Deploying to Cloudflare Workers
 last_edited: '2026-07-09T00:00:00.000Z'
-next: ''
-previous: ''
+next: content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
+previous: content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
 ---
 
 TinaCMS works with Cloudflare Workers using git-connected builds. Every push to your production branch runs the build (including the `tinacms build` step) and deploys the result to the Workers runtime.
@@ -44,7 +45,7 @@ In the Cloudflare dashboard go to **Workers & Pages** | **Create** | **Workers**
 
 Set the build under **Build configuration**:
 
-* **Build command:** `pnpm build` — the starter's `build` script runs `tinacms build` and then `astro build`.
+* **Build command:** `pnpm build` — the starter's `build` script is `tinacms build --content=local -c "astro build"`, which indexes your committed content, then runs `astro build`.
 * **Deploy command:** `npx wrangler deploy`
 * **Build output:** `dist` (Astro's default; you don't need to change this).
 
@@ -60,7 +61,7 @@ Set the build under **Build configuration**:
 
 <WarningCallout
   body={<>
-    Workers keep **build** variables and **runtime** variables separate. The island route reads TinaCloud config at request time, so add the same variables again under **Settings** | **Variables and Secrets** (not just the build section).
+    Workers keep **build** variables and **runtime** variables separate. The island route reads your TinaCloud client ID and token at request time, so add `PUBLIC_TINA_CLIENT_ID` and `TINA_TOKEN` again under **Settings** | **Variables and Secrets** (not just the build section). `SITE_URL` is only used at build time.
   </>}
 />
 
@@ -85,10 +86,12 @@ Add your build-time credentials under **Settings** | **Build** | **Variables and
 * `NEXT_PUBLIC_TINA_CLIENT_ID` — your TinaCloud client ID.
 * `TINA_TOKEN` — a content token from TinaCloud.
 
+As with Astro, Workers keep build and runtime variables separate — if your OpenNext SSR reads these at request time, add them again under **Settings** | **Variables and Secrets**.
+
 ## Finalising TinaCloud setup
 
 Your first deployment gives you a default domain like `https://<worker-name>.<account-name>.workers.dev`. Set this (or your custom domain) as the **Site URL** in your TinaCloud project's configuration so the editor loads against the right origin.
 
 ## Troubleshooting
 
-**"JavaScript heap out of memory" during the build.** The TinaCloud indexing step can exceed Node's default heap. Raise it with a build-time environment variable: `NODE_OPTIONS = --max-old-space-size=4096`.
+**"JavaScript heap out of memory" during the build.** The TinaCloud indexing step can exceed Node's default heap. Raise it with a build-time environment variable `NODE_OPTIONS` set to `--max-old-space-size=4096`.


### PR DESCRIPTION
## What

Documents deploying the TinaCMS Astro starter to Cloudflare, and fixes a wrong assumption baked into PBI [#7118](https://github.com/tinacms/tinacms/issues/7118).

The PBI asked for a **Cloudflare Pages (static export)** guide for the Astro starter. That path doesn't work with the current starter:

- `@astrojs/cloudflare` (v13, what the starter uses) [no longer supports Cloudflare Pages](https://docs.astro.build/en/guides/integrations-guide/cloudflare/) — it targets Workers. A local build confirms the output is a Worker (`dist/server/entry.mjs` + generated `wrangler.json` with an `ASSETS` binding), not the classic Pages `_worker.js`/`functions/` layout.
- The starter isn't a pure static export anyway: the visual-editing route (`src/pages/tina-island/[name].ts`) is `prerender = false`. A static-only Pages upload would serve the pages but break click-to-edit at request time.

So this documents the **Cloudflare Workers** path, which is supported and keeps visual editing working.

## Changes

- **`cloudflare-workers.mdx`** — rewritten with a `tina-astro-starter` walkthrough: host auto-detection (`WORKERS_CI` → `@astrojs/cloudflare`, no `astro add`), the shipped `wrangler.jsonc` + `nodejs_compat` (the island route needs `node:async_hooks`), build/deploy commands, env vars (`SITE_URL`, `PUBLIC_TINA_CLIENT_ID`, `TINA_TOKEN`) in build **and** runtime, and a request-time visual-editing verification step. Next.js/OpenNext content retained.
- **`cloudflare-pages.mdx`** — added a note steering Astro users to Workers.
- **`frameworks/astro.mdx`** — linked the Workers deploy doc from Next Steps.

## Verification

- Built the starter locally with the Cloudflare adapter (`DEPLOY_ADAPTER=cloudflare pnpm build:local`): succeeds, emits the Worker + `dist/client` static assets, island route bundled into the server entry.
- **Not yet verified against a live Cloudflare deploy** (needs a Cloudflare + TinaCloud account). The `/admin` → edit → save → rebuild roundtrip and the live click-to-edit island route should be confirmed on a real deploy before this is considered fully done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)