### PR TITLE
Brand: 'Tina' -> 'TinaCMS' in docs/{frameworks,tinacloud,self-hosted} (80 hits)

### DIFF
--- a/content/docs/frameworks/11ty.mdx
+++ b/content/docs/frameworks/11ty.mdx
@@ -24,7 +24,7 @@ This will ask you a few setup questions.
 
 ## Model your content
 
-To edit your site's content in Tina, you can model your content in the tina/config.ts file.
+To edit your site's content in TinaCMS, you can model your content in the tina/config.ts file.
 
 Learn more about [content modelling](/docs/schema/)
 
@@ -44,7 +44,7 @@ With TinaCMS running, navigate to `http://localhost:8080/admin/index.html`
 
 > Hint: If you are getting error when running this command please see the [Common Errors](/docs/forestry/common-errors) page.
 
-At this point, you should be able to see the Tina admin, select a post, save changes, and see the changes persisted to your local markdown files.
+At this point, you should be able to see the TinaCMS admin, select a post, save changes, and see the changes persisted to your local markdown files.
 
 ![](/img/hugo-tina-admin-screenshot.png)
 

--- a/content/docs/frameworks/astro.mdx
+++ b/content/docs/frameworks/astro.mdx
@@ -50,11 +50,11 @@ Answer the prompts:
 |---|---|
 | Which framework is your existing site built with? | **Astro** |
 | Choose your package manager | *the one your site uses* |
-| Would you like to use TypeScript for your Tina configuration? | **Yes** |
+| Would you like to use TypeScript for your TinaCMS configuration? | **Yes** |
 
 > `init` adds TinaCMS to an **existing** site. Run it in an empty folder and it stops and points you to Option 1.
 
-`init` installs `@tinacms/astro` + an SSR adapter, wraps your `dev` / `build` scripts, and adds new files: a ready-to-edit demo at **`/tinacms-demo`**, your `tina/` config, and one sample collection. It won't overwrite your content, and it leaves a customized `astro.config` alone (an empty or default config gets the Tina wiring).
+`init` installs `@tinacms/astro` + an SSR adapter, wraps your `dev` / `build` scripts, and adds new files: a ready-to-edit demo at **`/tinacms-demo`**, your `tina/` config, and one sample collection. It won't overwrite your content, and it leaves a customized `astro.config` alone (an empty or default config gets the TinaCMS wiring).
 
 Start the dev server:
 
@@ -117,7 +117,7 @@ pnpm add @astrojs/node          # or @astrojs/vercel / netlify / cloudflare
 
 `@astrojs/node` is the safe default for local editing. Match it to your host (Vercel, Netlify, Cloudflare) when you deploy.
 
-Add the Tina integration and an SSR adapter to `astro.config.mjs`. If you already have an `integrations` array or an adapter, **keep them** and just append `tina()`.
+Add the TinaCMS integration and an SSR adapter to `astro.config.mjs`. If you already have an `integrations` array or an adapter, **keep them** and just append `tina()`.
 
 > **Not sure how to merge it?** Copy the version `init` printed in your terminal, or compare your file against the snippet below and keep your existing integrations and adapter.
 
@@ -150,7 +150,7 @@ pnpm dev
 
 ## Make your existing Astro pages editable
 
-Right after `init`, **`/tinacms-demo` is the only page wired for Tina editing**. It's a working template for the rest of your site: copy the same pattern into your existing pages and components. (An *island* is just an editable section of a page.) Each editable page wires these five things, all scaffolded for the demo:
+Right after `init`, **`/tinacms-demo` is the only page wired for TinaCMS editing**. It's a working template for the rest of your site: copy the same pattern into your existing pages and components. (An *island* is just an editable section of a page.) Each editable page wires these five things, all scaffolded for the demo:
 
 1. **A field in your schema** (`tina/config.ts`): whatever you want to edit.
 2. **A data loader**: wrap the query in `requestWithMetadata()`.

--- a/content/docs/frameworks/gatsby.mdx
+++ b/content/docs/frameworks/gatsby.mdx
@@ -1,6 +1,6 @@
 ---
 id: /docs/frameworks/gatsby
-title: Gatsby + Tina Setup Guide
+title: Gatsby + TinaCMS Setup Guide
 last_edited: '2025-10-21T09:41:02.906Z'
 next: content/docs/frameworks/jekyll.mdx
 previous: content/docs/frameworks/hugo.mdx
@@ -10,7 +10,7 @@ previous: content/docs/frameworks/hugo.mdx
 
 TinaCMS can be added to your Gatsby site locally. In this doc, we'll guide through the local setup, as well as editing on your production site.
 
-> You can reference our [Tina Gatsby Starter](https://github.com/tinacms/tina-gatsby-starter) for an example.
+> You can reference our [TinaCMS Gatsby Starter](https://github.com/tinacms/tina-gatsby-starter) for an example.
 
 ## Getting Started
 
@@ -43,13 +43,13 @@ To work around this, add the following lines to your **package.json** file.
 +  },
 ```
 
-That way you can force the graphql version to be the one Tina needs.
+That way you can force the graphql version to be the one TinaCMS needs.
 
 > To be sure which version you need, you can run `npm list graphql` in your project folder
 
 ### Allowing static `/admin/index.html` file in dev-mode
 
-To make Tina admin accessible in dev-mode, you will need to add the following code to your **gatsby-node.ts** file.
+To make TinaCMS admin accessible in dev-mode, you will need to add the following code to your **gatsby-node.ts** file.
 
 ```diff
 + import express, { Express } from "express";
@@ -61,7 +61,7 @@ To make Tina admin accessible in dev-mode, you will need to add the following co
 
 ## Model your content
 
-To edit your site's content in Tina, you can model your content in the tina/config.ts file.
+To edit your site's content in TinaCMS, you can model your content in the tina/config.ts file.
 
 Learn more about [content modelling](/docs/schema/)
 
@@ -81,7 +81,7 @@ With TinaCMS running, navigate to `http://localhost:8000/admin/index.html`
 
 > Hint: One common error is caused by running `gatsby clean` **after** `tinacms build`. This causes your admin html file to be wiped out. For more common errors, please see the [Common Errors](/docs/forestry/common-errors) page.
 
-At this point, you should be able to see the Tina admin, select a post, save changes, and see the changes persisted to your local markdown files.
+At this point, you should be able to see the TinaCMS admin, select a post, save changes, and see the changes persisted to your local markdown files.
 
 ![](/img/hugo-tina-admin-screenshot.png)
 
@@ -103,6 +103,6 @@ Read more about [data fetching](/docs/features/data-fetching/) and [visual editi
 
 ## See Also
 
-* [Astro setup guide](/docs/frameworks/astro/) - Using Tina with Astro (our default starter)
-* [Next.js setup guide](/docs/frameworks/next/app-router/) - Using Tina with Next.js
+* [Astro setup guide](/docs/frameworks/astro/) - Using TinaCMS with Astro (our default starter)
+* [Next.js setup guide](/docs/frameworks/next/app-router/) - Using TinaCMS with Next.js
 * [Visual Editing setup](/docs/contextual-editing/overview/) - Enable live preview editing

--- a/content/docs/frameworks/hugo.mdx
+++ b/content/docs/frameworks/hugo.mdx
@@ -10,7 +10,7 @@ previous: content/docs/frameworks/next/pages-router.mdx
 
 TinaCMS can be added to your Hugo site locally. In this doc, we'll guide through the local setup, as well as editing on your production site.
 
-> You can reference our [Tina Hugo Starter](https://github.com/tinacms/tina-hugo-starter) for an example.
+> You can reference our [TinaCMS Hugo Starter](https://github.com/tinacms/tina-hugo-starter) for an example.
 
 ## Getting Started
 
@@ -28,7 +28,7 @@ When prompted for the "**public assets directory**", enter: **static**.
 
 ## Model your content
 
-To edit your site's content in Tina, you can model your content in the tina/config.ts file.
+To edit your site's content in TinaCMS, you can model your content in the tina/config.ts file.
 
 Learn more about [content modelling](/docs/schema/)
 
@@ -48,7 +48,7 @@ With TinaCMS running, navigate to `http://localhost:1313/admin`
 
 > Hint: If you are getting error when running this command please see the [Common Errors](/docs/forestry/common-errors) page.
 
-At this point, you should be able to see the Tina admin, select a post, save changes, and see the changes persisted to your local markdown files.
+At this point, you should be able to see the TinaCMS admin, select a post, save changes, and see the changes persisted to your local markdown files.
 
 ![](/img/hugo-tina-admin-screenshot.png)
 
@@ -60,6 +60,6 @@ At this point, you should be able to see the Tina admin, select a post, save cha
 
 ## See Also
 
-* [Next.js setup guide](/docs/frameworks/next/app-router/) - Using Tina with Next.js
-* [Astro setup guide](/docs/frameworks/astro/) - Using Tina with Astro
-* [Gatsby setup guide](/docs/frameworks/gatsby/) - Using Tina with Gatsby
+* [Next.js setup guide](/docs/frameworks/next/app-router/) - Using TinaCMS with Next.js
+* [Astro setup guide](/docs/frameworks/astro/) - Using TinaCMS with Astro
+* [Gatsby setup guide](/docs/frameworks/gatsby/) - Using TinaCMS with Gatsby

--- a/content/docs/frameworks/jekyll.mdx
+++ b/content/docs/frameworks/jekyll.mdx
@@ -26,7 +26,7 @@ When prompted for the "**public assets directory**", enter: "**./**".
 
 ## Model your content
 
-To edit your site's content in Tina, you can model your content in the tina/config.ts file.
+To edit your site's content in TinaCMS, you can model your content in the tina/config.ts file.
 
 Learn more about [content modelling](/docs/schema/)
 
@@ -46,7 +46,7 @@ With TinaCMS running, navigate to `http://localhost:4000/admin/index.html`
 
 > Hint: If you are getting error when running this command please see the [Common Errors](/docs/forestry/common-errors) page.
 
-At this point, you should be able to see the Tina admin, select a post, save changes, and see the changes persisted to your local markdown files.
+At this point, you should be able to see the TinaCMS admin, select a post, save changes, and see the changes persisted to your local markdown files.
 
 ![](/img/hugo-tina-admin-screenshot.png)
 

--- a/content/docs/frameworks/next/app-router.mdx
+++ b/content/docs/frameworks/next/app-router.mdx
@@ -53,7 +53,7 @@ With TinaCMS running, navigate to `http://localhost:3000/admin/index.html`.
 
 > ❓ Hint: If you are getting errors when running this command, please see the [Common Errors](/docs/forestry/common-errors) page.
 
-At this point, you should be able to see the Tina admin, select a post, save changes, and see the changes persisted to your local markdown files.
+At this point, you should be able to see the TinaCMS admin, select a post, save changes, and see the changes persisted to your local markdown files.
 
 ![TinaCMS Admin Screenshot](/img/hugo-tina-admin-screenshot.png)
 

--- a/content/docs/frameworks/next/pages-router.mdx
+++ b/content/docs/frameworks/next/pages-router.mdx
@@ -53,7 +53,7 @@ With TinaCMS running, navigate to `http://localhost:3000/admin/index.html`.
 
 > ❓ Hint: If you are getting errors when running this command, please see the [Common Errors](/docs/forestry/common-errors) page.
 
-At this point, you should be able to see the Tina admin, select a post, save changes, and see the changes persisted to your local markdown files.
+At this point, you should be able to see the TinaCMS admin, select a post, save changes, and see the changes persisted to your local markdown files.
 
 ![TinaCMS Admin Screenshot](/img/hugo-tina-admin-screenshot.png)
 

--- a/content/docs/frameworks/other.mdx
+++ b/content/docs/frameworks/other.mdx
@@ -48,7 +48,7 @@ These should be applied manually if they haven't been set by the CLI.
 
 ## Model your content
 
-To edit your site's content in Tina, you can model your content in the tina/config.ts file.
+To edit your site's content in TinaCMS, you can model your content in the tina/config.ts file.
 
 Learn more about [content modelling](/docs/schema/)
 
@@ -72,7 +72,7 @@ With TinaCMS running, navigate to `http://localhost:3000/admin/index.html`
   </>}
 />
 
-At this point, you should be able to see the Tina admin, select a post, save changes, and see the changes persisted to your local markdown files.
+At this point, you should be able to see the TinaCMS admin, select a post, save changes, and see the changes persisted to your local markdown files.
 
 ![](/img/hugo-tina-admin-screenshot.png)
 

--- a/content/docs/frameworks/remix.mdx
+++ b/content/docs/frameworks/remix.mdx
@@ -1,6 +1,6 @@
 ---
 id: /docs/frameworks/remix
-title: Remix + Tina Setup Guide
+title: Remix + TinaCMS Setup Guide
 last_edited: '2025-10-21T09:40:01.270Z'
 next: ''
 previous: ''
@@ -10,7 +10,7 @@ previous: ''
 
 TinaCMS can be added to your Remix site locally. In this doc, we'll guide through the local setup, as well as editing on your production site.
 
-> You can reference our [Tina Remix Starter](https://github.com/tinacms/tina-remix-starter) for an example.
+> You can reference our [TinaCMS Remix Starter](https://github.com/tinacms/tina-remix-starter) for an example.
 
 ## Getting Started
 
@@ -26,7 +26,7 @@ When prompted for the "**public assets directory**", enter: **public**.
 
 ## Model your content
 
-To edit your site's content in Tina, you can model your content in the tina/config.ts file.
+To edit your site's content in TinaCMS, you can model your content in the tina/config.ts file.
 
 Learn more about [content modelling](/docs/schema/)
 
@@ -46,19 +46,19 @@ With TinaCMS running, navigate to `http://localhost:3000/admin/index.html`
 
 > Hint: If you are getting error when running this command please see the [Common Errors](/docs/forestry/common-errors) page.
 
-At this point, you should be able to see the Tina admin, select a post, save changes, and see the changes persisted to your local markdown files.
+At this point, you should be able to see the TinaCMS admin, select a post, save changes, and see the changes persisted to your local markdown files.
 
 ![](/img/hugo-tina-admin-screenshot.png)
 
 ## Data-fetching in your pages
 
-Tina offers an easy-to-use client for data-fetching your content.
+TinaCMS offers an easy-to-use client for data-fetching your content.
 
 Read more about [data fetching here](/docs/features/data-fetching/).
 
 ## Setting up Visual Editing (Optional)
 
-For pages powered by Tina's content API, your pages with TinaCMS's you may want to leverage TinaCMS's visual editing features.
+For pages powered by TinaCMS's content API, your pages with TinaCMS's you may want to leverage TinaCMS's visual editing features.
 
 ![block-based-editing-visual](/gif/blocks.gif)
 

--- a/content/docs/frameworks/sveltekit.mdx
+++ b/content/docs/frameworks/sveltekit.mdx
@@ -35,15 +35,15 @@ This will ask you a few setup questions.
 
 ## Move static files
 
-TinaCMS assumes your static files are in the `public` directory. However, SvelteKit serves static files from the `static` directory. You'll need to ensure Tina is configured to use this directory.
+TinaCMS assumes your static files are in the `public` directory. However, SvelteKit serves static files from the `static` directory. You'll need to ensure TinaCMS is configured to use this directory.
 
 Confirm you have both directories under `static`:
 
 ```bash
- # Tina admin
+ # TinaCMS admin
  static/admin/index.html
  
- # Tina media/images
+ # TinaCMS media/images
  static/images
 ```
 
@@ -82,7 +82,7 @@ export default defineConfig({
 
 ## Model your content
 
-To edit your site's content in Tina, you can model your content in the `tina/config.ts` file.
+To edit your site's content in TinaCMS, you can model your content in the `tina/config.ts` file.
 
 Learn more about [content modelling](/docs/schema/)
 
@@ -98,7 +98,7 @@ With TinaCMS running, navigate to `http://localhost:5173/admin/index.html`
 
 > Hint: If you encounter an error when running this command, please see the [Common Errors](/docs/forestry/common-errors) page.
 
-At this point, you should be able to see the Tina admin, select a post, save changes, and see the changes persisted to your local markdown files.
+At this point, you should be able to see the TinaCMS admin, select a post, save changes, and see the changes persisted to your local markdown files.
 
 ![](/img/hugo-tina-admin-screenshot.png)
 

--- a/content/docs/self-hosted/existing-site.mdx
+++ b/content/docs/self-hosted/existing-site.mdx
@@ -9,7 +9,7 @@ next: content/docs/self-hosted/manual-setup.mdx
 previous: content/docs/self-hosted/starters/nextjs-vercel.mdx
 ---
 
-If you want to self-host the Tina backend, and don't want to use our [pre-configured starter](/docs/self-hosted/starters/nextjs-vercel/), you can follow the steps below.
+If you want to self-host the TinaCMS backend, and don't want to use our [pre-configured starter](/docs/self-hosted/starters/nextjs-vercel/), you can follow the steps below.
 
 We offer a CLI init to quickly set up the backend, but **it supports Next.js only**. On any other framework, Astro included, `tinacms init backend` stops with an error and points you at this page. If you are not on Next.js, follow the [manual setup approach](/docs/self-hosted/manual-setup/) instead.
 
@@ -19,7 +19,7 @@ We offer a CLI init to quickly set up the backend, but **it supports Next.js onl
 
 ## Setup
 
-If you already have Tina Setup in your project, make sure has the latest version of all tina packages.
+If you already have TinaCMS Setup in your project, make sure has the latest version of all tina packages.
 
 In the terminal, run:
 

--- a/content/docs/self-hosted/manual-setup.mdx
+++ b/content/docs/self-hosted/manual-setup.mdx
@@ -81,7 +81,7 @@ export default isLocal
     })
 ```
 
-## 4. Host the Tina Backend
+## 4. Host the TinaCMS Backend
 
 You will need a [backend endpoint](/docs/reference/self-hosted/tina-backend/nextjs) that hosts the GraphQL and auth api endpoints.
 

--- a/content/docs/self-hosted/overview.mdx
+++ b/content/docs/self-hosted/overview.mdx
@@ -1,7 +1,7 @@
 ---
 cmsUsageWarning: >-
   https://github.com/tinacms/tinacms/blob/main/packages/tinacms-authjs/src/index.ts
-title: Self-hosting Tina
+title: Self-hosting TinaCMS
 alias: self-hosting-overview
 last_edited: '2025-10-20T00:37:05.999Z'
 next: content/docs/self-hosted/starters/nextjs-vercel.mdx
@@ -14,9 +14,9 @@ For users who do not wish to host their CMS backend on TinaCloud, **we provide a
 
 > Want to jump into the code? Check out the [Self-hosted Starter Docs](/docs/self-hosted/starters/nextjs-vercel/).
 
-## What is the Tina Data Layer
+## What is the TinaCMS Data Layer
 
-The [Tina Data Layer](https://tina.io/docs/tinacloud#data-layer) provides a GraphQL API that serves Markdown and JSON files backed by a database. You can think of the database as more of an ephemeral cache, since the single source of truth for your content is really your Markdown/JSON files.
+The [TinaCMS Data Layer](https://tina.io/docs/tinacloud#data-layer) provides a GraphQL API that serves Markdown and JSON files backed by a database. You can think of the database as more of an ephemeral cache, since the single source of truth for your content is really your Markdown/JSON files.
 
 ## How Does Self-hosting Work?
 

--- a/content/docs/tinacloud/alpha-faq.mdx
+++ b/content/docs/tinacloud/alpha-faq.mdx
@@ -6,7 +6,7 @@ title: TinaCloud FAQ
 
 The TinaCloud Beta release gives early adopters the chance to test visual content editing and our Git-backed content API!
 
-TinaCloud brings together Tina's open-source content editor with a GraphQL API that talks to content stored in your repository (ie. Markdown and soon JSON).
+TinaCloud brings together TinaCMS's open-source content editor with a GraphQL API that talks to content stored in your repository (ie. Markdown and soon JSON).
 
 ## Where do I start?
 
@@ -21,7 +21,7 @@ Since this is a Beta release you should expect to run into bugs occasionally or 
 These features are not (yet) included in TinaCloud and you might miss them:
 
 - A multi-branch workflow
-- The GraphQL API for your content is not yet queryable with read-only tokens. That means it’s only used while editing content with Tina.
+- The GraphQL API for your content is not yet queryable with read-only tokens. That means it’s only used while editing content with TinaCMS.
 
 ## What technical considerations should I make when working with TinaCloud?
 
@@ -31,7 +31,7 @@ You'll find success with TinaCloud if your project includes:
 - GitHub - The first Git provider that TinaCloud integrates with. Other Git providers may be available in the future.
 - Static, file-based builds - The TinaCloud client collects your filesystem content at build time. The ability to fetch content from our cloud API during builds will come soon.
 
-The [Next.js starter](https://github.com/tinacms/tina-cloud-starter) can get you up and running quickly with the above considerations. Give it a try and let us know how we can make developing with Tina easier.
+The [Next.js starter](https://github.com/tinacms/tina-cloud-starter) can get you up and running quickly with the above considerations. Give it a try and let us know how we can make developing with TinaCMS easier.
 
 ## How can I share an idea or get help using TinaCloud?
 

--- a/content/docs/tinacloud/api-versioning.mdx
+++ b/content/docs/tinacloud/api-versioning.mdx
@@ -3,7 +3,7 @@ title: GraphQL API Versioning
 previous: content/docs/tinacloud/deployment-options/github-pages.mdx
 ---
 
-Tina is still evolving. In order to support a range of clients using different versions of Tina, Tina's [Content Api](../#content-api) leverages version metadata in your site's generated schema to select the appropriate version of the GraphQL API in TinaCloud. Starting with version 0.59.3, this version metadata will be compiled into your site's schema json.
+TinaCMS is still evolving. In order to support a range of clients using different versions of TinaCMS, TinaCMS's [Content Api](../#content-api) leverages version metadata in your site's generated schema to select the appropriate version of the GraphQL API in TinaCloud. Starting with version 0.59.3, this version metadata will be compiled into your site's schema json.
 
 ## What to know
 
@@ -25,6 +25,6 @@ For example:
 | 0.60.0        | 0.60.1            |
 | 0.60.1        | 0.60.1            |
 
-### What if my local version of Tina is different than what is in GitHub?
+### What if my local version of TinaCMS is different than what is in GitHub?
 
-If you are running Tina locally with TinaCloud, it is possible to upgrade the GraphQL API to a different version than what is compiled into the schema and committed to GitHub. Since TinaCloud uses the version in GitHub to determine what version of the GraphQL API to serve, you may encounter incompatibilities. To resolve the issue, commit and changes to your Tina schema directory (`tina`) whenever you upgrade Tina and make sure these changes are pushed to GitHub whenever you are working locally.
+If you are running TinaCMS locally with TinaCloud, it is possible to upgrade the GraphQL API to a different version than what is compiled into the schema and committed to GitHub. Since TinaCloud uses the version in GitHub to determine what version of the GraphQL API to serve, you may encounter incompatibilities. To resolve the issue, commit and changes to your TinaCMS schema directory (`tina`) whenever you upgrade TinaCMS and make sure these changes are pushed to GitHub whenever you are working locally.

--- a/content/docs/tinacloud/beta-migration.mdx
+++ b/content/docs/tinacloud/beta-migration.mdx
@@ -7,7 +7,7 @@ previous: ''
 
 <WarningCallout
   body={<>
-    Tina is currently in full release. While the content of this page may still be useful, we recommend using later versions of Tina – [latest changes](https://tina.io/whats-new/tinacms/).
+    TinaCMS is currently in full release. While the content of this page may still be useful, we recommend using later versions of TinaCMS – [latest changes](https://tina.io/whats-new/tinacms/).
   </>}
 />
 
@@ -19,7 +19,7 @@ under the hood. One of the biggest of these changes is how we handle user accoun
 Previously when you created a TinaCloud account you were creating an **organization** that you accessed at `https://OrgName.tina.io`. We thought that giving each organization its own unique subdomain and pool of users would be neat, but after spending some time in that paradigm it turned out to be a lot of added complexity that didn't add much value.
 
 With the release of the beta we're moving user accounts to the forefront. Whenever you create a TinaCloud account you'll always access it at [https://app.tina.io](https://app.tina.io). This means that even
-if you are part of multiple organizations, you'll only have a single Tina account.
+if you are part of multiple organizations, you'll only have a single TinaCMS account.
 
 > Tools for creating/managing organizations within TinaCloud accounts are coming. For now we create a default organization, which you'll still be able to invite users to.
 
@@ -41,7 +41,7 @@ Since we're changing how user accounts work within TinaCloud, existing alpha use
 yarn remove tina-graphql-gateway-cli tina-graphql-gateway
 ```
 
-1. Add the new Tina dependencies.
+1. Add the new TinaCMS dependencies.
 
 ```
 yarn add tinacms @tinacms/auth
@@ -55,6 +55,6 @@ yarn add -D @tinacms/cli
 * Delete `NEXT_PUBLIC_ORGANIZATION_NAME`
 * Change `NEXT_PUBLIC_TINA_CLIENT_ID` to the Client ID found in your new TinaCloud Account.
 
-That's it! With any luck you should be able to keep working on your Tina enabled site the same as before. We're not expecting to have to repeat this process when we make it to our first full release.
+That's it! With any luck you should be able to keep working on your TinaCMS enabled site the same as before. We're not expecting to have to repeat this process when we make it to our first full release.
 
 If you come across any problems or have any questions feel free to [head over to our Discord](https://discord.com/invite/zumN63Ybpf)! We'd love to hear from you.

--- a/content/docs/tinacloud/branching.mdx
+++ b/content/docs/tinacloud/branching.mdx
@@ -5,12 +5,12 @@ last_edited: '2023-04-12T10:00:00.000Z'
 
 > For a more advanced branching and Pull-Request workflow, checkout TinaCloud's [Editorial Workflow](https://tina.io/editorial-workflow/) (only available on Business and Enterprise plans).
 
-If your content editors need to work on multiple branches, you can enable Tina's branch switching plugin. This allows you to create new branches and switch between them from Tina's UI. In the future, we'll build on this foundation and support creating pull requests, merging, and other related workflows. 
+If your content editors need to work on multiple branches, you can enable TinaCMS's branch switching plugin. This allows you to create new branches and switch between them from TinaCMS's UI. In the future, we'll build on this foundation and support creating pull requests, merging, and other related workflows. 
 <WebmEmbed embedSrc="/img/docs/tinacloud/branch-selector_e5ndeg.webm"/>
 
 ## Installation
 
-Simply add the branch-switcher flag to your CMS callback function in your Tina [config file](/docs/reference/config/). If your site does not already make use of the CMS callback function, add this to your config.
+Simply add the branch-switcher flag to your CMS callback function in your TinaCMS [config file](/docs/reference/config/). If your site does not already make use of the CMS callback function, add this to your config.
 
 ```javascript
 cmsCallback: (cms) => {
@@ -24,6 +24,6 @@ For an example, see [this repo](https://github.com/tinacms/demo-incremental/blob
 
 ## Demo
 
-Here is a quick video demo of Tina's branch plugin
+Here is a quick video demo of TinaCMS's branch plugin
 
 <Youtube embedSrc="https://www.youtube.com/embed/XvL3pFiYaVw" />

--- a/content/docs/tinacloud/dashboard/projects.mdx
+++ b/content/docs/tinacloud/dashboard/projects.mdx
@@ -34,7 +34,7 @@ This name is shown to your users when they log in to the project. Defaults to th
 
 #### Site URL(s)
 
-In these fields, enter both the local URL and the production site URL (if known). For security reasons, Tina will only work at these locations.
+In these fields, enter both the local URL and the production site URL (if known). For security reasons, TinaCMS will only work at these locations.
 
 If you are developing locally, this value might be something like:
 
@@ -48,7 +48,7 @@ If TinaCloud is configured on your production site, this value might be somethin
 
 ##### Glob Patterns
 
-Tina also supports Glob patterns for the Site URL. This can be useful if you want to allow editing on dynamic preview deployments.
+TinaCMS also supports Glob patterns for the Site URL. This can be useful if you want to allow editing on dynamic preview deployments.
 
 E.g. on Vercel this may look like: `https://<VERCEL-PROJECT-NAME>-*-<VERCEL-ACCOUNT-OWNER>.vercel.app`
 

--- a/content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
+++ b/content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
@@ -103,9 +103,9 @@ mkdir -p /www/tinademo
 cd /www/tinademo
 ```
 
-#### Create a Tina Project
+#### Create a TinaCMS Project
 
-Use the template to create a basic Tina project.
+Use the template to create a basic TinaCMS project.
 
 ```plaintext
 npx create-tina-app@latest

--- a/content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
+++ b/content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
@@ -6,7 +6,7 @@ next: content/docs/tinacloud/deployment-options/cloudflare-workers.mdx
 previous: content/docs/tinacloud/deployment-options/github-pages.mdx
 ---
 
-TinaCMS works well with Cloudflare Pages when your site is deployed as a **static export**: content is rendered at build time, while visual editing remains fully live in the browser via Tina's client-side data layer. This page covers a **Next.js** static export.
+TinaCMS works well with Cloudflare Pages when your site is deployed as a **static export**: content is rendered at build time, while visual editing remains fully live in the browser via TinaCMS's client-side data layer. This page covers a **Next.js** static export.
 
 <WarningCallout
   body={<>
@@ -14,11 +14,11 @@ TinaCMS works well with Cloudflare Pages when your site is deployed as a **stati
   </>}
 />
 
-## Why static export works well with Tina
+## Why static export works well with TinaCMS
 
-Tina's live editing experience is client-side. Pages are pre-rendered at build time, and the `useTina()` hook in your client components hydrates with the build-time data for visitors. 
+TinaCMS's live editing experience is client-side. Pages are pre-rendered at build time, and the `useTina()` hook in your client components hydrates with the build-time data for visitors. 
 
-When you open `/admin` and edit a page, Tina swaps live data into the React tree, no server required. Saving commits to GitHub, which triggers a new Cloudflare build, which deploys the updated static site.
+When you open `/admin` and edit a page, TinaCMS swaps live data into the React tree, no server required. Saving commits to GitHub, which triggers a new Cloudflare build, which deploys the updated static site.
 
 ## Configure your project for static export
 

--- a/content/docs/tinacloud/deployment-options/cloudflare-workers.mdx
+++ b/content/docs/tinacloud/deployment-options/cloudflare-workers.mdx
@@ -6,7 +6,7 @@ next: content/docs/tinacloud/deployment-options/alibaba-cloud.mdx
 previous: content/docs/tinacloud/deployment-options/cloudflare-pages.mdx
 ---
 
-Deploy to Cloudflare Workers when your site needs a server at request time: SSR, API routes, redirects, or the Tina visual-editing route. Every push to your production branch rebuilds and redeploys.
+Deploy to Cloudflare Workers when your site needs a server at request time: SSR, API routes, redirects, or the TinaCMS visual-editing route. Every push to your production branch rebuilds and redeploys.
 
 ## Astro
 

--- a/content/docs/tinacloud/deployment-options/github-pages.mdx
+++ b/content/docs/tinacloud/deployment-options/github-pages.mdx
@@ -111,4 +111,4 @@ export default Index;
 
 ## Environment variables
 
-Assuming that your Tina `clientID` and `token` are setup as environment variables, you will need to add those to the GitHub Secrets for your project. The secrets we used in the code snippet above were `TINA_PUBLIC_CLIENT_ID` & `TINA_TOKEN`.
+Assuming that your TinaCMS `clientID` and `token` are setup as environment variables, you will need to add those to the GitHub Secrets for your project. The secrets we used in the code snippet above were `TINA_PUBLIC_CLIENT_ID` & `TINA_TOKEN`.

--- a/content/docs/tinacloud/deployment-options/netlify.mdx
+++ b/content/docs/tinacloud/deployment-options/netlify.mdx
@@ -17,7 +17,7 @@ In Netlify, your build configuration can be updated at **Settings** > **Build & 
 
 ## Environment variables
 
-Assuming that your Tina `clientID` and `token` are setup as environment variables, you will need to add those to the Netlify UI for your project. You can learn more about [Netlify environment variables](https://docs.netlify.com/environment-variables/overview/).
+Assuming that your TinaCMS `clientID` and `token` are setup as environment variables, you will need to add those to the Netlify UI for your project. You can learn more about [Netlify environment variables](https://docs.netlify.com/environment-variables/overview/).
 
 <WarningCallout
   body={<>

--- a/content/docs/tinacloud/deployment-options/vercel.mdx
+++ b/content/docs/tinacloud/deployment-options/vercel.mdx
@@ -34,7 +34,7 @@ Mandatory environment variables include the NEXT\_PUBLIC\_TINA\_CLIENT\_ID and t
 
 ## Your First Deployment
 
-Once ready, select `Deploy` and wait for your first build to run. Once it succeeds, visit your new Tina site by selecting `Inspect Deployment`.
+Once ready, select `Deploy` and wait for your first build to run. Once it succeeds, visit your new TinaCMS site by selecting `Inspect Deployment`.
 
 If any errors occur, refer to the build logs and address them accordingly.
 

--- a/content/docs/tinacloud/overview.mdx
+++ b/content/docs/tinacloud/overview.mdx
@@ -4,7 +4,7 @@ cmsUsageWarning: 'https://github.com/tinacms/tinacms/blob/main/packages/tinacms/
 seo:
   title: 'Overview: Going to Production with TinaCloud'
   description: >-
-    Learn how to take a Tina site to production with TinaCloud. Follow our
+    Learn how to take a TinaCMS site to production with TinaCloud. Follow our
     step-by-step guide for setup and deployment on Vercel, Netlify, or GitHub
     Pages
 title: Going to Production with TinaCloud
@@ -18,7 +18,7 @@ previous: content/docs/tinacloud.mdx
 
 <Youtube embedSrc="https://www.youtube.com/embed/sTVd8CYtXrA?si=DmnS-45aXkmCq8Fa" />
 
-To deploy your site to production, you'll need to connect Tina to a hosted backend. This doc will walk you through the steps to get your site from [running locally to running for production](/docs/introduction/faq/#what-is-local-mode-vs-prod-mode).
+To deploy your site to production, you'll need to connect TinaCMS to a hosted backend. This doc will walk you through the steps to get your site from [running locally to running for production](/docs/introduction/faq/#what-is-local-mode-vs-prod-mode).
 
 ## Prerequisites
 
@@ -67,7 +67,7 @@ export default defineConfig({
 
 <WarningCallout
   body={<>
-    Note: If you're loading your schema config values from a local environment file, Tina's build process will only pickup `.env` files (not `.env.local` or `.env.development`).
+    Note: If you're loading your schema config values from a local environment file, TinaCMS's build process will only pickup `.env` files (not `.env.local` or `.env.development`).
   </>}
 />
 
@@ -127,7 +127,7 @@ The apiURL is configured to use the local Content API in development (to query y
 
 The next step is to update your deployment configuration, so the TinaCMS admin gets built alongside your site. This allows your editors to enter the CMS through `<your-site>/admin` (or `your-site/admin/index.html`).
 
-In general, you'll want to make sure that your build command is running `tinacms build` before your site's build command. This will build the TinaCMS admin alongside your site. You'll also want to make sure that your Tina `NEXT_PUBLIC_TINA_CLIENT_ID` and `TINA_TOKEN` are setup as environment variables on your host.
+In general, you'll want to make sure that your build command is running `tinacms build` before your site's build command. This will build the TinaCMS admin alongside your site. You'll also want to make sure that your TinaCMS `NEXT_PUBLIC_TINA_CLIENT_ID` and `TINA_TOKEN` are setup as environment variables on your host.
 
 <WarningCallout
   body={<>

--- a/content/docs/tinacloud/schema-migration.mdx
+++ b/content/docs/tinacloud/schema-migration.mdx
@@ -4,7 +4,7 @@ title: From GraphQL Gateway to TinaCMS
 
 # Package reorganization
 
-As we've trialed the GraphQL API and how it works with TinaCMS, it's become apparent that this is the primary path we want to carve out for users of Tina. We'll be moving the `tina-graphq-gateway` APIs in to the `tinacms` package to reflect its more central role in the Tina workflow. Other backend integrations will still be available to build out via the new `@tinacms/toolkit` package. You can read more details on those changes [here](https://github.com/tinacms/tinacms/issues/1898).
+As we've trialed the GraphQL API and how it works with TinaCMS, it's become apparent that this is the primary path we want to carve out for users of TinaCMS. We'll be moving the `tina-graphq-gateway` APIs in to the `tinacms` package to reflect its more central role in the TinaCMS workflow. Other backend integrations will still be available to build out via the new `@tinacms/toolkit` package. You can read more details on those changes [here](https://github.com/tinacms/tinacms/issues/1898).
 
 ### `tinacms` is absorbing `tina-graphql-gateway`
 
@@ -47,7 +47,7 @@ yarn remove tina-graphql-gateway-cli
 
 ## The new `defineSchema` API
 
-We're going to be leaning on a more _primitive_ concept of how types are defined with Tina, and in doing so will be introducing some breaking changes to the way schemas are defined. 
+We're going to be leaning on a more _primitive_ concept of how types are defined with TinaCMS, and in doing so will be introducing some breaking changes to the way schemas are defined. 
 
 ### Collections now accept a `fields` _or_ `templates` property
 
@@ -121,7 +121,7 @@ By default `string` will use the `text` field, but you can change that by specif
 }
 ```
 
-For the most part, the UI properties are added to the field and adhere to the existing capabilities of Tina's core [field plugins](/docs/reference/toolkit/fields/). But there's nothing stopping you from providing your own components -- just be sure to register those with the CMS object on the frontend:
+For the most part, the UI properties are added to the field and adhere to the existing capabilities of TinaCMS's core [field plugins](/docs/reference/toolkit/fields/). But there's nothing stopping you from providing your own components -- just be sure to register those with the CMS object on the frontend:
 
 ```js
 {
@@ -135,7 +135,7 @@ For the most part, the UI properties are added to the field and adhere to the ex
 }
 ```
 
-[Register](/docs/extending-tina/custom-field-components) your `myMapField` with Tina:
+[Register](/docs/extending-tina/custom-field-components) your `myMapField` with TinaCMS:
 
 ```js
 cms.fields.add({
@@ -146,7 +146,7 @@ cms.fields.add({
 
 #### One important gotcha
 
-Every property in the `defineSchema` API must be serializable. Meaning functions will not work. For example, there's no way to define a `validate` or `parse` function at this level. However, you can either use the [formifyCallback](/docs/extending-tina/custom-field-components) API to get access to the Tina form, or provide your own logic by specifying a plugin of your choice:
+Every property in the `defineSchema` API must be serializable. Meaning functions will not work. For example, there's no way to define a `validate` or `parse` function at this level. However, you can either use the [formifyCallback](/docs/extending-tina/custom-field-components) API to get access to the TinaCMS form, or provide your own logic by specifying a plugin of your choice:
 
 ```js
 {
@@ -216,7 +216,7 @@ While this, is a `checkbox` field
 
 ### Introducing the `object` type
 
-Tina currently represents the concept of an _object_ in two ways: a `group` (and `group-list`), which is a uniform collection of fields; and `blocks`, which is a polymporphic collection. Moving forward, we'll be introducing a more comprehensive type, which envelopes the behavior of both `group` and `blocks`, and since _every_ field can be a `list`, this also makes `group-list` redundant.
+TinaCMS currently represents the concept of an _object_ in two ways: a `group` (and `group-list`), which is a uniform collection of fields; and `blocks`, which is a polymporphic collection. Moving forward, we'll be introducing a more comprehensive type, which envelopes the behavior of both `group` and `blocks`, and since _every_ field can be a `list`, this also makes `group-list` redundant.
 
 > Note: we've previously assumed that `blocks` usage would _always_ be as an array. We'll be keeping that assumption with the `blocks` type for compatibility, but `object` will allow for non-array polymorphic objects.
 

--- a/content/docs/tinacloud/tinacms-availability-China.mdx
+++ b/content/docs/tinacloud/tinacms-availability-China.mdx
@@ -42,5 +42,5 @@ TinaCMS is generally available and usable in mainland China. The main obstacle i
 
 For detailed implementation guidance:
 
-* [Deploying to Alibaba Cloud](/docs/tinacloud/deployment-options/alibaba-cloud) - Learn how to set up a Tina Project with Alibaba Cloud infrastructure
-* [Internationalization](/docs/guides/internationalization#internationalization-with-github-action) - Add multi-language support to your Tina Project
+* [Deploying to Alibaba Cloud](/docs/tinacloud/deployment-options/alibaba-cloud) - Learn how to set up a TinaCMS Project with Alibaba Cloud infrastructure
+* [Internationalization](/docs/guides/internationalization#internationalization-with-github-action) - Add multi-language support to your TinaCMS Project


### PR DESCRIPTION
Part of #4845 (batch 3 of the standalone-`Tina` cleanup — English docs, first slice).

## Summary

80 in-content occurrences of standalone `Tina` replaced with `TinaCMS` across three docs subtrees, all pure product usage — "Tina admin", "Tina Starter", "with Tina", "Tina Data Layer", "Tina Backend", etc.

Applied as a semi-automated pass with `perl -pi -e 's/\bTina\b(?!\.io|-CMS|-Docs|-Cloud| CMS| Teams)/TinaCMS/g'` on 26 files, then a manual review of the 27th (`projects.mdx`) to preserve 5 UI-label references (see below).

## Scope

- `content/docs/frameworks/` — 10 files (Astro, Next.js app/pages router, Remix, SvelteKit, Hugo, Gatsby, Jekyll, 11ty, `other`)
- `content/docs/tinacloud/` — 14 files (overview, api-versioning, alpha-faq, schema-migration, branching, beta-migration, tinacms-availability-China, dashboard, deployment-options for Cloudflare Workers/Pages, GitHub Pages, Vercel, Netlify, Alibaba)
- `content/docs/self-hosted/` — 3 files (overview, existing-site, manual-setup)

27 files changed, 80 insertions / 80 deletions.

## Intentionally NOT changed (5 hits in `projects.mdx`)

| File:line | Text | Why |
|---|---|---|
| `docs/tinacloud/dashboard/projects.mdx:81` | `##### Path To Tina` | UI field label in the TinaCloud dashboard — changing docs alone would drift from the app |
| `docs/tinacloud/dashboard/projects.mdx:85` | `Path To Tina Config input` | same |
| `docs/tinacloud/dashboard/projects.mdx:89` | `Path To Tina Field` | same |
| `docs/tinacloud/dashboard/projects.mdx:91` | `Path to Tina Field` | same |
| `docs/tinacloud/dashboard/projects.mdx:105` | image alt `Path to Tina Folder UI under Advanced Settings` | reference to the same UI element |

If the TinaCloud app label is later changed to "Path To TinaCMS", these can be updated in a follow-up.

## Verify

```bash
# after merge, only the 5 "Path To Tina" survivors above should remain:
grep -rnP "\bTina\b" \
  content/docs/frameworks/ content/docs/tinacloud/ content/docs/self-hosted/ \
  | grep -vE "TinaCMS|TinaCloud|TinaDocs|TinaGPT|TinaTeach|Tina\.io|Tina-Docs|Tina-Cloud|Tina-CMS|Tina Teams|Tina CMS"
```

## Test plan

- [ ] Preview deploy → spot-check a few pages:
  - `/docs/frameworks/gatsby` — title reads "Gatsby + TinaCMS Setup Guide", body copy uses "TinaCMS admin".
  - `/docs/frameworks/astro` — TinaCMS integration steps, `/tinacms-demo` route reference unchanged.
  - `/docs/tinacloud/overview` — reads "connect TinaCMS to a hosted backend".
  - `/docs/tinacloud/dashboard/projects` — "For security reasons, TinaCMS will only work…" but the "Path To Tina" subheading still reads verbatim to match the dashboard UI.
  - `/docs/self-hosted/overview` — title reads "Self-hosting TinaCMS", "TinaCMS Data Layer" heading + body.
