### PR TITLE
Add opt-in LOW_MEMORY flag to cut dev server memory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,7 @@ SENDGRID_API_KEY=***
 SENDGRID_FROM_EMAIL=***
 CONTACT_FORM_TO=***
 YOUTUBE_API_KEY=***
+
+# Optional: set to true on low-RAM machines to cut dev server memory
+# (~8.7GB -> ~7.6GB peak) at the cost of ~13s per dev-server restart.
+LOW_MEMORY=false

--- a/next.config.js
+++ b/next.config.js
@@ -160,9 +160,18 @@ const config = {
     ];
   },
 
-  webpack(config) {
+  webpack(config, { dev }) {
     config.module.rules.push({ test: /\.md$/, use: 'raw-loader' });
     config.resolve.fallback = { ...config.resolve.fallback, fs: 'empty' };
+
+    // Opt-in escape hatch for low-RAM machines. Disabling webpack's persistent
+    // cache drops the dev server's peak memory on a cold homepage compile from
+    // ~8.7GB to ~7.6GB, at the cost of ~13s on each dev-server restart (the
+    // cache is no longer reused). Cold compile time is unchanged.
+    // Off by default; set LOW_MEMORY=true in your local .env to enable.
+    if (dev && process.env.LOW_MEMORY === 'true') {
+      config.cache = false;
+    }
 
     config.plugins.push(
       new MonacoWebpackPlugin({


### PR DESCRIPTION
Part of #4789

The dev server peaks around 8.7GB compiling the homepage, which makes the repo hard to run on a 16GB machine. Setting `LOW_MEMORY=true` disables webpack's persistent cache in dev and drops that to ~7.6GB.

Off by default — nothing changes unless you opt in.

## To test

Add to your local `.env` (gitignored):

```
LOW_MEMORY=true
```

Or run it inline:

```
LOW_MEMORY=true pnpm dev
```

## Measured

Cold homepage compile on this repo, macOS, Node 22:

| | idle | homepage peak |
|---|---|---|
| default | 2947MB | 8672MB |
| `LOW_MEMORY=true` | 2431MB | 7625MB |

## Trade-off

Restarting the dev server costs ~13s more, because webpack can no longer reuse its cache. Cold compile time is unchanged (marginally faster — it skips cache serialization). If you have plenty of RAM, leave it off.

## Background

This came out of profiling why the dev server is so heavy. A V8 heap profile of a cold homepage compile shows the memory is almost entirely webpack's own machinery — `fromStringFast` (node:buffer) 568MB, webpack bundle5 258MB, `readFileSync` 212MB, `_serialize` 68MB — with no application code in the top 15 allocators.

Worth recording what was ruled out, all A/B measured, so nobody repeats it:

- Route splitting (compiling 10 of 39 blocks instead of all): −136MB. Cost saturates by ~10 blocks and the homepage needs 10.
- Removing mermaid entirely: −106MB (it's 947MB in isolation, but overlaps with everything else once the full block library is compiled).
- Splitting the 874-line `docAndBlogComponents`: −112MB.
- Turbopack: **+1526MB**, though 3.3x faster compiles. Also blocked by `.babelrc`, `forceSwcTransforms` and `next-svgr`.
- Next 15 + `experimental.webpackMemoryOptimizations`: **+650MB**; the flag itself does nothing.

Separately worth knowing: opening only the route you're working on matters more than any of this — a cold `/docs` is ~3.4GB versus ~8.7GB for the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)