### PR TITLE
📝 Add a Self-Hosting on Astro page

### DIFF
--- a/content/docs-toc/docs-toc.json
+++ b/content/docs-toc/docs-toc.json
@@ -667,6 +667,11 @@
                   "_template": "item"
                 },
                 {
+                  "title": "Self-Hosting on Astro",
+                  "slug": "content/docs/self-hosted/astro.mdx",
+                  "_template": "item"
+                },
+                {
                   "title": "Migrating From TinaCloud",
                   "slug": "content/docs/self-hosted/migrating-from-tinacloud.mdx",
                   "_template": "item"

--- a/content/docs/frameworks/astro.mdx
+++ b/content/docs/frameworks/astro.mdx
@@ -178,6 +178,7 @@ See [Visual Editing Setup → Astro](/docs/contextual-editing/astro/) for the fu
 * [Visual Editing Setup → Astro](/docs/contextual-editing/astro/): the integration, per-island refetch, and custom MDX embeds
 * [Deploy to Cloudflare Workers](/docs/tinacloud/deployment-options/cloudflare-workers): the starter auto-detects the host and keeps visual editing working at request time
 * [Migrating from React-based Visual Editing](/docs/migrations/astro-react-free-visual-editing/): existing sites on the old `client:tina` path
+* [Self-hosting on Astro](/docs/self-hosted/astro/): run the Tina backend on your own infrastructure instead of TinaCloud
 * [Content modeling](/docs/schema/) · [Data fetching](/docs/features/data-fetching/) · [Deploy your site](/docs/tinacloud)
 
 Questions? Join the [TinaCMS Discord](https://discord.gg/suurtdwX).

--- a/content/docs/self-hosted/astro.mdx
+++ b/content/docs/self-hosted/astro.mdx
@@ -34,7 +34,7 @@ The island registry and your `<TinaIsland>` regions are unaffected, since they c
 
 That is a constraint on the route signature, not on Astro. Two shapes work:
 
-* **One Node server.** Build with `@astrojs/node` in `mode: 'middleware'` and Astro becomes a Connect/Express middleware. Run a server that mounts `TinaNodeBackend` on `/api/tina/*` behind a body parser such as `express.json()`, and passes everything else to Astro. This suits a VPS or container, where you already have a long-running process.
+* **One Node server.** Build with `@astrojs/node` in `mode: 'middleware'` and Astro becomes a Connect/Express middleware, so a single process can mount `TinaNodeBackend` on `/api/tina/*` and pass everything else to Astro. Scope the body parser to that path, `app.use('/api/tina', express.json())`, rather than applying it globally: `TinaNodeBackend` needs `req.body` populated, but consuming the stream for every route takes it away from Astro's own form posts. This suits a VPS or container, where you already have a long-running process.
 * **A standalone serverless function** beside your static output, which is what the existing backend host pages cover: [Vercel Functions](/docs/reference/self-hosted/tina-backend/vercel-functions/) and [Netlify Functions](/docs/reference/self-hosted/tina-backend/netlify-functions/). [tina-self-hosted-static-demo](https://github.com/tinacms/tina-self-hosted-static-demo) is a working example of that shape.
 
 The starter's `astro.config.mjs` defaults to the Node adapter in `standalone` mode, so the first option means switching that to `middleware` and supplying your own server entry.

--- a/content/docs/self-hosted/astro.mdx
+++ b/content/docs/self-hosted/astro.mdx
@@ -28,16 +28,16 @@ In `src/lib/data.ts` (starter) or `src/lib/tina/data.ts` (`init`):
 
 The island registry and your `<TinaIsland>` regions are unaffected, since they consume the loaders rather than the client directly.
 
-## Host the backend as its own function
+## Give the backend a Node request and response
 
-`TinaNodeBackend` is a Node `(req, res)` handler that reads an already-parsed `req.body`. An Astro `APIRoute` receives a web `Request` and returns a `Response`, so the handler will not mount under `src/pages/api/` as-is.
+`TinaNodeBackend` is a Node `(req, res)` handler that reads an already-parsed `req.body`. An Astro `APIRoute` receives a web `Request` and returns a `Response`, so the handler does not mount under `src/pages/api/` as-is.
 
-Deploy it beside your Astro output instead:
+That is a constraint on the route signature, not on Astro. Two shapes work:
 
-* [Vercel Functions](/docs/reference/self-hosted/tina-backend/vercel-functions/)
-* [Netlify Functions](/docs/reference/self-hosted/tina-backend/netlify-functions/)
+* **One Node server.** Build with `@astrojs/node` in `mode: 'middleware'` and Astro becomes a Connect/Express middleware. Run a server that mounts `TinaNodeBackend` on `/api/tina/*` behind a body parser such as `express.json()`, and passes everything else to Astro. This suits a VPS or container, where you already have a long-running process.
+* **A standalone serverless function** beside your static output, which is what the existing backend host pages cover: [Vercel Functions](/docs/reference/self-hosted/tina-backend/vercel-functions/) and [Netlify Functions](/docs/reference/self-hosted/tina-backend/netlify-functions/). [tina-self-hosted-static-demo](https://github.com/tinacms/tina-self-hosted-static-demo) is a working example of that shape.
 
-[tina-self-hosted-static-demo](https://github.com/tinacms/tina-self-hosted-static-demo) is a working example of that shape: a static site with the Tina backend running as a standalone function.
+The starter's `astro.config.mjs` defaults to the Node adapter in `standalone` mode, so the first option means switching that to `middleware` and supplying your own server entry.
 
 ## The init CLI does not cover Astro
 

--- a/content/docs/self-hosted/astro.mdx
+++ b/content/docs/self-hosted/astro.mdx
@@ -1,0 +1,50 @@
+---
+id: /docs/self-hosted/astro
+title: Self-Hosting on Astro
+next: content/docs/self-hosted/migrating-from-tinacloud.mdx
+previous: content/docs/self-hosted/manual-setup.mdx
+---
+
+Astro works with a self-hosted Tina backend. Nothing in `@tinacms/astro` is tied to TinaCloud: `requestWithMetadata()` wraps whatever `{ data, query, variables }` your client hands it, so visual editing, `<TinaMarkdown>` and the island endpoint behave the same against your own backend.
+
+Start with [Manual Setup](/docs/self-hosted/manual-setup/), which covers the parts that are identical on every framework: choosing a Git provider, database adapter and auth provider, creating `tina/database.ts`, and setting `contentApiUrlOverride` plus an `authProvider` in `tina/config.ts`.
+
+This page covers what is different on Astro.
+
+## The starter ships wired to TinaCloud
+
+[`tina-astro-starter`](https://github.com/tinacms/tina-astro-starter) and `tinacms init` both set up TinaCloud, and the starter's `.env.example` lists only `PUBLIC_TINA_CLIENT_ID` and `TINA_TOKEN`. Moving to your own backend is a deliberate swap rather than a config flag.
+
+## Point your loaders at the database client
+
+The generated data loaders import the TinaCloud client. Self-hosted, they need the database client instead.
+
+In `src/lib/data.ts` (starter) or `src/lib/tina/data.ts` (`init`):
+
+```diff
+-import client from '../../tina/__generated__/client';
++import client from '../../tina/__generated__/databaseClient';
+```
+
+The island registry and your `<TinaIsland>` regions are unaffected, since they consume the loaders rather than the client directly.
+
+## Host the backend as its own function
+
+`TinaNodeBackend` is a Node `(req, res)` handler that reads an already-parsed `req.body`. An Astro `APIRoute` receives a web `Request` and returns a `Response`, so the handler will not mount under `src/pages/api/` as-is.
+
+Deploy it beside your Astro output instead:
+
+* [Vercel Functions](/docs/reference/self-hosted/tina-backend/vercel-functions/)
+* [Netlify Functions](/docs/reference/self-hosted/tina-backend/netlify-functions/)
+
+[tina-self-hosted-static-demo](https://github.com/tinacms/tina-self-hosted-static-demo) is a working example of that shape: a static site with the Tina backend running as a standalone function.
+
+## The init CLI does not cover Astro
+
+`tinacms init backend` supports Next.js only. Choose Astro and it stops with an error pointing at the [Next.js CLI guide](/docs/self-hosted/existing-site/). Follow [Manual Setup](/docs/self-hosted/manual-setup/) instead.
+
+## See Also
+
+* [Astro setup guide](/docs/frameworks/astro/) - setting up TinaCMS with Astro
+* [Manual Setup](/docs/self-hosted/manual-setup/) - the framework-agnostic self-hosting steps
+* [Self-hosting overview](/docs/self-hosted/overview/) - how the backend, database adapter and auth provider fit together

--- a/content/docs/self-hosted/manual-setup.mdx
+++ b/content/docs/self-hosted/manual-setup.mdx
@@ -2,7 +2,7 @@
 id: /docs/self-hosted/manual-setup
 title: Self Hosted Manual Setup
 last_edited: '2024-11-19T00:56:06.271Z'
-next: content/docs/self-hosted/migrating-from-tinacloud.mdx
+next: content/docs/self-hosted/astro.mdx
 previous: content/docs/self-hosted/existing-site.mdx
 ---
 

--- a/content/docs/self-hosted/migrating-from-tinacloud.mdx
+++ b/content/docs/self-hosted/migrating-from-tinacloud.mdx
@@ -3,7 +3,7 @@ id: /docs/self-hosted/migrating-from-tinacloud
 
 title: Migrating from TinaCloud to Self-Hosted
 next: content/docs/self-hosted/querying-data.mdx
-previous: content/docs/self-hosted/manual-setup.mdx
+previous: content/docs/self-hosted/astro.mdx
 ---
 
 The easiest way to migrate from TinaCloud to self-hosted is to use [`@tinacms/cli init backend`](/docs/self-hosted/existing-site) (Next JS only). If you are not using Next.js, you can [check out the manual setup guide](/docs/self-hosted/manual-setup).


### PR DESCRIPTION
Closes #4796

**TL;DR** Adds `/docs/self-hosted/astro`, covering only what differs from Manual Setup, and leaves the Astro framework guide with a link rather than setup detail.

**Pain:** Astro is the default starter in `create-tina-app`, but there is no Astro page under `/docs/self-hosted/`, `content/docs/self-hosted/starters/` holds only `nextjs-vercel.mdx`, and the starter's `.env.example` lists just `PUBLIC_TINA_CLIENT_ID` and `TINA_TOKEN`. The reasonable conclusion is "Astro is TinaCloud only", which is wrong. It has already been asked publicly on https://github.com/tinacms/tinacms/discussions/5247#discussioncomment-17598758 and gone unanswered.

**Solution:** Add `content/docs/self-hosted/astro.mdx` under Self-Hosting > Getting Started, sequenced after Manual Setup, which it defers to for everything framework-agnostic. It documents only the Astro-specific facts: the starter ships wired to TinaCloud, loaders import `__generated__/client` and need `__generated__/databaseClient`, `TinaNodeBackend` needs a Node `(req, res)` pair so it will not mount in an Astro `APIRoute` (either run it in a Node server via `@astrojs/node` in `mode: 'middleware'`, or deploy it as a standalone function), and `tinacms init backend` refuses Astro. The framework guide at `/docs/frameworks/astro` gets a single Next Steps link, so self-hosting setup lives in the self-hosting docs and is not duplicated.