### PR TITLE
Add Watch the Videos link to the whats-new pages

### DIFF
--- a/app/whats-new/tinacloud/WhatsNewTinaCloudPageLayout.tsx
+++ b/app/whats-new/tinacloud/WhatsNewTinaCloudPageLayout.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { FaNewspaper } from 'react-icons/fa';
+import { FaNewspaper, FaYoutube } from 'react-icons/fa';
 import { H1_HEADINGS_SIZE } from '@/component/styles/typography';
 import { WhatsNewCard } from '../tinacms/WhatsNewTinaCMSLayout';
 
@@ -24,6 +24,12 @@ export const WhatsNewTinaCloudPageLayout = ({ data }) => {
           className="flex items-center justify-center hover:text-blue-800"
         >
           See Newsletters <FaNewspaper className="ml-2" />
+        </Link>
+        <Link
+          href="https://www.youtube.com/@TinaCMS/videos"
+          className="flex items-center justify-center hover:text-blue-800"
+        >
+          Watch the Videos <FaYoutube className="ml-2" />
         </Link>
       </div>
     </div>

--- a/app/whats-new/tinacms/WhatsNewTinaCMSLayout.tsx
+++ b/app/whats-new/tinacms/WhatsNewTinaCMSLayout.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { FaGithub, FaNewspaper } from 'react-icons/fa';
+import { FaGithub, FaNewspaper, FaYoutube } from 'react-icons/fa';
 import { H1_HEADINGS_SIZE } from '@/component/styles/typography';
 
 interface ChangeItem {
@@ -139,6 +139,12 @@ const WhatsNewTinaCMSPageLayout = ({ data }) => {
           className="flex items-center justify-center hover:text-blue-800"
         >
           See Newsletters <FaNewspaper className="ml-2" />
+        </Link>
+        <Link
+          href="https://www.youtube.com/@TinaCMS/videos"
+          className="flex items-center justify-center hover:text-blue-800"
+        >
+          Watch the Videos <FaYoutube className="ml-2" />
         </Link>
       </div>
     </div>


### PR DESCRIPTION
Closes #4755

**TL;DR** Link the TinaCMS YouTube channel from the What's New pages.

**Pain:** The sprint and release videos on YouTube are invisible to people reading the release notes on tina.io - the What's New pages only link GitHub and the newsletter archive, so the videos miss an audience that is already interested in what shipped.

**Solution:** Adds a "Watch the Videos" link (with a YouTube icon) to the footer of /whats-new/tinacms and /whats-new/tinacloud, pointing at the TinaCMS channel's videos tab.

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?