### PR TITLE
chore: replace pixelmatch with @blazediff/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.5",
+    "@blazediff/core": "^1.10.0",
     "@playwright/test": "^1.49.1",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.1.11",
@@ -132,7 +133,6 @@
     "babel-plugin-styled-components": "^1.13.3",
     "jest": "^25.5.4",
     "next-sitemap": "^4.2.3",
-    "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
     "tailwindcss": "^4.1.8",
     "ts-jest": "^25.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.3.5
         version: 2.3.5
+      '@blazediff/core':
+        specifier: ^1.10.0
+        version: 1.10.0
       '@playwright/test':
         specifier: ^1.49.1
         version: 1.53.2
@@ -303,9 +306,6 @@ importers:
       next-sitemap:
         specifier: ^4.2.3
         version: 4.2.3(next@14.2.35(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.2))
-      pixelmatch:
-        specifier: ^7.1.0
-        version: 7.1.0
       pngjs:
         specifier: ^7.0.0
         version: 7.0.0
@@ -1091,6 +1091,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@blazediff/core@1.10.0':
+    resolution: {integrity: sha512-AOQff0zgR7cGsZL+4E7hVkmujoPUpm0J9xzWGWZj5wCjd3gmxESXAPfKyuzs93VdpQNFhHlBhfOjrcZ+XTERtQ==}
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
@@ -7735,10 +7738,6 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
-  pixelmatch@7.1.0:
-    resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
-    hasBin: true
-
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -10797,6 +10796,8 @@ snapshots:
   '@biomejs/cli-win32-x64@2.3.5':
     optional: true
 
+  '@blazediff/core@1.10.0': {}
+
   '@braintree/sanitize-url@7.1.2': {}
 
   '@chevrotain/types@11.1.2': {}
@@ -11548,7 +11549,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.2
 
-  '@jest/test-sequencer@25.5.4':
+  '@jest/test-sequencer@25.5.4(bufferutil@4.0.9)':
     dependencies:
       '@jest/test-result': 25.5.0
       graceful-fs: 4.2.11
@@ -11556,7 +11557,10 @@ snapshots:
       jest-runner: 25.5.4(bufferutil@4.0.9)
       jest-runtime: 25.5.4(bufferutil@4.0.9)
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - utf-8-validate
 
   '@jest/transform@25.5.1':
     dependencies:
@@ -16722,7 +16726,7 @@ snapshots:
   jest-config@25.5.4(bufferutil@4.0.9):
     dependencies:
       '@babel/core': 7.28.0
-      '@jest/test-sequencer': 25.5.4
+      '@jest/test-sequencer': 25.5.4(bufferutil@4.0.9)
       '@jest/types': 25.5.0
       babel-jest: 25.5.1(@babel/core@7.28.0)
       chalk: 3.0.0
@@ -18584,10 +18588,6 @@ snapshots:
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
-
-  pixelmatch@7.1.0:
-    dependencies:
-      pngjs: 7.0.0
 
   pkg-dir@4.2.0:
     dependencies:

--- a/tests/visual-compare/generate-report.ts
+++ b/tests/visual-compare/generate-report.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import pixelmatch from 'pixelmatch';
+import diff from '@blazediff/core';
 import { PNG } from 'pngjs';
 import sharp from 'sharp';
 
@@ -113,14 +113,9 @@ async function compareImages(slug: string): Promise<DiffResult> {
   const diffPng = new PNG({ width, height });
   const totalPixels = width * height;
 
-  const diffPixels = pixelmatch(
-    new Uint8Array(rgbaA),
-    new Uint8Array(rgbaB),
-    new Uint8Array(diffPng.data.buffer),
-    width,
-    height,
-    { threshold: 0.1 },
-  );
+  const diffPixels = diff(rgbaA, rgbaB, diffPng.data, width, height, {
+    threshold: 0.1,
+  });
 
   const diffPercent = (diffPixels / totalPixels) * 100;
 


### PR DESCRIPTION
**What:** Swaps `pixelmatch` for `@blazediff/core` in the visual-diff report generator.

**Why:** Same algorithm, meaningfully faster. On a 4K pair (M1 Max, 50 runs, IO excluded) pixelmatch takes 302.29ms vs 211.92ms for `@blazediff/core` — [~62% average improvement across the fixture set](https://github.com/teimurjan/blazediff/blob/main/benchmarks/pixel-by-pixel.md), with the largest wins on identical pairs, which is most of what this report compares.

**How:** Identical signature (`diff(a, b, output, w, h, opts)`), so only the import and call name change. The `new Uint8Array(...)` wrappers are gone since blazediff accepts `Buffer` directly — that also drops two full-size RGBA copies per page and removes a latent bug where `new Uint8Array(diffPng.data.buffer)` viewed the whole backing `ArrayBuffer` rather than the Buffer's slice.

**Notes:** Both use the same YIQ perceptual delta and anti-aliasing detection, so counts track pixelmatch within ~0.05% across the fixture set. Already used by Vitest, Shopify (react-native-skia), Ant Design, Ant Design X, AntV G, GPT-Vis, Vega, ApexCharts, and Avatune. MIT, zero dependencies.

Background:
- [Building BlazeDiff: block-level optimization](https://dev.to/teimurjan/building-blazediff-how-i-made-the-fastest-image-diff-up-to-60-faster-with-block-level-optimization-ok7)
- [Porting scientific algorithms from MATLAB to JavaScript](https://hackernoon.com/porting-scientific-algorithms-from-matlab-to-javascript)
- [Beating JavaScript performance limits with Rust and N-API](https://hackernoon.com/beating-javascript-performance-limits-with-rust-and-n-api-building-a-faster-image-diff-tool)
