### PR TITLE
Fix YouTube Error 153 by declaring a referrer policy on embeds

### DIFF
--- a/components/blocks/Features/Features.tsx
+++ b/components/blocks/Features/Features.tsx
@@ -339,6 +339,7 @@ const YouTubeEmbed = ({ videoId }: { videoId: string }) => (
       src={`https://www.youtube.com/embed/${videoId}?autoplay=1`}
       title="YouTube video player"
       frameBorder="0"
+      referrerPolicy="strict-origin-when-cross-origin"
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
       allowFullScreen
     ></iframe>

--- a/components/blocks/Media/MediaComponent.tsx
+++ b/components/blocks/Media/MediaComponent.tsx
@@ -16,6 +16,7 @@ const VideoGridComponent = ({ data }) => {
             src={media.embedUrl}
             title="YouTube video player"
             className="object-cover rounded-lg"
+            referrerPolicy="strict-origin-when-cross-origin"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
           />

--- a/components/blocks/VideoEmbed/LiteYouTube.tsx
+++ b/components/blocks/VideoEmbed/LiteYouTube.tsx
@@ -49,6 +49,7 @@ export const LiteYouTube = ({
           title={title}
           className="absolute inset-0 w-full h-full rounded-lg shadow-lg"
           frameBorder="0"
+          referrerPolicy="strict-origin-when-cross-origin"
           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen
         />

--- a/components/tinaMarkdownComponents/docAndBlogComponents.tsx
+++ b/components/tinaMarkdownComponents/docAndBlogComponents.tsx
@@ -286,6 +286,7 @@ export const docAndBlogComponents: Components<{
           height={`${height}px`}
           src={iframeSrc}
           title="Iframe"
+          referrerPolicy="strict-origin-when-cross-origin"
         />
       </div>
     );
@@ -558,6 +559,7 @@ export const docAndBlogComponents: Components<{
           className="absolute top-0 left-0 w-full h-full rounded-md"
           src={embedSrc}
           title="YouTube video player"
+          referrerPolicy="strict-origin-when-cross-origin"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen={true}
         ></iframe>

--- a/components/youtubeEmbedReferrerPolicy.test.ts
+++ b/components/youtubeEmbedReferrerPolicy.test.ts
@@ -1,0 +1,102 @@
+// `fs` and `path` are imported without the `node:` prefix on purpose: Jest 25 cannot
+// resolve prefixed builtins.
+import fs from 'fs';
+import path from 'path';
+
+// YouTube's embedded player refuses to start with "Error 153 - Video player
+// configuration error" when the iframe request carries no Referer header. Browsers
+// send one by default, but an embedding context can withhold it (iOS in-app
+// WKWebView browsers, a document-level `Referrer-Policy: no-referrer`, some privacy
+// settings). Setting the policy on the iframe itself overrides that context, so
+// every YouTube embed we render has to declare it.
+const REQUIRED_POLICY = 'referrerPolicy="strict-origin-when-cross-origin"';
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SCAN_DIRS = ['app', 'components'];
+
+// The YouTube embeds that existed when this test was written. New ones are picked up
+// by the scan automatically; this list only proves the scan still sees the ones we
+// know about, so it cannot quietly stop matching and pass on nothing.
+const KNOWN_EMBED_FILES = [
+  'components/blocks/Features/Features.tsx',
+  'components/blocks/Media/MediaComponent.tsx',
+  'components/blocks/VideoEmbed/LiteYouTube.tsx',
+  'components/tinaMarkdownComponents/docAndBlogComponents.tsx',
+];
+
+function tsxFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return tsxFiles(full);
+    }
+    return entry.isFile() && entry.name.endsWith('.tsx') ? [full] : [];
+  });
+}
+
+// Returns the source of every `<iframe ...>` opening tag in the file. Only a `>` at
+// brace depth zero and outside a quoted value ends a tag, so an expression such as
+// `height={h > 400 ? 400 : h}` does not truncate one.
+function iframeTags(source: string): string[] {
+  const tags: string[] = [];
+  let start = source.indexOf('<iframe');
+  while (start !== -1) {
+    let depth = 0;
+    let quote = '';
+    let end = -1;
+    for (let i = start; i < source.length; i++) {
+      const char = source[i];
+      if (quote !== '') {
+        if (char === quote) {
+          quote = '';
+        }
+      } else if (char === '{') {
+        depth++;
+      } else if (char === '}') {
+        depth--;
+      } else if (depth > 0) {
+        // Anything inside a JSX expression cannot end the tag.
+      } else if (char === '"' || char === "'") {
+        quote = char;
+      } else if (char === '>') {
+        end = i;
+        break;
+      }
+    }
+    if (end === -1) {
+      break;
+    }
+    tags.push(source.slice(start, end + 1));
+    start = source.indexOf('<iframe', end);
+  }
+  return tags;
+}
+
+// An iframe counts as a YouTube embed when anything in its opening tag mentions
+// YouTube: the src, or the title on the components that take the URL from Tina.
+const youtubeEmbeds = SCAN_DIRS.flatMap((dir) =>
+  tsxFiles(path.join(REPO_ROOT, dir)).flatMap((file) =>
+    iframeTags(fs.readFileSync(file, 'utf8'))
+      .filter((tag) => /youtube/i.test(tag))
+      // Forward slashes so the paths match KNOWN_EMBED_FILES on Windows too.
+      .map((tag) => ({
+        file: path.relative(REPO_ROOT, file).split(path.sep).join('/'),
+        tag,
+      })),
+  ),
+);
+
+test('the scan still finds every known YouTube embed', () => {
+  const files = youtubeEmbeds.map((embed) => embed.file);
+  const notFound = KNOWN_EMBED_FILES.filter((known) => !files.includes(known));
+
+  expect(notFound).toEqual([]);
+});
+
+test('every YouTube embed sets a referrer policy on the iframe', () => {
+  const missingPolicy = youtubeEmbeds
+    .filter((embed) => !embed.tag.includes(REQUIRED_POLICY))
+    .map((embed) => embed.file);
+
+  expect(missingPolicy).toEqual([]);
+});

--- a/content/docs/contextual-editing/astro.mdx
+++ b/content/docs/contextual-editing/astro.mdx
@@ -255,6 +255,7 @@ const { videoId } = Astro.props;
 <iframe
   src={`https://www.youtube.com/embed/${videoId}`}
   title="YouTube video player"
+  referrerpolicy="strict-origin-when-cross-origin"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; picture-in-picture"
   allowfullscreen
 />


### PR DESCRIPTION
Fixes #4748

## The pain

On an iPad, the video at the top of [/docs/vibe-coding](https://tina.io/docs/vibe-coding) does not play.
You get a dark box reading "Error 153 - Video player configuration error".
The box has no thumbnail in it, so it looks like a broken image.
The same page plays in desktop Chrome, so the iPad looked like the cause.

## Investigation

Error 153 comes from YouTube, not from us.
Its player refuses to configure itself when the request for the embed arrives with no `Referer` header.
So the question was not what the iPad does differently, it was who drops that header.

I loaded the live page in Chrome and in WebKit.
For each one I recorded the `Referer` sent to `youtube.com/embed`, then read the error text from inside the iframe:

| Browser | `Referer` sent | Result |
| --- | --- | --- |
| Chrome desktop | `https://tina.io/` | plays |
| WebKit, iPad viewport | `https://tina.io/` | plays |
| WebKit, iPad viewport, referrer withheld | none | Error 153 |
| Chrome desktop, referrer withheld | none | Error 153 |

Desktop Chrome fails the same way once the referrer is withheld, so this is not an iPad bug.
Our embeds never declared a referrer policy, which left the header to whatever context loaded the page.
Browsers send it by default.
iOS in-app WebViews, which is what Outlook and Teams open a tapped link in, do not.
The bug report came from a link in an email, which fits.

The site is not the one dropping it: there is no `Referrer-Policy` header in `next.config.js`, `vercel.json`, or `middleware.ts`.
That leaves the iframe as the only place we can defend against a context that withholds it.

## The solution

Set `referrerPolicy="strict-origin-when-cross-origin"` on the iframe.
An attribute on the iframe overrides the surrounding context, so the header goes out even inside a WebView that would otherwise drop it.
That value is already the default in Chrome, Firefox, and Safari, so a normal visitor's header does not change.
Every embed URL is `https`, so there is no downgrade case.

Applied to the 4 components that render a YouTube embed, plus 2 places carrying the same gap:

- the generic `Iframe` rich-text component, which an editor can point at a YouTube embed URL
- the Astro sample in `content/docs/contextual-editing/astro.mdx`, which taught readers to build the same broken component. Only the English source changes here, because `content/docs-zh/` is regenerated by the auto-translate workflow.

`components/youtubeEmbedReferrerPolicy.test.ts` fails if a YouTube iframe under `app/` or `components/` drops the attribute.
Strip it from one embed and the test names that file.

Checks on this branch: `npx jest` 82 passed in 15 suites, `npx tsc` exit 0, `npx biome ci .` exit 0.
`pnpm build` needs TinaCloud credentials, so CI covers that one.

## Suggested review order

1. `components/tinaMarkdownComponents/docAndBlogComponents.tsx` - the `Youtube` component from the bug report, and the generic `Iframe` component with the same gap.
2. `components/blocks/VideoEmbed/LiteYouTube.tsx` - shared by `RecentPosts` and `VideoDisplay`, so 1 attribute covers 3 call sites.
3. `components/blocks/Features/Features.tsx` and `components/blocks/Media/MediaComponent.tsx` - the last 2 renderers, same line in each.
4. `content/docs/contextual-editing/astro.mdx` - the docs sample that shipped the bug to readers.
5. `components/youtubeEmbedReferrerPolicy.test.ts` - the guard, which reads better once you have seen the embeds it protects.

## Reproduce it

You do not need an iPad.
Withhold the referrer with the Playwright MCP server and read what the player says.
Pass this to `browser_run_code_unsafe`:

```js
async (page) => {
  await page.route('**/docs/vibe-coding', async (route) => {
    const res = await route.fetch();
    const headers = { ...res.headers(), 'referrer-policy': 'no-referrer' };
    delete headers['content-encoding'];
    delete headers['content-length'];
    await route.fulfill({ status: res.status(), headers, body: await res.text() });
  });
  await page.goto('https://tina.io/docs/vibe-coding');
  const frame = page.frameLocator('iframe[src*="buaXi8Hh420"]');
  return await frame.locator('body').innerText({ timeout: 15000 });
}
```

Against production it returns `Watch video on YouTube / Error 153 / Video player configuration error`.

For the fixed version, run `pnpm dev` on this branch and point the same call at `http://localhost:3000/docs/vibe-coding`.
The referrer is still withheld, but the component carries the attribute, so you get the player back: `Vibe blogging with GitHub Copilot & TinaCMS | Hark Singh`.
