### PR TITLE
docs: fix three pages that render as raw source

### DIFF
--- a/content/docs-zh/contextual-editing/astro.mdx
+++ b/content/docs-zh/contextual-editing/astro.mdx
@@ -30,7 +30,7 @@ Astro 的可视化编辑路径不使用 `useTina()`；该钩子是 React 特有�
     **您需要一个 SSR 适配器。** 每个岛屿的刷新端点 (`/tina-island/[name]`)
     在每次按键时运行。将 `adapter` 设置在 `astro.config.mjs` 中为
     `@astrojs/node`、`@astrojs/vercel`、`@astrojs/netlify` 或 `@astrojs/cloudflare`。
-    `output: 'server'` 是最简单的选择；`output: 'static'` 也可以，只要您将可编辑区域包裹在 [`<TinaIsland>`](#static-site-editing) 中。
+    `output: 'server'` 是最简单的选择；`output: 'static'` 也可以，只要您将可编辑区域包裹在 [`<TinaIsland />`](#static-site-editing) 中。
   </>}
 />
 

--- a/content/docs/contextual-editing/astro.mdx
+++ b/content/docs/contextual-editing/astro.mdx
@@ -32,7 +32,7 @@ In production (no admin parent), the middleware injects nothing and `init()` exi
     runs at request time on every keystroke. Set `adapter` in `astro.config.mjs` to
     `@astrojs/node`, `@astrojs/vercel`, `@astrojs/netlify`, or `@astrojs/cloudflare`.
     `output: 'server'` is the simplest choice; `output: 'static'` also works as
-    long as you wrap editable regions in [`<TinaIsland>`](#static-site-editing).
+    long as you wrap editable regions in [`<TinaIsland />`](#static-site-editing).
   </>}
 />
 

--- a/content/docs/errors/esbuild-error.mdx
+++ b/content/docs/errors/esbuild-error.mdx
@@ -8,7 +8,7 @@ The `tina/config.{ts,js,tsx}` file is built with [esbuild](https://esbuild.githu
 
 This means that there was a syntax or semantic error somewhere in your code. This could be inside the .tina folder or in any file that was imported from your schema file.
 
-## ERROR: your config.{ts,js} was not successfully executed
+## ERROR: your `config.{ts,js}` was not successfully executed
 
 This error means that the schema was compiled correctly (correct syntax) but when the code was run it produced an error.
 


### PR DESCRIPTION
Closes #4794

**TL;DR** Fix three docs pages that render as a wall of raw markdown inside a single `<pre>`.

**Pain:** When `@tinacms/mdx` cannot parse a document it emits one `invalid_markdown` node and the renderer prints the raw body verbatim, so readers get unparsed headings, literal backticks and a raw `<WarningCallout ... />` tag instead of a page. The Astro visual editing docs (en and zh) reference `` `<TinaIsland>` `` inside a `WarningCallout` body, where acorn parses the contents as real JSX and code span backticks give no protection, and `esbuild-error.mdx` carries a bare `{ts,js}` in a heading that MDX reads as a JS expression.

**Solution:** Self-close the tag as `` `<TinaIsland />` `` so acorn accepts it while the rendered text keeps its angle brackets, and backtick the heading to `` `config.{ts,js}` `` to match how that same string is already written in the page's opening paragraph.

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
