### PR TITLE
Add TinaCon registration link

### DIFF
--- a/content/conference/TinaCon2026.mdx
+++ b/content/conference/TinaCon2026.mdx
@@ -11,7 +11,7 @@ banner:
     title: Agenda
   rightButton:
     title: Register
-    link: ''
+    link: 'https://www.eventbrite.com/e/1993579033555'
 about:
   heading: About the Conference
   description: |


### PR DESCRIPTION
## What changed

- Added the TinaCon Eventbrite URL to the existing `Register` button configuration.

## Why

The conference page already supported a secondary registration CTA, but its link was empty. Because the component only renders that button when a link exists, visitors had no direct path from the TinaCon page to ticket sales.

## Impact

Visitors to `/conference` will see the existing **Register** button and can open the TinaCon Eventbrite ticket page in a new tab.

## Validation

- Confirmed the supplied Eventbrite event is live and its ticket selector opens correctly.
- Ran `git diff --check` successfully.
- Full local build was not run because this fresh checkout did not have project dependencies installed; the change only updates an existing TinaCMS content field.