### PR TITLE
📝 Fix self-hosted backend samples that reference a removed auth API

### DIFF
--- a/content/docs-zh/reference/self-hosted/tina-backend/vercel-functions.mdx
+++ b/content/docs-zh/reference/self-hosted/tina-backend/vercel-functions.mdx
@@ -14,17 +14,17 @@ id: '/docs/reference/self-hosted/tina-backend/vercel-functions'
 ```ts
 // `api/tina/backend.{ts,js}`
 
-import { TinaNodeBackend, LocalBackendAuthentication } from '@tinacms/datalayer'
-import { TinaAuthJSOptions, AuthJsBackendAuthentication } from 'tinacms-authjs'
+import { TinaNodeBackend, LocalBackendAuthProvider } from '@tinacms/datalayer'
+import { TinaAuthJSOptions, AuthJsBackendAuthProvider } from 'tinacms-authjs'
 
-import databaseClient from '../../../tina/__generated__/databaseClient'
+import databaseClient from '../../tina/__generated__/databaseClient'
 
 const isLocal = process.env.TINA_PUBLIC_IS_LOCAL === 'true'
 
 const handler = TinaNodeBackend({
-  authentication: isLocal
-    ? LocalBackendAuthentication()
-    : AuthJsBackendAuthentication({
+  authProvider: isLocal
+    ? LocalBackendAuthProvider()
+    : AuthJsBackendAuthProvider({
         authOptions: TinaAuthJSOptions({
           databaseClient: databaseClient,
           secret: process.env.NEXTAUTH_SECRET,

--- a/content/docs-zh/self-hosted/manual-setup.mdx
+++ b/content/docs-zh/self-hosted/manual-setup.mdx
@@ -90,17 +90,17 @@ export default isLocal
 ```js
 // pages/api/tina/[...routes].{ts,js}
 
-import { TinaNodeBackend, LocalBackendAuthentication } from '@tinacms/datalayer'
-import { TinaAuthJSOptions, AuthJsBackendAuthentication } from 'tinacms-authjs'
+import { TinaNodeBackend, LocalBackendAuthProvider } from '@tinacms/datalayer'
+import { TinaAuthJSOptions, AuthJsBackendAuthProvider } from 'tinacms-authjs'
 
 import databaseClient from '../../../tina/__generated__/databaseClient'
 
 const isLocal = process.env.TINA_PUBLIC_IS_LOCAL === 'true'
 
 const handler = TinaNodeBackend({
-  authentication: isLocal
-    ? LocalBackendAuthentication()
-    : AuthJsBackendAuthentication({
+  authProvider: isLocal
+    ? LocalBackendAuthProvider()
+    : AuthJsBackendAuthProvider({
         authOptions: TinaAuthJSOptions({
           databaseClient: databaseClient,
           secret: process.env.NEXTAUTH_SECRET,

--- a/content/docs/reference/self-hosted/tina-backend/vercel-functions.mdx
+++ b/content/docs/reference/self-hosted/tina-backend/vercel-functions.mdx
@@ -14,17 +14,17 @@ Create a file called `api/tina/backend.{ts,js}` and add the following code:
 ```ts
 // `api/tina/backend.{ts,js}`
 
-import { TinaNodeBackend, LocalBackendAuthentication } from '@tinacms/datalayer'
-import { TinaAuthJSOptions, AuthJsBackendAuthentication } from 'tinacms-authjs'
+import { TinaNodeBackend, LocalBackendAuthProvider } from '@tinacms/datalayer'
+import { TinaAuthJSOptions, AuthJsBackendAuthProvider } from 'tinacms-authjs'
 
-import databaseClient from '../../../tina/__generated__/databaseClient'
+import databaseClient from '../../tina/__generated__/databaseClient'
 
 const isLocal = process.env.TINA_PUBLIC_IS_LOCAL === 'true'
 
 const handler = TinaNodeBackend({
-  authentication: isLocal
-    ? LocalBackendAuthentication()
-    : AuthJsBackendAuthentication({
+  authProvider: isLocal
+    ? LocalBackendAuthProvider()
+    : AuthJsBackendAuthProvider({
         authOptions: TinaAuthJSOptions({
           databaseClient: databaseClient,
           secret: process.env.NEXTAUTH_SECRET,

--- a/content/docs/self-hosted/manual-setup.mdx
+++ b/content/docs/self-hosted/manual-setup.mdx
@@ -90,17 +90,17 @@ In this example we will show how to host the GraphQL API on Vercel. You can use 
 ```js
 // pages/api/tina/[...routes].{ts,js}
 
-import { TinaNodeBackend, LocalBackendAuthentication } from '@tinacms/datalayer'
-import { TinaAuthJSOptions, AuthJsBackendAuthentication } from 'tinacms-authjs'
+import { TinaNodeBackend, LocalBackendAuthProvider } from '@tinacms/datalayer'
+import { TinaAuthJSOptions, AuthJsBackendAuthProvider } from 'tinacms-authjs'
 
 import databaseClient from '../../../tina/__generated__/databaseClient'
 
 const isLocal = process.env.TINA_PUBLIC_IS_LOCAL === 'true'
 
 const handler = TinaNodeBackend({
-  authentication: isLocal
-    ? LocalBackendAuthentication()
-    : AuthJsBackendAuthentication({
+  authProvider: isLocal
+    ? LocalBackendAuthProvider()
+    : AuthJsBackendAuthProvider({
         authOptions: TinaAuthJSOptions({
           databaseClient: databaseClient,
           secret: process.env.NEXTAUTH_SECRET,


### PR DESCRIPTION
Closes #4791

**TL;DR** Manual Setup and the Vercel Functions backend page configure `TinaNodeBackend` with an auth API that no published package exports, so both samples throw on copy-paste.

**Pain:** Both pages document `authentication:` with `LocalBackendAuthentication()` / `AuthJsBackendAuthentication()`. Neither name is exported by `@tinacms/datalayer` or `tinacms-authjs`, and `TinaBackendOptions` has no `authentication` key, so `TinaNodeBackend` throws a TypeError destructuring `authProvider` before it serves a request. Manual Setup is exactly where `/docs/self-hosted/existing-site` sends anyone not on Next.js, so it is the first thing a self-hoster on Astro, 11ty, Hugo or SvelteKit copies. The `nextjs` and `netlify-functions` pages are already correct, so this is drift on two pages rather than a stale API across the docs.

**Solution:** Rename to the shipped API on both pages: `authentication:` to `authProvider:`, `LocalBackendAuthentication` to `LocalBackendAuthProvider`, `AuthJsBackendAuthentication` to `AuthJsBackendAuthProvider`. On the Vercel page only, drop one level off the `databaseClient` import, since the file is `api/tina/backend.ts` and `../../tina/...` is what resolves. Both changes are mirrored into the `content/docs-zh/` copies, which carry the same English code blocks.