### PR TITLE
docs: document media in the editorial workflow

### DIFF
--- a/content/docs/reference/media/repo-based.mdx
+++ b/content/docs/reference/media/repo-based.mdx
@@ -140,7 +140,7 @@ See [Media in the Editorial Workflow](/docs/tinacloud/editorial-workflow/#media-
 ### Caveats
 
 * The media workflow only triggers when the branch you are currently editing is itself protected. On a non-protected working branch, uploads and deletes are saved directly to that branch.
-* Each media upload or delete creates its own working branch and pull request.
+* Each media upload or delete on a protected branch creates its own working branch and pull request. All subsequent media operations on that branch will be appended to the created pull request"
 * Images cannot be altered in place. Once uploaded, subsequent changes to an asset are not reflected, so upload a new file instead.
 
 If you are configuring Tina on a non-default branch (and the Tina config has not yet been merged to your default branch), the automatic media sync on project creation may not be able to locate your media configuration. In this case, the **Media** tab in your TinaCloud project dashboard will show that media has not yet been synced. Once your Tina config has been merged to the default branch, you can trigger a sync manually from that tab.

--- a/content/docs/reference/media/repo-based.mdx
+++ b/content/docs/reference/media/repo-based.mdx
@@ -127,11 +127,21 @@ When uploading files to TinaCloud, the maximum allowed file size is 100 MiB.
 
 ## How does this work with Branching?
 
-Repo-based media is designed to be used around a single-branch workflow. If your project is using [multiple branches](/docs/tinacloud/branching/) or [Editorial Workflow](/docs/drafts/editorial-workflow/), there are some known caveats to be aware of.
+By default, repo-based media is scoped to a single media branch (your repository's default branch), and every editing branch reads and writes its assets there.
 
-* Images cannot be altered. Once uploaded, any subsequent changes to an asset will not be reflected.
-* If you only have a single branch with media enabled, the media store will source/upload images to/from that branch.
-* If you have multiple branches with media enabled, then all media will be sourced/uploaded to/from the repository's default branch.
+When your project has [Editorial Workflow](/docs/tinacloud/editorial-workflow/) enabled, media becomes **branch-aware** and goes through the same review process as your content:
+
+* Each branch has its own view of your media, so uploads and deletes on one branch do not affect other branches until they are merged.
+* When you upload or delete media while editing a **protected** branch, TinaCMS does not write straight to it. Instead it prompts you to create a working branch, saves the asset to that branch, and opens a pull request, just like saving content. You are switched onto the new branch and can keep working, and the change reaches the protected branch only once the pull request is merged.
+* You can choose **Save to protected branch** in the prompt to bypass the workflow and write directly.
+
+See [Media in the Editorial Workflow](/docs/tinacloud/editorial-workflow/#media-in-the-editorial-workflow) for the full flow.
+
+### Caveats
+
+* The media workflow only triggers when the branch you are currently editing is itself protected. On a non-protected working branch, uploads and deletes are saved directly to that branch.
+* Each media upload or delete creates its own working branch and pull request.
+* Images cannot be altered in place. Once uploaded, subsequent changes to an asset are not reflected, so upload a new file instead.
 
 If you are configuring Tina on a non-default branch (and the Tina config has not yet been merged to your default branch), the automatic media sync on project creation may not be able to locate your media configuration. In this case, the **Media** tab in your TinaCloud project dashboard will show that media has not yet been synced. Once your Tina config has been merged to the default branch, you can trigger a sync manually from that tab.
 

--- a/content/docs/reference/media/repo-based.mdx
+++ b/content/docs/reference/media/repo-based.mdx
@@ -2,7 +2,7 @@
 cmsUsageWarning: 'https://github.com/tinacms/tinacms/blob/main/packages/@tinacms/schema-tools/src/types/index.ts'
 title: Repo-based Media
 alias: repo-based-media
-last_edited: '2025-09-18T23:25:44.757Z'
+last_edited: '2026-07-12T23:58:57.199Z'
 next: ''
 previous: ''
 ---
@@ -125,7 +125,7 @@ Learn more about [Next.js remote patterns](https://nextjs.org/docs/app/api-refer
 
 When uploading files to TinaCloud, the maximum allowed file size is 100 MiB.
 
-## How does this work with Branching?
+## How does this work with Editorial Workflow?
 
 By default, repo-based media is scoped to a single media branch (your repository's default branch), and every editing branch reads and writes its assets there.
 

--- a/content/docs/tinacloud/editorial-workflow.mdx
+++ b/content/docs/tinacloud/editorial-workflow.mdx
@@ -43,6 +43,23 @@ Once you enter the new branch name, the following actions will occur:
 
 When you are ready to publish your content, merge the draft pull request into the protected branch (e.g., main) through GitHub. After the pull request is successfully merged, the updated content will be available on the protected branch.
 
+## Media in the Editorial Workflow
+
+Media follows the same review process as your content. When you upload or delete an image while editing a protected branch, TinaCMS routes the change through a branch and pull request instead of writing to the protected branch directly.
+
+When you upload or delete media on a protected branch, a prompt appears to create a new branch. Once you confirm:
+
+* A new branch is created for the media change.
+* The asset is saved to that branch, not to the protected branch.
+* A pull request is created.
+* You are switched onto the new branch so you can keep editing.
+
+To publish the media change, merge its pull request into the protected branch, the same as you would for content.
+
+> Prefer to skip the workflow for a one-off change? Choose **Save to protected branch** in the prompt to write the media directly to the protected branch.
+
+For how media storage and branching fit together, see [Repo-based Media](/docs/reference/media/repo-based/#how-does-this-work-with-branching).
+
 ## GitHub Pull Request links
 
 In the branch list modal, you can click on the dropdown and click "View Pull Request" to view the pull request on GitHub. This will open a new tab in your browser. This link will only aprear of the pull request has been created with TinaCMS and not if it was created manually.


### PR DESCRIPTION
Closes #4698

**TL;DR** Document branch-aware media / media in the Editorial Workflow (now GA): uploads and deletes on a protected branch route through a branch and pull request like content, instead of writing straight to the protected branch.

**Pain:** The docs still described the old single-branch media model. The Repo-based Media page said all media is sourced and uploaded to and from the repository's default branch, and the Editorial Workflow page had no mention of media at all, so the shipped behavior was undocumented (and the media page linked to a stale `/docs/drafts/editorial-workflow/`).

**Solution:** Rewrote the Repo-based Media "How does this work with Branching?" section for branch-aware media plus the media workflow, added a Caveats list, and fixed the stale link to `/docs/tinacloud/editorial-workflow/`. Added a "Media in the Editorial Workflow" section to the Editorial Workflow page (create-branch prompt, save-to-branch, PR, auto-switch, and the Save-to-protected-branch escape hatch), cross-linked both ways.
