### PR TITLE
docs: note tinacms 3.9.4+ requirement for global collections

### DIFF
--- a/content/docs/reference/collections.mdx
+++ b/content/docs/reference/collections.mdx
@@ -286,6 +286,8 @@ To set the default for a [rich-text field](/docs/reference/types/rich-text/), yo
 
 ## Global Collections
 
+> Global collections require tinacms: 3.9.4 or later. On older versions the collection still works, but it appears in the regular collections list instead of under **Site**.
+
 Set `ui.global: true` to make a collection **global**. A global collection holds a single, site-wide settings document — things like header and footer content, navigation, theme options, or SEO defaults — rather than a list of many documents.
 
 In the editor, a global collection is presented differently from a regular collection:


### PR DESCRIPTION
No linked issue in this repo; motivated by tinacms/tinacms#7114 and a Discord report of the same confusion.

**TL;DR** Add a one-line version callout to the Global Collections docs: the Site-heading sidebar behaviour requires tinacms 3.9.4 or later.

**Pain:** Two support threads hit the same silent failure: the user followed the docs, but their resolved `tinacms` package predated 3.9.4, so the global collection quietly stayed under **Collections** with no error surface and the docs appeared wrong.

**Solution:** A blockquote under the **Global Collections** heading, matching the version-note style used in contextual-drafts.mdx: states the 3.9.4 requirement and what older versions show instead, so users can self-diagnose.

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

🤖 Generated with [Claude Code](https://claude.com/claude-code)