### PR TITLE
📝 Say which frameworks the self-hosted backend and init CLI support

### DIFF
--- a/content/docs/self-hosted/existing-site.mdx
+++ b/content/docs/self-hosted/existing-site.mdx
@@ -11,7 +11,7 @@ previous: content/docs/self-hosted/starters/nextjs-vercel.mdx
 
 If you want to self-host the Tina backend, and don't want to use our [pre-configured starter](/docs/self-hosted/starters/nextjs-vercel/), you can follow the steps below.
 
-We offer a CLI init to quickly setup the backend on Next.js sites, or you can take the [manual setup approach](/docs/self-hosted/manual-setup/) if you're using another framework.
+We offer a CLI init to quickly set up the backend, but **it supports Next.js only**. On any other framework, Astro included, `tinacms init backend` stops with an error and points you at this page. If you are not on Next.js, follow the [manual setup approach](/docs/self-hosted/manual-setup/) instead.
 
 > Prefer a video walkthrough? Check out this video:
 

--- a/content/docs/self-hosted/manual-setup.mdx
+++ b/content/docs/self-hosted/manual-setup.mdx
@@ -123,7 +123,7 @@ The sample above is a Next.js API route, but `TinaNodeBackend` itself is not tie
 
 What it cannot do is mount directly in a route whose signature is the web `Request` / `Response` API, which is what Astro's `APIRoute` and SvelteKit's `+server.ts` give you. Two shapes work instead:
 
-* **Mount it in a Node server.** Frameworks that can build to Connect/Express middleware, such as Astro via `@astrojs/node` in `mode: 'middleware'`, let one server handle `/api/tina/*` with `TinaNodeBackend` and pass everything else to the framework. Put a body parser such as `express.json()` in front so `req.body` is populated.
+* **Mount it in a Node server.** Frameworks that can build to Connect/Express middleware, such as Astro via `@astrojs/node` in `mode: 'middleware'`, let one server handle `/api/tina/*` with `TinaNodeBackend` and pass everything else to the framework. Scope the body parser to that path, `app.use('/api/tina', express.json())`: `TinaNodeBackend` needs `req.body` populated, but parsing every route consumes the stream the framework needs for its own form posts.
 * **Deploy it as a standalone serverless function** beside your site: [Vercel Functions](/docs/reference/self-hosted/tina-backend/vercel-functions/) or [Netlify Functions](/docs/reference/self-hosted/tina-backend/netlify-functions/). [tina-self-hosted-static-demo](https://github.com/tinacms/tina-self-hosted-static-demo) is a working example of a static site with the backend as its own function.
 
 ## 5. Update the TinaCMS config

--- a/content/docs/self-hosted/manual-setup.mdx
+++ b/content/docs/self-hosted/manual-setup.mdx
@@ -119,14 +119,12 @@ export default (req, res) => {
 
 ### Hosting it outside Next.js
 
-The sample above is a Next.js API route, but `TinaNodeBackend` itself is not tied to Next. It is a plain Node `(req, res)` handler that expects an already-parsed `req.body`, so any host that hands it that shape works.
+The sample above is a Next.js API route, but `TinaNodeBackend` itself is not tied to Next. It is a plain Node `(req, res)` handler that expects an already-parsed `req.body`, so anything able to hand it that pair will serve it.
 
-Frameworks whose routes use the web `Request` / `Response` API instead, Astro and SvelteKit among them, cannot mount it directly. Host it as a standalone serverless function beside your site:
+What it cannot do is mount directly in a route whose signature is the web `Request` / `Response` API, which is what Astro's `APIRoute` and SvelteKit's `+server.ts` give you. Two shapes work instead:
 
-* [Vercel Functions](/docs/reference/self-hosted/tina-backend/vercel-functions/)
-* [Netlify Functions](/docs/reference/self-hosted/tina-backend/netlify-functions/)
-
-[tina-self-hosted-static-demo](https://github.com/tinacms/tina-self-hosted-static-demo) is a working example of that shape: a static site with the Tina backend as its own function.
+* **Mount it in a Node server.** Frameworks that can build to Connect/Express middleware, such as Astro via `@astrojs/node` in `mode: 'middleware'`, let one server handle `/api/tina/*` with `TinaNodeBackend` and pass everything else to the framework. Put a body parser such as `express.json()` in front so `req.body` is populated.
+* **Deploy it as a standalone serverless function** beside your site: [Vercel Functions](/docs/reference/self-hosted/tina-backend/vercel-functions/) or [Netlify Functions](/docs/reference/self-hosted/tina-backend/netlify-functions/). [tina-self-hosted-static-demo](https://github.com/tinacms/tina-self-hosted-static-demo) is a working example of a static site with the backend as its own function.
 
 ## 5. Update the TinaCMS config
 

--- a/content/docs/self-hosted/manual-setup.mdx
+++ b/content/docs/self-hosted/manual-setup.mdx
@@ -117,6 +117,17 @@ export default (req, res) => {
 
 > For more info see [Backend Host](/docs/reference/self-hosted/tina-backend/nextjs)
 
+### Hosting it outside Next.js
+
+The sample above is a Next.js API route, but `TinaNodeBackend` itself is not tied to Next. It is a plain Node `(req, res)` handler that expects an already-parsed `req.body`, so any host that hands it that shape works.
+
+Frameworks whose routes use the web `Request` / `Response` API instead, Astro and SvelteKit among them, cannot mount it directly. Host it as a standalone serverless function beside your site:
+
+* [Vercel Functions](/docs/reference/self-hosted/tina-backend/vercel-functions/)
+* [Netlify Functions](/docs/reference/self-hosted/tina-backend/netlify-functions/)
+
+[tina-self-hosted-static-demo](https://github.com/tinacms/tina-self-hosted-static-demo) is a working example of that shape: a static site with the Tina backend as its own function.
+
 ## 5. Update the TinaCMS config
 
 Update the TinaCMS config to use the GraphQL API you created in the previous step.


### PR DESCRIPTION
Closes #4798

**TL;DR** Manual Setup never says what "adjust the code for your framework" actually means, and Existing Site presents a hard Next.js-only limit as if it were a choice.

**Pain:** Manual Setup step 4 shows a Next.js API route and says only "code may need to be adjusted to suit your chosen framework", leaving out the part that matters: `TinaNodeBackend` is a Node `(req, res)` handler expecting an already-parsed `req.body`, so it will not mount in a route whose signature is the web `Request` / `Response` API, which is what Astro's `APIRoute` and SvelteKit's `+server.ts` give you. Separately, Existing Site reads "We offer a CLI init ... or you can take the manual setup approach if you're using another framework", which sounds like a preference. `tinacms init backend` actually errors out on anything but Next.js, and the error links to `https://tina.io/docs/r/self-hosting-nextjs`, which resolves to that same page, so a non-Next.js reader is sent in a circle.

**Solution:** Add a "Hosting it outside Next.js" subsection to Manual Setup step 4 that names the real constraint, the route signature rather than the framework, and gives both shapes that satisfy it: mounting the handler in a Node server, since adapters like `@astrojs/node` in `mode: 'middleware'` expose the same `(req, res)` pair, or deploying it as a standalone serverless function via the existing Vercel and Netlify Functions pages. Reword the Existing Site line so the Next.js-only limit reads as a limit. Both pages keep their code samples unchanged here.