### PR TITLE
🐛 Align the whats-new change rows into columns

### DIFF
--- a/app/whats-new/tinacms/WhatsNewTinaCMSLayout.tsx
+++ b/app/whats-new/tinacms/WhatsNewTinaCMSLayout.tsx
@@ -26,26 +26,26 @@ interface WhatsNewCardProps {
 
 const ChangeItemComponent = ({ change }: { change: ChangeItem }) => {
   return (
-    <li className="mb-3 flex justify-between">
-      <div className="flex items-start gap-2 mb-2">
-        {change.gitHubName && change.gitHubLink && (
-          <>
-            <Link
-              href={change.gitHubLink}
-              className="whitespace-nowrap items-center px-2 py-1 text-xs bg-orange-100 text-orange-500 rounded-md hover:bg-orange-200 transition-colors"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              @{change.gitHubName}
-            </Link>
-            <span>-</span>
-          </>
-        )}
-        {change.changesDescription && (
-          <p className="text-gray-700">{change.changesDescription}</p>
-        )}
-      </div>
-      <div className="flex gap-2 ">
+    <li className="col-span-full grid grid-cols-subgrid items-start">
+      {change.gitHubName && change.gitHubLink && (
+        <>
+          <Link
+            href={change.gitHubLink}
+            className="justify-self-start whitespace-nowrap items-center px-2 py-1 text-xs bg-orange-100 text-orange-500 rounded-md hover:bg-orange-200 transition-colors"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            @{change.gitHubName}
+          </Link>
+          <span>-</span>
+        </>
+      )}
+      {change.changesDescription && (
+        <p className="col-start-3 wrap-anywhere text-gray-700">
+          {change.changesDescription}
+        </p>
+      )}
+      <div className="col-start-4 flex gap-2">
         {change.pull_request_number && change.pull_request_link && (
           <Link
             href={change.pull_request_link}
@@ -95,7 +95,7 @@ export const WhatsNewCard = ({ item }: WhatsNewCardProps) => {
             {section.changesTitle}
           </h3>
           {section.changesList && section.changesList.length > 0 ? (
-            <ul className="space-y-4">
+            <ul className="grid grid-cols-[auto_auto_1fr_auto] gap-x-2 gap-y-4">
               {section.changesList.map((change, changeIndex) => (
                 <ChangeItemComponent
                   key={`change-${changeIndex}-${change.commit_hash || change.gitHubName || 'unknown'}`}


### PR DESCRIPTION
Closes #4811

**TL;DR** Align the change rows on the /whats-new pages into shared columns.

**Pain:** each row's dash and description started wherever the author badge ended, so rows with short usernames (e.g. @kulesy under v3.12.1) began further left than their neighbours and the list read ragged. A long unbreakable token in an entry (the raw "Updated dependencies" URL text on v3.12.1) could also push a row wider than the card.

**Solution:** each row is now a subgrid over shared columns (badge, dash, description, links), so the badge column sizes itself to the widest name per section and every description starts at the same edge. `wrap-anywhere` lets long tokens break instead of widening the shared column past the card. Badge-less rows (Updated Dependencies sections) collapse the empty columns and keep their current left-edge look, and the TinaCloud whats-new page reuses this component so it gets the same fix.

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

🤖 Generated with [Claude Code](https://claude.com/claude-code)