### PR TITLE
📝 Add Bun to the supported package managers list and recommend PNPM

### DIFF
--- a/content/docs/faq.mdx
+++ b/content/docs/faq.mdx
@@ -34,7 +34,7 @@ Anyone can start using Tina right away but it is designed for developers to setu
 
 TinaCMS is supported on all active LTS versions of Node. See [Node.js Releases](https://nodejs.org/en/about/previous-releases) to find out more about release versions.
 
-NPM, PNPM and Yarn package managers are all supported.
+NPM, PNPM, Yarn and Bun package managers are all supported. We recommend **PNPM**, which is the default in `create-tina-app` and the package manager we use to develop TinaCMS.
 
 | Node Version |                                          |
 | ------------ | ---------------------------------------- |

--- a/content/docs/setup-overview.mdx
+++ b/content/docs/setup-overview.mdx
@@ -15,7 +15,7 @@ Welcome to TinaCMS. This is your guide to getting started with Tina on a new or 
 
 TinaCMS is the best Git-backed headless content management system that enables developers and content creators to collaborate seamlessly. Build a custom visual editing experience designed specifically for your site.
 
-> TinaCMS supports the latest LTS versions of Node.js and works with NPM, PNPM, and Yarn.
+> TinaCMS supports the latest LTS versions of Node.js and all major package managers. We recommend PNPM. See [the FAQ](/docs/faq#4-what-versions-of-node-are-supported) for the full list.
 
 Pick an option below to start exploring.
 


### PR DESCRIPTION
Closes #4818

**TL;DR** Add Bun to the documented list of supported package managers, and name PNPM as the one we recommend.

**Pain:** `create-tina-app` has offered Bun since the December release, but the docs have never mentioned it. Someone running it sees Bun in the prompt and Yarn on the website, and Yarn is not even offered unless they happen to have it installed. The same "supported managers" sentence is duplicated in `setup-overview`, so the list can go stale in two places at once, which is exactly what happened here.

**Solution:** Adds Bun to the FAQ list and names PNPM as the recommendation, since it is the `create-tina-app` default and the package manager we use to develop TinaCMS. `setup-overview` now links to the FAQ instead of restating the list, leaving a single source of truth.

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?