### PR TITLE
📝 Lead with Astro as the default starter in the docs

### DIFF
--- a/content/docs/frameworks/astro.mdx
+++ b/content/docs/frameworks/astro.mdx
@@ -1,19 +1,21 @@
 ---
 id: /docs/frameworks/astro
 title: Astro + TinaCMS Setup Guide
-last_edited: '2026-06-12T00:00:00.000Z'
-next: content/docs/frameworks/hugo.mdx
-previous: content/docs/frameworks/next/pages-router.mdx
+last_edited: '2026-07-28T00:00:00.000Z'
+next: content/docs/frameworks/next/app-router.mdx
+previous: content/docs/introduction/using-starter.mdx
 ---
 
 \
 TinaCMS runs side-by-side with Astro, with **first-class visual editing that needs no React in your page tree**. It ships as `@tinacms/astro`, a vanilla-Astro rich-text renderer plus a one-line integration.
 
+> **Astro is our default starter.** It is the starter we recommend for new projects and the one we build and test against first. The [other starters](/docs/introduction/using-starter/) are still available and still supported.
+
 ## Getting Started
 
 There are 2 ways to set up TinaCMS with Astro.
 
-* **Option 1: Scaffold from the starter template** (best for new projects).
+* **Option 1: Scaffold from the starter template** (best for new projects, and the default starter).
 * **Option 2: Add TinaCMS to an existing Astro site** with `tinacms init`.
 
 > Examples use **pnpm**. On npm or yarn, swap the commands: `pnpm dev` becomes `npm run dev` or `yarn dev`; `pnpm add x` becomes `npm install x` or `yarn add x`.

--- a/content/docs/frameworks/gatsby.mdx
+++ b/content/docs/frameworks/gatsby.mdx
@@ -103,6 +103,6 @@ Read more about [data fetching](/docs/features/data-fetching/) and [visual editi
 
 ## See Also
 
-* [Next.js setup guide](/docs/frameworks/next/app-router/) - Using Tina with Next.js (recommended)
-* [Astro setup guide](/docs/frameworks/astro/) - Using Tina with Astro
+* [Astro setup guide](/docs/frameworks/astro/) - Using Tina with Astro (our default starter)
+* [Next.js setup guide](/docs/frameworks/next/app-router/) - Using Tina with Next.js
 * [Visual Editing setup](/docs/contextual-editing/overview/) - Enable live preview editing

--- a/content/docs/frameworks/hugo.mdx
+++ b/content/docs/frameworks/hugo.mdx
@@ -3,7 +3,7 @@ id: /docs/frameworks/hugo
 title: Hugo + TinaCMS Setup Guide
 last_edited: '2025-10-21T09:36:06.358Z'
 next: content/docs/frameworks/gatsby.mdx
-previous: content/docs/frameworks/astro.mdx
+previous: content/docs/frameworks/next/pages-router.mdx
 ---
 
 ## Introduction

--- a/content/docs/frameworks/next/app-router.mdx
+++ b/content/docs/frameworks/next/app-router.mdx
@@ -6,7 +6,7 @@ seo:
 title: Next.js App Router
 last_edited: '2025-10-21T09:40:34.169Z'
 next: content/docs/frameworks/next/pages-router.mdx
-previous: content/docs/introduction/using-starter.mdx
+previous: content/docs/frameworks/astro.mdx
 ---
 
 > 👆This guide assumes you are using the **[Next.js app router.](https://nextjs.org/docs/app)**

--- a/content/docs/frameworks/next/pages-router.mdx
+++ b/content/docs/frameworks/next/pages-router.mdx
@@ -5,7 +5,7 @@ seo:
     practices, and how to enable a smooth editing experience.
 title: Next.js Pages Router
 last_edited: '2025-10-21T09:40:45.384Z'
-next: content/docs/frameworks/astro.mdx
+next: content/docs/frameworks/hugo.mdx
 previous: content/docs/frameworks/next/app-router.mdx
 ---
 

--- a/content/docs/integration/frameworks.mdx
+++ b/content/docs/integration/frameworks.mdx
@@ -14,7 +14,9 @@ Tina's default "basic editor" works in a wide variety of frameworks. It reads/wr
 
 ![basic editor](/img/docs/basic-editor.png)
 
-> Tina also allows support for ["Visual Editing"](/docs/contextual-editing/overview/) so that editors can see their pages being updated in real-time as they make changes. Visual editing is currently limited to React-based frameworks (NextJS, React, etc).
+> **Astro is our default starter.** If you are starting a new site and have no framework preference, [start there](/docs/frameworks/astro/). Every framework below is still supported.
+
+> Tina also allows support for ["Visual Editing"](/docs/contextual-editing/overview/) so that editors can see their pages being updated in real-time as they make changes. Visual editing is available in React-based frameworks (NextJS, React, etc), and in [Astro](/docs/contextual-editing/astro/) without any React in your page tree.
 
 ## Configuring Tina with each framework
 
@@ -22,8 +24,8 @@ When configuring Tina, you will be prompted to provide a `publicFolder` in your 
 
 | **Framework**                | **Public assets directory** |
 | ---------------------------- | --------------------------- |
-| NextJS                       | public                      |
 | Astro                        | public                      |
+| NextJS                       | public                      |
 | Create React App             | public                      |
 | Hugo                         | static                      |
 | Jekyll                       | ./                          |

--- a/content/docs/integration/frameworks.mdx
+++ b/content/docs/integration/frameworks.mdx
@@ -16,7 +16,7 @@ Tina's default "basic editor" works in a wide variety of frameworks. It reads/wr
 
 > **Astro is our default starter.** If you are starting a new site and have no framework preference, [start there](/docs/frameworks/astro/). Every framework below is still supported.
 
-> Tina also allows support for ["Visual Editing"](/docs/contextual-editing/overview/) so that editors can see their pages being updated in real-time as they make changes. Visual editing is available in React-based frameworks (NextJS, React, etc), and in [Astro](/docs/contextual-editing/astro/) without any React in your page tree.
+> Tina also supports ["Visual Editing"](/docs/contextual-editing/overview/) so that editors can see their pages being updated in real-time as they make changes. Visual editing is available in React-based frameworks (NextJS, React, etc), and in [Astro](/docs/contextual-editing/astro/) without any React in your page tree.
 
 ## Configuring Tina with each framework
 

--- a/content/docs/introduction/tina-init.mdx
+++ b/content/docs/introduction/tina-init.mdx
@@ -6,7 +6,7 @@ id: /docs/introduction/tina-init/
 last_edited: '2022-02-04T15:51:56.737Z'
 ---
 
-> Note: This doc assumes that you have a working site. If not, you can quickly get started with our default [Astro starter](/docs/introduction/using-starter/), or one of the other starters in the CLI.
+> Note: This doc assumes that you have a working site. If not, you can quickly get started with our default [Astro starter](/docs/frameworks/astro/), or one of the [other starters](/docs/introduction/using-starter/) in the CLI.
 
 ## Adding Tina
 

--- a/content/docs/introduction/tina-init.mdx
+++ b/content/docs/introduction/tina-init.mdx
@@ -6,7 +6,7 @@ id: /docs/introduction/tina-init/
 last_edited: '2022-02-04T15:51:56.737Z'
 ---
 
-> Note: This doc assumes that you have a working site. If not, you can quickly get started using one of our [NextJS starters](/docs/introduction/using-starter/).
+> Note: This doc assumes that you have a working site. If not, you can quickly get started with our default [Astro starter](/docs/introduction/using-starter/), or one of the other starters in the CLI.
 
 ## Adding Tina
 

--- a/content/docs/introduction/using-starter.mdx
+++ b/content/docs/introduction/using-starter.mdx
@@ -1,8 +1,8 @@
 ---
 id: /docs/introduction/using-starter/
 title: Tina Starter - CLI
-last_edited: '2025-12-07T21:20:13.520Z'
-next: content/docs/frameworks/next/app-router.mdx
+last_edited: '2026-07-28T00:00:00.000Z'
+next: content/docs/frameworks/astro.mdx
 previous: content/docs/vibe-coding.mdx
 ---
 
@@ -29,3 +29,15 @@ Once your local starter has been created, to run the starter, follow the instruc
 ```
 pnpm run dev
 ```
+
+## Which starter should I pick?
+
+**Astro is our default starter.** It is the one we recommend for new projects, and the one we build and test against first. It ships with [React-free visual editing](/docs/contextual-editing/astro/), so editors get a live preview while visitors get plain static HTML. See the [Astro + TinaCMS setup guide](/docs/frameworks/astro/) for what is inside it.
+
+To skip the prompt and scaffold the Astro starter directly:
+
+```bash
+npx create-tina-app@latest --template tina-astro-starter
+```
+
+The other starters are still available and still supported. Pick one of those if you are already committed to a framework, for example the Next.js starter if you are building on [Next.js](/docs/frameworks/next/app-router/).

--- a/content/docs/setup-overview.mdx
+++ b/content/docs/setup-overview.mdx
@@ -31,7 +31,7 @@ Pick an option below to start exploring.
     {
       title: "Use a Starter Template",
       description:
-        "Using the CLI, choose one of our starters and get started with a new site locally.",
+        "Using the CLI, scaffold our default Astro starter (or another framework) and get started with a new site locally.",
       link: "/docs/introduction/using-starter/",
       linkText: ""
     },


### PR DESCRIPTION
## TL;DR

The getting-started path still pointed people at the Next.js starter: the CLI doc gave no steer on which starter to pick, and `tina-init` told readers to "get started using one of our NextJS starters". This updates the docs half of tinacms/tinacms#7180 so Astro leads everywhere.

**Files to review (9, +31 / -15):**

| File | Why |
|---|---|
| `content/docs/introduction/using-starter.mdx` *(start here)* | New "Which starter should I pick?" section, plus the direct `--template tina-astro-starter` command. |
| `content/docs/integration/frameworks.mdx` | Default-starter callout; also corrects the visual-editing claim (see notes). |
| `content/docs/frameworks/astro.mdx` | Marked as the default starter. |
| `content/docs/setup-overview.mdx`, `introduction/tina-init.mdx`, `frameworks/gatsby.mdx` | Copy now names Astro instead of Next.js. |
| `frameworks/{hugo,next/app-router,next/pages-router}.mdx` | Frontmatter `prev`/`next` only. |

## Reviewer notes

- **Screenshot is now stale.** `/img/docs/introduction/cli-starter.png` on the starter page still shows the old CLI menu, with "NextJS starter" starred and no Astro option, so it contradicts the new text. Needs a fresh capture once the `TEMPLATES` reorder ships.
- **Fixed an adjacent wrong claim.** The frameworks overview said visual editing "is currently limited to React-based frameworks". That is wrong given `@tinacms/astro`, and it undercut the default-starter callout sitting right above it. Happy to split this out.
- **Prev/next now matches the TOC.** `docs-toc.json` already listed Astro first under Frameworks, but the `prev`/`next` chain still ran Next.js → Astro. Reordered to agree; no content moved.
- **Blog post deliberately untouched.** [Astro is becoming the default starter](https://tina.io/blog/astro-is-becoming-the-default-tinacms-starter) (2026-05-28) still reads "We have not changed the default yet." It is accurate as a dated post, but it ranks well for this. A short follow-up announcing the switch would resolve it better than editing history.
- **No `zh` changes.** `content/docs-zh/` is handled by the existing "Chinese translation for PR #X" automation.

## Links

- [tinacms/tinacms#7180 - Promote Astro to the flagship TinaCMS starter](https://github.com/tinacms/tinacms/issues/7180)
- [tinacms/tinacms#7179 - Canary Testing, Astro Flagship Starter](https://github.com/tinacms/tinacms/issues/7179)