### PR TITLE
🐛 Centre hero buttons on mobile

### DIFF
--- a/components/blocks/Hero/Hero.tsx
+++ b/components/blocks/Hero/Hero.tsx
@@ -31,14 +31,14 @@ export const HeroFeature = ({ item, spacing, children }) => {
       <div className="flex flex-col gap-2">
         {item.headline && item.blockSettings?.isHeadingOne ? (
           <h1
-            className={`${H1_HEADINGS_SIZE} font-ibm-plex  text-center font-bold`}
+            className={`${H1_HEADINGS_SIZE} font-ibm-plex text-center font-bold text-balance`}
             data-tina-field={tinaField(item, 'headline')}
           >
             {item.headline}
           </h1>
         ) : (
           <h2
-            className={`${BLOCK_HEADINGS_SIZE} font-ibm-plex text-black text-center font-bold`}
+            className={`${BLOCK_HEADINGS_SIZE} font-ibm-plex text-black text-center font-bold text-balance`}
             data-tina-field={tinaField(item, 'headline')}
           >
             {item.headline}
@@ -46,7 +46,7 @@ export const HeroFeature = ({ item, spacing, children }) => {
         )}
         {item.headline2 && (
           <h2
-            className={`${BLOCK_HEADINGS_SIZE} font-ibm-plex text-black text-center font-bold`}
+            className={`${BLOCK_HEADINGS_SIZE} font-ibm-plex text-black text-center font-bold text-balance`}
             data-tina-field={tinaField(item, 'headline2')}
           >
             {item.headline2}
@@ -66,7 +66,7 @@ export const HeroFeature = ({ item, spacing, children }) => {
       {/* items-center on mobile: the column's cross axis is horizontal, so
           items-start pinned the buttons left under a centred headline. */}
       {item.buttons?.length > 0 && (
-        <div className="flex flex-col md:grid md:grid-cols-2 lg:flex lg:flex-row justify-center items-center md:items-start lg:items-center gap-10 pb-10">
+        <div className="flex flex-col md:grid md:grid-cols-2 lg:flex lg:flex-row justify-center items-center md:items-start lg:items-center gap-4 md:gap-10 pb-10">
           {/* Tina's button objects have no `id`, so key on the label. */}
           {item.buttons.map((button, index) => (
             <div

--- a/components/blocks/Hero/Hero.tsx
+++ b/components/blocks/Hero/Hero.tsx
@@ -63,8 +63,10 @@ export const HeroFeature = ({ item, spacing, children }) => {
       )}
       {/* Skipped entirely when there are no buttons — the row's own pb-10 would
           otherwise leave a dead gap under a text-only hero. */}
+      {/* items-center on mobile: the column's cross axis is horizontal, so
+          items-start pinned the buttons left under a centred headline. */}
       {item.buttons?.length > 0 && (
-        <div className="flex flex-col md:grid md:grid-cols-2 lg:flex lg:flex-row justify-center items-start lg:items-center gap-10 pb-10">
+        <div className="flex flex-col md:grid md:grid-cols-2 lg:flex lg:flex-row justify-center items-center md:items-start lg:items-center gap-10 pb-10">
           {/* Tina's button objects have no `id`, so key on the label. */}
           {item.buttons.map((button, index) => (
             <div


### PR DESCRIPTION
Closes #4783

**TL;DR** Centre the hero button row on mobile, where the column layout was pinning it to the left edge. Tablet and desktop stay pixel-identical.

**Pain:** on a phone the hero buttons sit hard against the left edge under a centred headline and paragraph, so the block reads as broken. Visible on /partners and /forestry.

**Solution:** centres the buttons on the cross axis at the mobile breakpoint only, leaving the tablet grid and desktop row alone.

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
