### PR TITLE
Update footer: 'maintained by' -> 'actively developed by' SSW

### DIFF
--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -258,7 +258,7 @@ export function Footer({ footerData }: { footerData: FooterData }) {
           rel="noopener noreferrer"
           className="relative z-10 flex flex-wrap items-center justify-center gap-x-1.5 gap-y-1 px-4 text-center text-white text-sm md:text-base font-bold no-underline hover:no-underline"
         >
-          TinaCMS is maintained by
+          TinaCMS is actively developed by
           <svg
             viewBox="0 0 90 60"
             fill="white"


### PR DESCRIPTION
Fixes #4777

## Summary

Per Adam's request in #4777, updates the SSW footer banner copy:

- from: *"TinaCMS is maintained by SSW, Australia's leading software consultants"*
- to: *"TinaCMS is actively developed by SSW, Australia's leading software consultants"*

Change is a single word swap in `components/footer/footer.tsx` (the SSW gradient banner just above the footer's end); the SSW logo and "Australia's leading software consultants" line are unchanged.

## Test plan

- [ ] Open any page in the preview deploy, scroll to the footer, confirm the red SSW banner now reads "TinaCMS is actively developed by [SSW logo], Australia's leading software consultants".
