### PR TITLE
Brand: 'Tina' -> 'TinaCMS/Cloud/Docs' in TOC, pages, examples, whats-new, nav (26 hits)

### DIFF
--- a/content/docs-toc/docs-toc.json
+++ b/content/docs-toc/docs-toc.json
@@ -34,10 +34,10 @@
           "_template": "item"
         },
         {
-          "title": "Getting Started with Tina",
+          "title": "Getting Started with TinaCMS",
           "items": [
             {
-              "title": "Tina Starter - CLI",
+              "title": "TinaCMS Starter - CLI",
               "slug": "content/docs/introduction/using-starter.mdx",
               "_template": "item"
             },
@@ -777,7 +777,7 @@
                   "_template": "item"
                 },
                 {
-                  "title": "Tina Cloud",
+                  "title": "TinaCloud",
                   "slug": "content/docs/reference/self-hosted/auth-provider/tinacloud.mdx",
                   "_template": "item"
                 },

--- a/content/docs-toc/docs-zh-toc.json
+++ b/content/docs-toc/docs-zh-toc.json
@@ -626,7 +626,7 @@
                   "_template": "item"
                 },
                 {
-                  "title": "Tina Cloud",
+                  "title": "TinaCloud",
                   "slug": "content/zh/docs/reference/self-hosted/auth-provider/tinacloud.mdx",
                   "_template": "item"
                 },

--- a/content/docs-toc/learn-toc.json
+++ b/content/docs-toc/learn-toc.json
@@ -143,7 +143,7 @@
           "_template": "item"
         },
         {
-          "title": "Using Tina as a Website Builder",
+          "title": "Using TinaCMS as a Website Builder",
           "slug": "content/docs/editing/blocks.mdx",
           "_template": "item"
         },
@@ -153,7 +153,7 @@
           "_template": "item"
         },
         {
-          "title": "Querying Tina Content at Runtime",
+          "title": "Querying TinaCMS Content at Runtime",
           "slug": "content/docs/guides/react-data-fetching.mdx",
           "_template": "item"
         },
@@ -221,12 +221,12 @@
               "title": "NextJS",
               "items": [
                 {
-                  "title": "Querying Tina Content in NextJS",
+                  "title": "Querying TinaCMS Content in NextJS",
                   "slug": "content/docs/guides/nextjs-data-fetching.mdx",
                   "_template": "item"
                 },
                 {
-                  "title": "Internationalization with NextJS+Tina",
+                  "title": "Internationalization with NextJS+TinaCMS",
                   "slug": "content/docs/guides/nextjs-internationalization.mdx",
                   "_template": "item"
                 },

--- a/content/examples/index.json
+++ b/content/examples/index.json
@@ -1,7 +1,7 @@
 {
   "examples": [
     {
-      "label": "Tina NextJS Starter",
+      "label": "TinaCMS NextJS Starter",
       "description": "A Next.js blog site built with TinaCMS.\n",
       "image": "/img/Tina_Cloud_Starter_pxdxfu.png",
       "link": "https://github.com/tinacms/tina-cloud-starter"
@@ -13,26 +13,26 @@
       "link": "https://github.com/tinacms/tina-react-starter"
     },
     {
-      "label": "Tina Self Hosted Demo",
+      "label": "TinaCMS Self Hosted Demo",
       "description": "A demo of how to use self-hosted TinaCMS with Nextjs.\\\n\\\nUses\n\n* Vercel KV\n* GitHub\n* Auth.js\n",
       "image": "/img/Tina_Self_Hosted_Demo_k4vpql.png",
       "link": "https://github.com/tinacms/tina-self-hosted-demo"
     },
     {
-      "label": "Tina Remix Starter",
+      "label": "TinaCMS Remix Starter",
       "description": "An example of how to use TinaCMS and remix.\n",
       "image": "/img/Tina_Remix_w3cpe4.png",
       "link": "https://github.com/tinacms/tina-remix-starter"
     },
     {
-      "label": "Tina Hugo Starter",
+      "label": "TinaCMS Hugo Starter",
       "description": "A starter showing how TinaCMS can be used with a static site generator like hugo. This starter could be modified to use any SSG.\n",
       "image": "/img/Tina_Hugo_Starter_bwulx5.png",
       "link": "https://github.com/tinacms/tina-hugo-starter"
     },
     {
-      "label": "Tina Self Hosted SSG Demo",
-      "description": "This demo shows how self hosted Tina works with static site generators. This demo uses 11ty but could be adapted to use any SSG.\n",
+      "label": "TinaCMS Self Hosted SSG Demo",
+      "description": "This demo shows how self hosted TinaCMS works with static site generators. This demo uses 11ty but could be adapted to use any SSG.\n",
       "image": "/img/Tina_Static_Starter_Self_Hosted_kknsnf.png",
       "link": "https://github.com/tinacms/tina-self-hosted-ssg-demo"
     },

--- a/content/navigationBar/navMenu.json
+++ b/content/navigationBar/navMenu.json
@@ -114,7 +114,7 @@
       "label": "About",
       "items": [
         {
-          "label": "About Tina",
+          "label": "About TinaCMS",
           "href": "/about"
         },
         {

--- a/content/pages/community.json
+++ b/content/pages/community.json
@@ -1,7 +1,7 @@
 {
   "title": "Community",
   "headline": "Join the club",
-  "description": "Tina is open source, extensible and community driven. Join the club.",
+  "description": "TinaCMS is open source, extensible and community driven. Join the club.",
   "gif": {
     "src": "/img/rico-replacement.jpg",
     "alt": "Join the club"
@@ -28,7 +28,7 @@
       "supporting_body": ""
     }
   },
-  "newsletter_header": "Tina Newsletter",
+  "newsletter_header": "TinaCMS Newsletter",
   "newsletter_cta": "We move quick. Stay up to date.",
   "img": {
     "src": "/img/rico-replacement.jpg",

--- a/content/pages/teams.json
+++ b/content/pages/teams.json
@@ -1,7 +1,7 @@
 {
   "title": "Early Access",
-  "description": "The power of Tina for the whole team",
-  "headline": "The power of Tina for the whole team",
+  "description": "The power of TinaCMS for the whole team",
+  "headline": "The power of TinaCMS for the whole team",
   "supporting_points": [
     {
       "_template": "point",
@@ -24,12 +24,12 @@
       "alt": "Join the club"
     },
     "supporting_headline": "Open source, extensible and community driven",
-    "supporting_body": "Tina is made better by the wisdom of crowds. blah blah blah. "
+    "supporting_body": "TinaCMS is made better by the wisdom of crowds. blah blah blah. "
   },
   "gif": {
     "src": "/img/rico-replacement.jpg",
     "alt": "Join the club"
   },
   "supporting_headline": "Open source, extensible and community driven",
-  "supporting_body": "Tina is made better by the wisdom of crowds. blah blah blah. "
+  "supporting_body": "TinaCMS is made better by the wisdom of crowds. blah blah blah. "
 }

--- a/content/whats-new-tinacloud/2025.08.0.json
+++ b/content/whats-new-tinacloud/2025.08.0.json
@@ -6,7 +6,7 @@
       "changesTitle": "✨ Features",
       "changesList": [
         {
-          "changesDescription": "Quick Start - Adding Tina Docs Template",
+          "changesDescription": "Quick Start - Adding TinaDocs Template",
           "gitHubName": "amankumarrr",
           "gitHubLink": "https://github.com/amankumarrr"
         }

--- a/content/whats-new-tinacloud/2025.08.0.mdx
+++ b/content/whats-new-tinacloud/2025.08.0.mdx
@@ -7,7 +7,7 @@ dateReleased: 2025-08-04T23:18:30Z
 
 ## What's Changed
 ### ✨ Features
-* Quick Start - Adding Tina Docs Template by @amankumarrr
+* Quick Start - Adding TinaDocs Template by @amankumarrr
 
 ### 👒 Dependencies
 * chore(deps): bump form-data from 4.0.2 to 4.0.4 by @dependabot[bot]

--- a/content/whats-new-tinacloud/2026.08.6.json
+++ b/content/whats-new-tinacloud/2026.08.6.json
@@ -51,7 +51,7 @@
           "gitHubLink": "https://github.com/Aibono1225"
         },
         {
-          "changesDescription": "Fix projects wedged when Tina config is missing on the default branch",
+          "changesDescription": "Fix projects wedged when TinaCMS config is missing on the default branch",
           "gitHubName": "Aibono1225",
           "gitHubLink": "https://github.com/Aibono1225"
         },

--- a/content/whats-new-tinacms/v3.5.0.json
+++ b/content/whats-new-tinacms/v3.5.0.json
@@ -6,7 +6,7 @@
       "changesTitle": "Minor Changes",
       "changesList": [
         {
-          "changesDescription": "Telemetry - We’ve added anonymous telemetry to help us understand how Tina is used and prioritize improvements in areas where it matters. No personal or sensitive data is collected, and the information cannot be used to identify individual users. Telemetry is used solely to improve performance, stability, and the overall user experience. You can opt-out at any time by disabling telemetry in your Tina config.",
+          "changesDescription": "Telemetry - We’ve added anonymous telemetry to help us understand how TinaCMS is used and prioritize improvements in areas where it matters. No personal or sensitive data is collected, and the information cannot be used to identify individual users. Telemetry is used solely to improve performance, stability, and the overall user experience. You can opt-out at any time by disabling telemetry in your TinaCMS config.",
           "pull_request_number": "6438",
           "pull_request_link": "https://github.com/tinacms/tinacms/pull/6438",
           "commit_hash": "f90d47b",

--- a/content/whats-new-tinacms/v3.9.0.json
+++ b/content/whats-new-tinacms/v3.9.0.json
@@ -15,7 +15,7 @@
           "gitHubLink": "https://github.com/JackDevAU"
         },
         {
-          "changesDescription": "Support Tina media uploads and deletes in the editorial workflow on protected branches. Media changes now prompt for a branch, write to that branch, switch the editor to it after the media operation succeeds, and continue through indexing and pull request creation with the same workflow progress UI as content edits.",
+          "changesDescription": "Support TinaCMS media uploads and deletes in the editorial workflow on protected branches. Media changes now prompt for a branch, write to that branch, switch the editor to it after the media operation succeeds, and continue through indexing and pull request creation with the same workflow progress UI as content edits.",
           "pull_request_number": "6902",
           "pull_request_link": "https://github.com/tinacms/tinacms/pull/6902",
           "commit_hash": "b9d561f",


### PR DESCRIPTION
Part of #4845 (batch 2 of the standalone-`Tina` cleanup — small config/schema JSONs).

## Summary

Reviewed 30 standalone `Tina` occurrences across TOC/nav/pages/examples/what's-new JSONs and applied 26 changes → the appropriate brand name. Most go to `TinaCMS`, a few to `TinaCloud` / `TinaDocs` where the reference is to those specific products.

## What changed (26 hits across 12 files)

### → `TinaCMS`

| File | Where | Change |
|---|---|---|
| `docs-toc/learn-toc.json` (×4) | TOC section titles | "Using Tina as a Website Builder" / "Querying Tina Content at Runtime" / "Querying Tina Content in NextJS" / "Internationalization with NextJS+Tina" |
| `docs-toc/docs-toc.json` (×2) | TOC section titles | "Getting Started with Tina" / "Tina Starter - CLI" |
| `pages/community.json` (×2) | Page description + newsletter header | "Tina is open source…" / "Tina Newsletter" |
| `pages/teams.json` (×3) | Description, headline, supporting body | All variants of "…of Tina for the whole team" / "Tina is made better by…" |
| `examples/index.json` (×6) | Starter/demo labels + one description | "Tina NextJS Starter", "Tina Self Hosted Demo", "Tina Remix Starter", "Tina Hugo Starter", "Tina Self Hosted SSG Demo" (+ its description) |
| `whats-new-tinacloud/2026.08.6.json` | Release-note bullet | "Fix projects wedged when Tina config is missing…" |
| `whats-new-tinacms/v3.5.0.json` (×2 on one line) | Telemetry release note | "how Tina is used" and "disabling telemetry in your Tina config" |
| `whats-new-tinacms/v3.9.0.json` | Release-note bullet | "Support Tina media uploads…" |
| `navigationBar/navMenu.json` | Nav label | "About Tina" → "About TinaCMS" |

### → `TinaCloud` (product-name normalization)

| File | Change |
|---|---|
| `docs-toc/docs-toc.json` | `"Tina Cloud"` → `"TinaCloud"` |
| `docs-toc/docs-zh-toc.json` | `"Tina Cloud"` → `"TinaCloud"` (English string inside a Chinese TOC) |

### → `TinaDocs` (product-name normalization)

| File | Change |
|---|---|
| `whats-new-tinacloud/2025.08.0.mdx` | `"Tina Docs Template"` → `"TinaDocs Template"` |
| `whats-new-tinacloud/2025.08.0.json` | same (JSON mirror of the mdx) |

## Intentionally NOT changed (4 hits)

| File:line | Text | Why |
|---|---|---|
| `docs-toc/docs-toc.json:811` | `"Tina's Edit State"` | Entrenched doc/section title; "TinaCMS's Edit State" reads awkward as a title |
| `whats-new-tinacloud/2025.07.10.mdx:20` | `"Add JSON validation for Tina lock"` | "Tina lock" refers to the `tina-lock.json` file (technical filename convention) |
| `whats-new-tinacloud/2025.07.10.json:59` | same (JSON mirror of the mdx) | same reason |
| `events/master-events.json:6` | `"Where's Tina?"` | Mascot / friendly voice (like "Where's Waldo?") |

## Verify

```bash
# After merge, only the 4 intentional survivors above should remain:
grep -rnP "\bTina\b" \
  content/docs-toc/ content/pages/ content/examples/ \
  content/whats-new-tinacloud/ content/whats-new-tinacms/ \
  content/navigationBar/ content/events/ \
  | grep -vE "TinaCMS|TinaCloud|TinaDocs|TinaGPT|TinaTeach|Tina\.io|Tina-Docs|Tina-Cloud|Tina-CMS|Tina Teams|Tina CMS"
```

## Test plan

- [ ] Preview deploy → `/community`, `/teams`, `/examples`, `/whats-new` — copy renders "TinaCMS" where changed.
- [ ] Docs sidebar / TOC titles now read "Getting Started with TinaCMS", "Using TinaCMS as a Website Builder", etc.
- [ ] `/whats-new/tinacloud/2025.08.0` release note reads "TinaDocs Template".
- [ ] Main nav still has an "About TinaCMS" entry.
