### PR TITLE
📝 Update docs and examples to reference tina-react-starter

### DIFF
--- a/content/docs-zh/guides/nextjs-data-fetching.mdx
+++ b/content/docs-zh/guides/nextjs-data-fetching.mdx
@@ -51,7 +51,7 @@ export const getStaticPaths = async () => {
 
 在Next.js中，可以指定[`fallback: "blocking"`](https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#fallback-blocking)，这允许`getStaticProps`在请求时在服务器端运行，当用户访问`getStaticPaths`中未指定的页面时。这允许文档创建与Tina一起工作，以及高级的NextJS功能如ISR。
 
-有关Tina + NextJS的完整工作示例，请查看我们的["Barebones Starter"](https://github.com/tinacms/tina-barebones-starter)。
+有关Tina + NextJS的完整工作示例，请查看我们的["React Starter"](https://github.com/tinacms/tina-react-starter)。
 
 ### 为SSR页面获取内容
 

--- a/content/docs/guides/nextjs-data-fetching.mdx
+++ b/content/docs/guides/nextjs-data-fetching.mdx
@@ -51,7 +51,7 @@ export const getStaticPaths = async () => {
 
 In Next.js one can specify [`fallback: "blocking"`](https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#fallback-blocking), this allows `getStaticProps` to run server-side at request time when a user goes to a page that was not specified in `getStaticPaths`. This allows document-creation to work with Tina, as well as advanced NextJS features like ISR.
 
-For a full working example of Tina + NextJS, [check out our "Barebones Starter"](https://github.com/tinacms/tina-barebones-starter).
+For a full working example of Tina + NextJS, [check out our "React Starter"](https://github.com/tinacms/tina-react-starter).
 
 ### Fetching content for SSR pages
 

--- a/content/examples/index.json
+++ b/content/examples/index.json
@@ -7,10 +7,10 @@
       "link": "https://github.com/tinacms/tina-cloud-starter"
     },
     {
-      "label": "Barebones Starter",
+      "label": "React Starter",
       "description": "A simple TinaCMS starter that uses Next.js with no styling, and minimal content.\n",
       "image": "/img/tina_qoie8s.png",
-      "link": "https://github.com/tinacms/tina-barebones-starter"
+      "link": "https://github.com/tinacms/tina-react-starter"
     },
     {
       "label": "Tina Self Hosted Demo",


### PR DESCRIPTION
## TL;DR

Part of the `tina-barebones-starter` → `tina-react-starter` rename (tinacms/tinacms#7185). Updates the Examples page card and the Next.js data-fetching guide (English + Chinese) to the new name and URL.

## Reviewer notes

- **Historical blog posts left untouched.** Dated posts under `content/blog/**` and `content/blog-zh/**` keep the old name as record; the GitHub redirect keeps their links alive.
- **`-preview-mode` links untouched.** The `contextual-drafts` guide links to the separate `tina-barebones-starter-preview-mode` repo, which is out of scope.

## Note

Merge after the GitHub repo rename lands (GitHub keeps a redirect from the old slug afterward).

## Links

- Tracking PBI: tinacms/tinacms#7185
