### PR TITLE
🐛 Stop the whats-new change rows collapsing on mobile

### DIFF
--- a/app/whats-new/tinacms/WhatsNewTinaCMSLayout.tsx
+++ b/app/whats-new/tinacms/WhatsNewTinaCMSLayout.tsx
@@ -26,7 +26,7 @@ interface WhatsNewCardProps {
 
 const ChangeItemComponent = ({ change }: { change: ChangeItem }) => {
   return (
-    <li className="col-span-full grid grid-cols-subgrid items-start">
+    <li className="flex flex-wrap items-start gap-2 sm:col-span-full sm:grid sm:grid-cols-subgrid">
       {change.gitHubName && change.gitHubLink && (
         <>
           <Link
@@ -37,15 +37,15 @@ const ChangeItemComponent = ({ change }: { change: ChangeItem }) => {
           >
             @{change.gitHubName}
           </Link>
-          <span>-</span>
+          <span className="hidden sm:block">-</span>
         </>
       )}
       {change.changesDescription && (
-        <p className="col-start-3 wrap-anywhere text-gray-700">
+        <p className="order-last w-full wrap-anywhere text-gray-700 sm:order-none sm:col-start-3 sm:w-auto">
           {change.changesDescription}
         </p>
       )}
-      <div className="col-start-4 flex gap-2">
+      <div className="flex gap-2 sm:col-start-4">
         {change.pull_request_number && change.pull_request_link && (
           <Link
             href={change.pull_request_link}
@@ -95,7 +95,7 @@ export const WhatsNewCard = ({ item }: WhatsNewCardProps) => {
             {section.changesTitle}
           </h3>
           {section.changesList && section.changesList.length > 0 ? (
-            <ul className="grid grid-cols-[auto_auto_1fr_auto] gap-x-2 gap-y-4">
+            <ul className="grid grid-cols-1 gap-x-2 gap-y-4 sm:grid-cols-[auto_auto_1fr_auto]">
               {section.changesList.map((change, changeIndex) => (
                 <ChangeItemComponent
                   key={`change-${changeIndex}-${change.commit_hash || change.gitHubName || 'unknown'}`}


### PR DESCRIPTION
Closes the mobile bug Adam reported on /whats-new/tinacms and /whats-new/tinacloud.

**Pain:** on a phone the description text rendered one character per line.

**Cause:** #4812 made each change row a 4-column grid `[auto auto 1fr auto]`. At phone width the author badge, the dash and the #PR/hash chips take the full row, so the `1fr` description column collapses to a few pixels and `wrap-anywhere` breaks the text letter by letter.

**Solution:** the shared column grid now only applies from `sm` up, so the desktop alignment fix from #4812 is unchanged. Below `sm` each row is a `flex flex-wrap` row — badge and links on the first line, description full width underneath, dash hidden. Both whats-new pages use the same `WhatsNewCard`, so one change covers them.

**Screenshots:**

<img width="148" height="320" alt="image1" src="https://github.com/user-attachments/assets/026c66be-c713-449e-85d8-ca1864ef19f6" />

**Figure: Bad, current mobile UI**

<img width="443" height="783" alt="Screenshot 2026-08-26 at 7 02 08 pm" src="https://github.com/user-attachments/assets/653ce228-61a6-4a28-9fb7-c352cc3012c4" />

**Figure: Fixed mobile UI**


### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

🤖 Generated with [Claude Code](https://claude.com/claude-code)