### PR TITLE
docs: document the Auth.js interop workaround for non-Next.js backends

### DIFF
--- a/content/docs/reference/self-hosted/auth-provider/authjs.mdx
+++ b/content/docs/reference/self-hosted/auth-provider/authjs.mdx
@@ -96,6 +96,65 @@ export default (req, res) => {
 }
 ```
 
+## Using Auth.js outside Next.js
+
+<WarningCallout
+  body={<>
+    **Known issue:** `tinacms-authjs` currently only works when your backend is bundled by Next.js. On any other host (Netlify Functions, Vercel Functions, or plain Node), the backend fails with `(0 , import_credentials.default) is not a function`, followed by `NextAuth is not a function` once that is worked around. Tracking issue: [tinacms/tinacms#7434](https://github.com/tinacms/tinacms/issues/7434). Until it is fixed, apply the workaround below.
+  </>}
+/>
+
+`tinacms-authjs` is published as ESM and does a default import of `next-auth`, which is CommonJS. Webpack (and therefore Next.js) unwraps that automatically, but Node's own ESM loader and esbuild do not, so the imported value is the module object rather than the function.
+
+To work around it, build the credentials provider yourself and swap in the auth route handler, both using an interop-safe unwrap:
+
+```js
+import NextAuthImport from 'next-auth'
+import CredentialsImport from 'next-auth/providers/credentials'
+
+const NextAuth = NextAuthImport.default ?? NextAuthImport
+const Credentials = CredentialsImport.default ?? CredentialsImport
+
+const provider = Credentials({
+  credentials: {
+    username: { label: 'Username', type: 'text' },
+    password: { label: 'Password', type: 'password' },
+  },
+  authorize: async ({ username, password }) => {
+    const result = await databaseClient.authenticate({ username, password })
+    return result.data?.authenticate || null
+  },
+})
+// This name must match exactly, or sign-in will not route to this provider
+provider.name = 'TinaCredentials'
+
+const authOptions = TinaAuthJSOptions({
+  databaseClient,
+  secret: process.env.NEXTAUTH_SECRET,
+  providers: [provider],
+})
+
+const authJs = AuthJsBackendAuthProvider({ authOptions })
+authJs.extraRoutes.auth.handler = async (req, res, opts) => {
+  const url = new URL(req.url, `http://${req.headers?.host || 'localhost'}`)
+  req.query.nextauth = url.pathname
+    ?.replace(`${opts.basePath}auth/`, '')
+    ?.split('/')
+  await NextAuth(authOptions)(req, res)
+}
+```
+
+Then pass `authJs` to `TinaNodeBackend` in place of the inline `AuthJsBackendAuthProvider({ ... })` call, keeping your `isLocal` branch:
+
+```js
+const tinaBackend = TinaNodeBackend({
+  authProvider: isLocal ? LocalBackendAuthProvider() : authJs,
+  databaseClient,
+})
+```
+
+Passing your own `providers` array is what avoids the broken code path, since `TinaAuthJSOptions` only builds its own credentials provider when `providers` is omitted. If your backend file is CommonJS, the two added imports become `require` calls and everything else is unchanged.
+
 ## Testing
 
 Now that you have set up the Auth.js auth provider you can test it out.

--- a/content/docs/reference/self-hosted/tina-backend/netlify-functions.mdx
+++ b/content/docs/reference/self-hosted/tina-backend/netlify-functions.mdx
@@ -64,6 +64,12 @@ app.get('/api/tina/*', async (req, res, next) => {
 export const handler = ServerlessHttp(app)
 ```
 
+<WarningCallout
+  body={<>
+    If this function returns a 500 with `(0 , import_credentials.default) is not a function`, you have hit a known `tinacms-authjs` bug that affects every non-Next.js backend. Changing `node_bundler` does not help. See [Using Auth.js outside Next.js](/docs/reference/self-hosted/auth-provider/authjs/#using-authjs-outside-nextjs) for the workaround, and [tinacms/tinacms#7434](https://github.com/tinacms/tinacms/issues/7434) for the fix.
+  </>}
+/>
+
 Since Netlify Functions do not support catch all routes, you will need to add the following to your `netilfy.toml` file.
 
 ```toml

--- a/content/docs/reference/self-hosted/tina-backend/vercel-functions.mdx
+++ b/content/docs/reference/self-hosted/tina-backend/vercel-functions.mdx
@@ -39,6 +39,12 @@ export default (req, res) => {
 }
 ```
 
+<WarningCallout
+  body={<>
+    If this function fails with `(0 , import_credentials.default) is not a function`, you have hit a known `tinacms-authjs` bug that affects every non-Next.js backend. See [Using Auth.js outside Next.js](/docs/reference/self-hosted/auth-provider/authjs/#using-authjs-outside-nextjs) for the workaround, and [tinacms/tinacms#7434](https://github.com/tinacms/tinacms/issues/7434) for the fix.
+  </>}
+/>
+
 Since Vercel Functions do not support catch all routes, you will need to add the following to your `vercel.json` file.
 
 ```json


### PR DESCRIPTION
Closes #4774

**TL;DR** Document the Auth.js interop workaround that self-hosted backends need outside Next.js.

**Pain:** anyone following the Netlify Functions or Vercel Functions backend docs gets a 500 with `(0 , import_credentials.default) is not a function`, because `tinacms-authjs` ships ESM that default-imports CommonJS `next-auth`. Webpack unwraps that automatically so the Next.js path works, but Node's own ESM loader and esbuild do not, which means both pages currently show a config that cannot work as written. There is no mention of this anywhere in the docs, and switching `node_bundler` does not help, so people burn hours before asking in Discord.

**Solution:** adds a "Using Auth.js outside Next.js" section to the Auth.js provider page with a workaround verified against `tinacms-authjs` 24.0.2 and `next-auth` 4.24.15, and links to it from the Netlify and Vercel pages using the exact error string so it is searchable. The upstream fix is tracked in tinacms/tinacms#7434, after which this section can be deleted.

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### All New Content Submissions: (To be confirmed by reviewer)

- [x] Title is short & specific
- [x] Headers are logically ordered & consistent
- [x] Purpose of document is explained in the first paragraph
- [x] Procedures are tested and work
- [x] Any technical concepts are explained or linked to
- [x] Document follows structure from templates
- [x] All links work
- [x] The spelling and grammar checker has been run
- [x] Graphics and images are clear and useful
- [x] Any prerequisites and next steps are defined.
