### PR TITLE
Fix missing video and shorten the URL on the vibe-blogging blog post

### DIFF
--- a/content/blog-zh/astro-is-becoming-the-default-tinacms-starter.mdx
+++ b/content/blog-zh/astro-is-becoming-the-default-tinacms-starter.mdx
@@ -8,7 +8,7 @@ title: Astro成为TinaCMS的默认入门模板
 date: '2026-05-28T00:00:00.000Z'
 last_edited: '2026-05-28T00:00:00.000Z'
 author: Matt Wicks
-prev: content/blog-zh/customblog_tinacmsai.mdx
+prev: content/blog-zh/vibe-blogging-with-tinacms.mdx
 next: content/blog-zh/tinacloud-separate-content-repos.mdx
 ---
 

--- a/content/blog-zh/astro-is-the-default-tinacms-starter.mdx
+++ b/content/blog-zh/astro-is-the-default-tinacms-starter.mdx
@@ -8,7 +8,7 @@ title: Astro成为TinaCMS的默认入门模板
 date: '2026-05-28T00:00:00.000Z'
 last_edited: '2026-05-28T00:00:00.000Z'
 author: Matt Wicks
-prev: content/blog-zh/customblog_tinacmsai.mdx
+prev: content/blog-zh/vibe-blogging-with-tinacms.mdx
 next: ''
 ---
 

--- a/content/blog-zh/vibe-blogging-with-tinacms.mdx
+++ b/content/blog-zh/vibe-blogging-with-tinacms.mdx
@@ -13,7 +13,7 @@ next: content/blog-zh/astro-is-becoming-the-default-tinacms-starter.mdx
 
 以下是该工作流程在实践中的样子。
 
-<Youtube embedSrc="https://www.youtube.com/watch?v=buaXi8Hh420&t=103s" caption="与Hark Singh一起进行Vibe博客创作" minutes="9分钟" />
+<Youtube embedSrc="https://www.youtube.com/embed/buaXi8Hh420" caption="与Hark Singh一起进行Vibe博客创作" minutes="9" />
 
 ## 从TinaCMS最佳实践开始
 

--- a/content/blog/astro-is-becoming-the-default-tinacms-starter.mdx
+++ b/content/blog/astro-is-becoming-the-default-tinacms-starter.mdx
@@ -8,7 +8,7 @@ title: Astro is becoming the default starter for TinaCMS
 date: '2026-05-28T00:00:00.000Z'
 last_edited: '2026-05-28T00:00:00.000Z'
 author: Matt Wicks
-prev: content/blog/customblog_tinacmsai.mdx
+prev: content/blog/vibe-blogging-with-tinacms.mdx
 next: content/blog/tinacloud-separate-content-repos.mdx
 ---
 

--- a/content/blog/vibe-blogging-with-tinacms.mdx
+++ b/content/blog/vibe-blogging-with-tinacms.mdx
@@ -14,7 +14,7 @@ Instead of relying on platforms like WordPress or Medium, this approach keeps ev
 
 Here is what that workflow looks like in practice.
 
-<Youtube embedSrc="https://www.youtube.com/watch?v=buaXi8Hh420&t=103s" caption="Vibe Blogging with Hark Singh" minutes="9 minutes" />
+<Youtube embedSrc="https://www.youtube.com/embed/buaXi8Hh420" caption="Vibe Blogging with Hark Singh" minutes="9" />
 
 ## Starting with TinaCMS Best Practices
 

--- a/content/settings/config.json
+++ b/content/settings/config.json
@@ -747,6 +747,16 @@
       "source": "/blog/astro-is-the-default-tinacms-starter",
       "destination": "/blog/astro-is-becoming-the-default-tinacms-starter",
       "permanent": true
+    },
+    {
+      "source": "/blog/customblog_tinacmsai",
+      "destination": "/blog/vibe-blogging-with-tinacms",
+      "permanent": true
+    },
+    {
+      "source": "/zh/blog/customblog_tinacmsai",
+      "destination": "/zh/blog/vibe-blogging-with-tinacms",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
Fixes the video on the vibe-blogging post. It used a `watch?v=` URL, which YouTube won't embed in an iframe, so nothing rendered. Switched to the `embed/` form every other post uses.

Also renamed the slug `customblog_tinacmsai` → `vibe-blogging-with-tinacms`, with 301 redirects for the old English and Chinese URLs so existing links don't 404.

### Review order

- `content/blog/vibe-blogging-with-tinacms.mdx` (renamed from `customblog_tinacmsai.mdx`) - the video fix and the rename. The `content/blog-zh/` post is the same change in Chinese.
- `content/settings/config.json` - the two 301 redirects for the old EN + ZH URLs.
- The three adjacent Astro posts - `prev` pointer updates to the new path.
