### PR TITLE
Typography fixes: docs H1 descenders + cap blog title at text-5xl

### DIFF
--- a/components/Docs/docsMain/docsMainBody.tsx
+++ b/components/Docs/docsMain/docsMainBody.tsx
@@ -20,7 +20,7 @@ const MainDocsBodyHeader = ({
         ></DocsMobileHeader>
       </div>
       <h1
-        className={`pt-4 font-ibm-plex text-4xl bg-linear-to-r from-orange-500 via-orange-500 to-orange-600 bg-clip-text text-transparent`}
+        className={`pt-2 font-ibm-plex text-4xl leading-[1.3] bg-linear-to-r from-orange-500 via-orange-500 to-orange-600 bg-clip-text text-transparent`}
       >
         {DocumentTitle}
       </h1>

--- a/components/blog/BlogPageClient.tsx
+++ b/components/blog/BlogPageClient.tsx
@@ -87,7 +87,7 @@ const BlogPageClient: React.FC<BlogPageClientProps> = ({
 function BlogPageTitle({ title }: { title: string }) {
   const blogTitleStyling =
     'leading-[1.3] max-w-3xl bg-linear-to-r from-orange-400 via-orange-500 to-orange-600 ' +
-    'text-transparent bg-clip-text font-ibm-plex mx-auto text-4xl md:text-5xl lg:text-6xl';
+    'text-transparent bg-clip-text font-ibm-plex mx-auto text-4xl md:text-5xl';
 
   return (
     <header className="relative z-10 overflow-visible text-center px-8 pt-12 pb-4">


### PR DESCRIPTION
Fixes #4754

## Summary

Two small typographic fixes to titles, addressing both items in #4754:

### 1. Tina.io Docs — fix line height so "g" isn't cut

On docs pages (e.g. `/docs/vibe-coding`), the H1 title had descenders clipped — letters like `g`, `y`, `p` had their tails cut off (visible in the "g" of "Coding"). The H1 uses `bg-clip-text text-transparent`, which clips the gradient to the glyph bounding box; combined with `text-4xl`'s tight default line-height, descenders fell outside the clip region.

While in there, the top padding was also heavier than needed (`pt-4`/16px).

Change in `components/Docs/docsMain/docsMainBody.tsx`:

- Added `leading-[1.3]` so `bg-clip-text` has enough vertical room for descenders (matches the blog title convention).
- `pt-4` → `pt-2` (halved).

### 2. Tina.io Blog — reduce font size on desktop

On blog posts (e.g. `/blog/tinacms-news-may-june-2026`), the title was `text-6xl` on `lg` screens, which read as too large on desktop. Dropped `lg:text-6xl` in `components/blog/BlogPageClient.tsx` so the title stays at `text-5xl` from `md` upwards.

## Test plan

- [ ] `/docs/vibe-coding` — "g" tail no longer clipped; space above title looks tighter.
- [ ] `/blog/tinacms-news-may-june-2026` (or any blog post) at `lg`+ widths — title is no longer oversized.
- [ ] Spot-check other doc + blog titles at various lengths on mobile, tablet, desktop.
