### PR TITLE
Brand: use TinaCMS in site title / sidebar title config

### DIFF
--- a/content/settings/config.json
+++ b/content/settings/config.json
@@ -1,7 +1,7 @@
 {
-  "title": "Tina",
+  "title": "TinaCMS",
   "description": "TinaCMS is a fully open-source headless CMS that supports Git",
-  "sidebarTitle": "Tina",
+  "sidebarTitle": "TinaCMS",
   "seoDefaultTitle": "TinaCMS – Headless CMS with GitHub & Markdown Support",
   "publisher": "TinaCMS",
   "applicationName": "Tina.io",

--- a/content/siteConfig.json
+++ b/content/siteConfig.json
@@ -1,6 +1,6 @@
 {
-  "title": "Tina",
-  "sidebarTitle": "Tina",
+  "title": "TinaCMS",
+  "sidebarTitle": "TinaCMS",
   "seoDefaultTitle": "TinaCMS – Headless CMS with GitHub & Markdown Support",
   "description": "TinaCMS is a fully open-source headless CMS that supports Git",
   "siteUrl": "https://tina.io",


### PR DESCRIPTION
Part of #4845.

## Summary

First (smallest, highest-impact) step in the brand-consistency cleanup: replaces standalone "Tina" with "TinaCMS" in the site's `title` / `sidebarTitle` config. These fields flow into `<title>` tags and other site-wide chrome, so this single change fixes the most visible "Tina" occurrences without touching a single blog post or doc.

## Change

- `content/siteConfig.json` — `title` and `sidebarTitle` → `"TinaCMS"`
- `content/settings/config.json` — `title` and `sidebarTitle` → `"TinaCMS"`

Nothing else in these files is touched — `applicationName: "Tina.io"`, `description`, `seoDefaultTitle`, redirects, socials, etc. all unchanged.

## Follow-ups (from #4845)

The remaining ~1,380 in-content occurrences (blog, docs, `main/`, Chinese content) are intentionally not in this PR — they need per-file review because some usages ("Meet Tina", historic blog titles, mascot voice) should stay as "Tina". Those will come as separate scoped PRs.

## Test plan

- [ ] Preview deploy → confirm browser tab / OG title now reads "TinaCMS" where it used to read "Tina".
- [ ] Confirm no visual regression on pages that read `sidebarTitle` (nav sidebars, docs sidebar header if applicable).
