### PR TITLE
Brand: 'Tina' -> 'TinaCMS' in docs/{reference,graphql,extending-tina} (90 hits)

### DIFF
--- a/content/docs/extending-tina/custom-field-components.mdx
+++ b/content/docs/extending-tina/custom-field-components.mdx
@@ -13,7 +13,7 @@ This component completely overrides the original component, providing the user w
 
 ## Environment Variables in Custom Components
 
-Custom field components run inside the Tina admin, which is built as a **static SPA** separately from your site. Environment variables are embedded into the admin JavaScript at build time — they are not read at runtime. This means two things must be true for a variable to be available:
+Custom field components run inside the TinaCMS admin, which is built as a **static SPA** separately from your site. Environment variables are embedded into the admin JavaScript at build time — they are not read at runtime. This means two things must be true for a variable to be available:
 
 1. **It must use an allowed prefix.** For security reasons, only these variables are included:
    - `TINA_PUBLIC_*`
@@ -35,7 +35,7 @@ const secret = process.env.MY_API_KEY
 
 <WarningCallout
   body={<>
-    If your custom component relies on an environment variable and it's always `undefined`, check that: (1) the variable name starts with `TINA_PUBLIC_` or `NEXT_PUBLIC_`, and (2) the variable is defined in your `.env` file or CI environment when `tinacms build` runs. Note that Tina only loads `.env` files — not `.env.local` or `.env.development`. See the [config reference](/docs/reference/config#environment-variables) and [security advisory](/blog/2023-02-security-update) for details.
+    If your custom component relies on an environment variable and it's always `undefined`, check that: (1) the variable name starts with `TINA_PUBLIC_` or `NEXT_PUBLIC_`, and (2) the variable is defined in your `.env` file or CI environment when `tinacms build` runs. Note that TinaCMS only loads `.env` files — not `.env.local` or `.env.development`. See the [config reference](/docs/reference/config#environment-variables) and [security advisory](/blog/2023-02-security-update) for details.
   </>}
 />
 
@@ -214,8 +214,8 @@ The below tutorial includes a segment on creating a custom Icon selector using a
 
 ### Image scale slider component
 
-With a little bit of extra CSS you can create scalable images in Tina. This will save you having to crop images for your blog.
-![An image being scaled within the Tina editor](/img-scale-component.gif)
+With a little bit of extra CSS you can create scalable images in TinaCMS. This will save you having to crop images for your blog.
+![An image being scaled within the TinaCMS editor](/img-scale-component.gif)
 
 ```
 import { wrapFieldsWithMeta } from 'tinacms';

--- a/content/docs/extending-tina/edit-state.mdx
+++ b/content/docs/extending-tina/edit-state.mdx
@@ -1,6 +1,6 @@
 ---
 id: /docs/extending-tina/edit-state
-title: Manually editing Tina's edit state
+title: Manually editing TinaCMS's edit state
 ---
 
 ## Manually toggling via `useEditState`

--- a/content/docs/extending-tina/filename-customization.mdx
+++ b/content/docs/extending-tina/filename-customization.mdx
@@ -6,7 +6,7 @@ next: content/docs/extending-tina/before-submit.mdx
 previous: content/docs/extending-tina/format-and-parse.mdx
 ---
 
-By default, Tina does not enforce strict filename constraints, as operating systems support a wide variety of formats. However, you can enforce custom constraints at the collection level if needed.
+By default, TinaCMS does not enforce strict filename constraints, as operating systems support a wide variety of formats. However, you can enforce custom constraints at the collection level if needed.
 
 ## Filename Rules
 
@@ -112,7 +112,7 @@ export default defineConfig({
 
 ### Example with default slugify
 
-If no `slugify` function is provided and a field has `isTitle: true`, Tina uses a default `slugify` function. This removes non-alphanumeric characters and replaces spaces with dashes.
+If no `slugify` function is provided and a field has `isTitle: true`, TinaCMS uses a default `slugify` function. This removes non-alphanumeric characters and replaces spaces with dashes.
 
 ```ts
 export default defineConfig({

--- a/content/docs/extending-tina/overview.mdx
+++ b/content/docs/extending-tina/overview.mdx
@@ -1,16 +1,16 @@
 ---
 id: /docs/extending-tina/overview
-title: Extending Tina
+title: Extending TinaCMS
 last_edited: '2025-05-01T01:56:24.122Z'
 next: ''
 previous: ''
 ---
 
-Tina has many advanced features that allow the entire CMS editing experience to be customized.
+TinaCMS has many advanced features that allow the entire CMS editing experience to be customized.
 
 ## Customizing Fields
 
-Tina allows any field to be customized through the `ui` property. This allows a custom experience to be created for your editors. Some of the main customization features are:
+TinaCMS allows any field to be customized through the `ui` property. This allows a custom experience to be created for your editors. Some of the main customization features are:
 
 - Customizing the rendered [field component](/docs/extending-tina/custom-field-components/)
 - Customizing the [parsing and formatting](/docs/extending-tina/format-and-parse/) of user input
@@ -64,4 +64,4 @@ export default defineConfig({
 })
 ```
 
-The `cmsCallback` hook is primarily used for registering custom field plugins. It can also be used for altering Tina's UI, dynamically hiding the sidebar on specific pages, tapping into the CMS event bus, etc.
+The `cmsCallback` hook is primarily used for registering custom field plugins. It can also be used for altering TinaCMS's UI, dynamically hiding the sidebar on specific pages, tapping into the CMS event bus, etc.

--- a/content/docs/graphql/cli.mdx
+++ b/content/docs/graphql/cli.mdx
@@ -12,7 +12,7 @@ The `@tinacms/cli` package will be installed as a dev dependency with the [tina 
 npx @tinacms/cli init
 ```
 
-This will setup a dummy `tina/config.{js,ts}` in your site, and install any required Tina dependencies.
+This will setup a dummy `tina/config.{js,ts}` in your site, and install any required TinaCMS dependencies.
 
 ## Running the GraphQL API
 
@@ -32,7 +32,7 @@ This command also takes an argument (`-c`) that allows you to run a command as a
 The reason we want to run the GraphQL API with our site is so that:
 
 - When our static pages build in CI, they can source their content from the local files using the GraphQL API.
-- In development, we can test out Tina with our local files.
+- In development, we can test out TinaCMS with our local files.
 
 Now if you run the updated `dev` script with:
 
@@ -55,7 +55,7 @@ Your console might show something like:
 
 Started Filesystem GraphQL server on port: 4001
 Visit the playground at http://localhost:3000/admin/index.html#/graphql
-Generating Tina config
+Generating TinaCMS config
 ...
 ```
 

--- a/content/docs/graphql/queries/add-document.mdx
+++ b/content/docs/graphql/queries/add-document.mdx
@@ -27,4 +27,4 @@ The `addPendingDocument` mutation will take in the collection name as a paramete
   }"
 />
 
-> Ready to try out some of these queries using your specific schema? Try [running the Tina CLI](/docs/graphql/cli/) and testing them out using the Altair client
+> Ready to try out some of these queries using your specific schema? Try [running the TinaCMS CLI](/docs/graphql/cli/) and testing them out using the Altair client

--- a/content/docs/graphql/queries/advanced/filter-documents.mdx
+++ b/content/docs/graphql/queries/advanced/filter-documents.mdx
@@ -6,7 +6,7 @@ next: ''
 previous: ''
 ---
 
-Tina automatically creates filters for collections defined in your schema.
+TinaCMS automatically creates filters for collections defined in your schema.
 
 To filter collection results, pass the `filter` argument to the `<collection>Connection` query, followed by any of the filter [operator types](/docs/graphql/queries/advanced/filter-documents/#operator-types) for the fields on your collection.
 

--- a/content/docs/graphql/queries/advanced/limitations.mdx
+++ b/content/docs/graphql/queries/advanced/limitations.mdx
@@ -6,7 +6,7 @@ next: ''
 previous: ''
 ---
 
-There are a number of limitations to keep in mind when leveraging query functionality with Tina's Content API:
+There are a number of limitations to keep in mind when leveraging query functionality with TinaCMS's Content API:
 
 ## Filter operations
 

--- a/content/docs/graphql/queries/query-documents.mdx
+++ b/content/docs/graphql/queries/query-documents.mdx
@@ -4,7 +4,7 @@ title: Querying a List of Documents
 last_edited: '2024-08-15T02:22:39.588Z'
 ---
 
-Tina's list queries implement the [cursor-based Relay specification](https://relay.dev/graphql/connections.htm). Collection lists can be queried with `<collection>Connection`.
+TinaCMS's list queries implement the [cursor-based Relay specification](https://relay.dev/graphql/connections.htm). Collection lists can be queried with `<collection>Connection`.
 
 ## Example
 

--- a/content/docs/reference/collections.mdx
+++ b/content/docs/reference/collections.mdx
@@ -186,7 +186,7 @@ We recommend using singular naming in a collection (post, not post**s**).
 
 ### Path
 
-`path` let's Tina know which directories hold documents for a collection.
+`path` let's TinaCMS know which directories hold documents for a collection.
 
 [`Format`](#format) or [`match`](#match) properties can further specify included documents.
 

--- a/content/docs/reference/config.mdx
+++ b/content/docs/reference/config.mdx
@@ -305,7 +305,7 @@ Note that it **must be** the default export.
 
 ### Vercel and TinaCloud Configuration
 
-This is a standard configuration using TinaCloud to host your datalayer and the built-in Tina media and search capabilities.
+This is a standard configuration using TinaCloud to host your datalayer and the built-in TinaCMS media and search capabilities.
 
 ```ts
 const branch =
@@ -349,7 +349,7 @@ export default defineConfig({
 
 ### Cloudinary Media Store
 
-Tina supports both Git-backed media and specific external media providers:
+TinaCMS supports both Git-backed media and specific external media providers:
 
 ```ts
 export default defineConfig({
@@ -366,10 +366,10 @@ export default defineConfig({
 
 ### TinaCloud Search Options
 
-Tina provides built-in search capabilities through TinaCloud.
+TinaCMS provides built-in search capabilities through TinaCloud.
 
 ```ts
-// Tina Cloud search
+// TinaCMS Cloud search
 export default defineConfig({
   // ... other config options
   search: {
@@ -388,11 +388,11 @@ TinaCMS uses environment variables in two contexts: the **site build** (your Nex
 
 #### Build-Time Embedding
 
-The Tina admin is a **statically built SPA**. Environment variables are embedded into the admin's JavaScript at build time (during `tinacms build` or `tinacms dev`). They are not read at runtime. This means a variable must be present in the environment when the build runs — setting it afterwards has no effect.
+The TinaCMS admin is a **statically built SPA**. Environment variables are embedded into the admin's JavaScript at build time (during `tinacms build` or `tinacms dev`). They are not read at runtime. This means a variable must be present in the environment when the build runs — setting it afterwards has no effect.
 
 #### `.env` File Support
 
-Tina's build process only picks up variables from `.env` files. Variables defined in `.env.local`, `.env.development`, or other dotenv variants are **not** loaded by the TinaCMS build. If you're deploying to a hosting provider (Vercel, Netlify, etc.), make sure the variables are also configured in that provider's environment settings.
+TinaCMS's build process only picks up variables from `.env` files. Variables defined in `.env.local`, `.env.development`, or other dotenv variants are **not** loaded by the TinaCMS build. If you're deploying to a hosting provider (Vercel, Netlify, etc.), make sure the variables are also configured in that provider's environment settings.
 
 #### Admin-Exposed Variables
 

--- a/content/docs/reference/content-api/content-delivery.mdx
+++ b/content/docs/reference/content-api/content-delivery.mdx
@@ -6,7 +6,7 @@ next: ''
 previous: ''
 ---
 
-Requests can be made to the Tina Content API with Read Only Tokens. In the majority of cases, these requests are made using the [Tina client](/docs/features/data-fetching/#making-requests-with-the-tina-client), however you can also hit the API directly.
+Requests can be made to the TinaCMS Content API with Read Only Tokens. In the majority of cases, these requests are made using the [TinaCMS client](/docs/features/data-fetching/#making-requests-with-the-tina-client), however you can also hit the API directly.
 
 ## Making requests with `curl` and `fetch`
 

--- a/content/docs/reference/content-api/data-layer.mdx
+++ b/content/docs/reference/content-api/data-layer.mdx
@@ -3,13 +3,13 @@ title: Data Layer
 last_edited: '2026-02-10T23:24:00.000Z'
 ---
 
-## What is the Tina Data Layer?
+## What is the TinaCMS Data Layer?
 
-The Tina Data Layer provides a GraphQL API that serves Markdown and JSON files backed by a database. You can think of the database as more of an ephemeral cache, since the single source of truth for your content is really your Markdown/JSON files.
+The TinaCMS Data Layer provides a GraphQL API that serves Markdown and JSON files backed by a database. You can think of the database as more of an ephemeral cache, since the single source of truth for your content is really your Markdown/JSON files.
 
 ![TinaCMS GraphQL Data Layer](/img/docs/tina-data-layer-diagram.png "TinaCMS Data Layer")
 
-TinaCMS implements this database layer between the Tina GraphQL API and the underlying Git repository. This data layer buffers requests between TinaCloud and GitHub resulting in improved editing performance with TinaCMS. 
+TinaCMS implements this database layer between the TinaCMS GraphQL API and the underlying Git repository. This data layer buffers requests between TinaCloud and GitHub resulting in improved editing performance with TinaCMS. 
 
 Primary benefits of the Data Layer include:
 
@@ -69,7 +69,7 @@ Indexing is the process of scanning your content files and storing them in the d
 - The configured [repository](/docs/tinacloud/dashboard/projects/#changing-the-repository) changes
 - A new branch is created in GitHub
 
-**Self-hosted:** Indexing occurs when your site is built. Content updates made by editors through Tina are immediately reflected, but edits made directly to GitHub outside of Tina won't appear until the next build.
+**Self-hosted:** Indexing occurs when your site is built. Content updates made by editors through TinaCMS are immediately reflected, but edits made directly to GitHub outside of TinaCMS won't appear until the next build.
 
 **Local dev:** The file watcher re-indexes files as soon as they change on disk.
 

--- a/content/docs/reference/fields.mdx
+++ b/content/docs/reference/fields.mdx
@@ -336,7 +336,7 @@ In the below example, as the user types they will see all lowercase characters. 
 
 ## Validating Field Values
 
-Tina allows client-side validation using a validation function, `ui.validate`. This function returns a `string` error message if the value is **invalid** or `null` if the field is **valid**.
+TinaCMS allows client-side validation using a validation function, `ui.validate`. This function returns a `string` error message if the value is **invalid** or `null` if the field is **valid**.
 
 To include other field values of the form in the validation, an `allValues` argument can be used.
 

--- a/content/docs/reference/markdown-spec.mdx
+++ b/content/docs/reference/markdown-spec.mdx
@@ -7,7 +7,7 @@ previous: ''
 
 ## Markdown Syntax Support
 
-While most markdown features are supported out of the box, Tina will ignore elements that it cannot handle. We *do not* expect to support the full [CommonMark](https://commonmark.org/) and
+While most markdown features are supported out of the box, TinaCMS will ignore elements that it cannot handle. We *do not* expect to support the full [CommonMark](https://commonmark.org/) and
 [GitHub Flavored Markdown](https://github.github.com/gfm/) specs. Be sure to voice your support for various rich-text features by reaching out through one of our [community channels](/community/)!
 
 ## Supported Elements
@@ -195,7 +195,7 @@ This means that any JavaScript expressions needing execution won't take effect.
 
 ## Automatic Transforms
 
-For some elements, Tina will automatically transform the values:
+For some elements, TinaCMS will automatically transform the values:
 
 ### Bold and italic marks
 

--- a/content/docs/reference/media/external/authentication.mdx
+++ b/content/docs/reference/media/external/authentication.mdx
@@ -8,7 +8,7 @@ next: ''
 previous: ''
 ---
 
-Tina supports using external media providers, however a light backend media handler needs to be setup/hosted by the user. Tina offers some helpers to make this easy, for `cloudinary`,`s3`, & `dos` ("Digital Ocean Spaces").
+TinaCMS supports using external media providers, however a light backend media handler needs to be setup/hosted by the user. TinaCMS offers some helpers to make this easy, for `cloudinary`,`s3`, & `dos` ("Digital Ocean Spaces").
 
 You'll also need to define your own authorization function, to check if users are allowed access to the handler.
 

--- a/content/docs/reference/media/external/cloudinary.mdx
+++ b/content/docs/reference/media/external/cloudinary.mdx
@@ -58,7 +58,7 @@ export default defineConfig({
 
 ## Set up API routes
 
-Tina's "external media provider" support requires a light backend media handler, that needs to be setup/hosted by the user. There are multiple ways to setup this handler:
+TinaCMS's "external media provider" support requires a light backend media handler, that needs to be setup/hosted by the user. There are multiple ways to setup this handler:
 
 ### "NextJS API Routes"
 

--- a/content/docs/reference/media/external/do-spaces.mdx
+++ b/content/docs/reference/media/external/do-spaces.mdx
@@ -63,7 +63,7 @@ export default defineConfig({
 
 ## Set up API routes
 
-Tina's "external media provider" support requires a light backend media handler, that needs to be setup/hosted by the user. There are multiple ways to do this, including the framework-agnostic [Netlify Functions implementation](/docs/reference/media/external/authentication/#netlify).
+TinaCMS's "external media provider" support requires a light backend media handler, that needs to be setup/hosted by the user. There are multiple ways to do this, including the framework-agnostic [Netlify Functions implementation](/docs/reference/media/external/authentication/#netlify).
 
 > **NOTE:** this step will show you how to set up an API route for Next.js. If you are using a different framework, you will need to set up your own API route.
 

--- a/content/docs/reference/media/external/s3.mdx
+++ b/content/docs/reference/media/external/s3.mdx
@@ -148,7 +148,7 @@ export default defineConfig({
 
 ## Set up API routes
 
-Tina's "external media provider" support requires a light backend media handler, that needs to be setup/hosted by the user. There are multiple ways to do this, including the framework-agnostic [Netlify Functions implementation](/docs/reference/media/external/authentication/#netlify).
+TinaCMS's "external media provider" support requires a light backend media handler, that needs to be setup/hosted by the user. There are multiple ways to do this, including the framework-agnostic [Netlify Functions implementation](/docs/reference/media/external/authentication/#netlify).
 
 ### Next.js
 

--- a/content/docs/reference/media/overriding-accepted-media-types.mdx
+++ b/content/docs/reference/media/overriding-accepted-media-types.mdx
@@ -29,7 +29,7 @@ This property determines the filetypes that can be uploaded
 
 ### next/image
 
-If you are using Next images, you will need to add the following to your next.config.js file to allow access to external images hosted on the Tina media hostname 
+If you are using Next images, you will need to add the following to your next.config.js file to allow access to external images hosted on the TinaCMS media hostname 
 
 ```javascript
 //next.config.js

--- a/content/docs/reference/overview.mdx
+++ b/content/docs/reference/overview.mdx
@@ -8,6 +8,6 @@ next: content/docs/reference/config.mdx
 
 ## Overview
 
-With all the flexibility Tina provides for being able to create custom, tailored sites, comes the need to clarify how to really leverage Tina's power by understanding some reference points.
+With all the flexibility TinaCMS provides for being able to create custom, tailored sites, comes the need to clarify how to really leverage TinaCMS's power by understanding some reference points.
 
 The following sections explain more about the way objects are defined, referenced, and provide some example usages.

--- a/content/docs/reference/rich-text-usage/markdown-shortcode.mdx
+++ b/content/docs/reference/rich-text-usage/markdown-shortcode.mdx
@@ -15,15 +15,15 @@ previous: ''
 
 ## Handling Markdown Shortcode
 
-If you have some custom **shortcode** logic in your markdown, you can specify it in the `templates` property and Tina will handle it as if it were a `jsx` element:
+If you have some custom **shortcode** logic in your markdown, you can specify it in the `templates` property and TinaCMS will handle it as if it were a `jsx` element:
 
-The following snippet would throw an error while parsing since Tina doesn't know what to do with `{{}}`:
+The following snippet would throw an error while parsing since TinaCMS doesn't know what to do with `{{}}`:
 
 ```markdown
 {{ WarningCallout content="This is an experimental feature, and the API is subject to change. Have any thoughts? Let us know in the chat, or through one of our [community channels](/community/)!" }}
 ```
 
-But you can tell Tina how to handle it with a `template`:
+But you can tell TinaCMS how to handle it with a `template`:
 
 ```ts
 fields: [
@@ -63,7 +63,7 @@ Certain frameworks support shortcodes with Raw string values:
 {{  myshortcode "This is some raw text" }}
 ```
 
-This is supported in Tina with the special `_value` field.
+This is supported in TinaCMS with the special `_value` field.
 
 ```ts
 fields: [
@@ -126,7 +126,7 @@ Your field template definition would look something like:
 
 ### Shortcode names with dashes
 
-Sometimes your shortcode will contain characters that aren't supported in Tina's content modelling
+Sometimes your shortcode will contain characters that aren't supported in TinaCMS's content modelling
 
 ```md
 {{ my-shortcode }}

--- a/content/docs/reference/search/overview.mdx
+++ b/content/docs/reference/search/overview.mdx
@@ -10,11 +10,11 @@ previous: ''
 
 TinaCMS provides built-in search functionality for content. This is useful for allowing editors to quickly finding content in a site. TinaCloud's content search is powered by [Fergus McDowall](https://github.com/fergiemcdowall "Fergus McDowall")'s [search-index](https://www.npmjs.com/package/search-index "search-index") library.
 
-> Note: Search is not currently supported in self-hosted Tina.
+> Note: Search is not currently supported in self-hosted TinaCMS.
 
 ## Configuration
 
-To enable search functionality, you will need to populate the `search` field in your Tina configuration. The only required element of the search configuration when using TinaCloud search is the `search.tina.indexerToken` field. This can be obtained from the TinaCloud [dashboard](/docs/tinacloud/dashboard/projects/#api-tokens) for the project.
+To enable search functionality, you will need to populate the `search` field in your TinaCMS configuration. The only required element of the search configuration when using TinaCloud search is the `search.tina.indexerToken` field. This can be obtained from the TinaCloud [dashboard](/docs/tinacloud/dashboard/projects/#api-tokens) for the project.
 
 ```javascript
 export default defineConfig({

--- a/content/docs/reference/self-hosted/auth-provider/authjs.mdx
+++ b/content/docs/reference/self-hosted/auth-provider/authjs.mdx
@@ -18,7 +18,7 @@ yarn add next-auth tinacms-authjs
 
 > Hint: Make sure you have a [database adapter](/docs/reference/self-hosted/database-adapter/overview/) setup before continuing.
 
-### Update Your Tina Config
+### Update Your TinaCMS Config
 
 We need to add the Auth Provider and a user collection to the `tina/config.{ts,js}` file.
 
@@ -65,7 +65,7 @@ Create a file called `content/users/index.json` that contains the initial seed u
 
 > After logging in, you can update the username and password
 
-### Update Tina Backend
+### Update TinaCMS Backend
 
 Update your `/api/tina/[...routes].{ts,js}` file to use the Auth.js backend.
 
@@ -131,7 +131,7 @@ any of these providers with some configuration changes. The user collection will
 
 As an example, we can configure the Discord OAuth login provider.
 
-### Update Your Tina Config
+### Update Your TinaCMS Config
 
 Here we switch from the `UsernamePasswordAuthJSProvider` to the `DefaultAuthJSProvider`. We also redefine the user collection to remove the password field, as it is no longer needed.
 
@@ -229,7 +229,7 @@ export default (req, res) => {
 }
 ```
 
-Here we specify the DiscordProvider. Also, note that we have added a `uidProp` to the options. This is used to tell Tina which property on the Discord auth object has
+Here we specify the DiscordProvider. Also, note that we have added a `uidProp` to the options. This is used to tell TinaCMS which property on the Discord auth object has
 the unique identifier for the user. If you are not sure what this should be, you can enable debug mode to see the auth object.
 
 Next, we'll need to create a separate endpoint for the backend. In `/pages/api/auth/[...nextauth].{ts,js}` we'll have:

--- a/content/docs/reference/self-hosted/auth-provider/bring-your-own.mdx
+++ b/content/docs/reference/self-hosted/auth-provider/bring-your-own.mdx
@@ -64,7 +64,7 @@ export default defineConfig({
 })
 ```
 
-## 2. Add Auth to the Tina Backend
+## 2. Add Auth to the TinaCMS Backend
 
 `TinaNodeBackend` takes an `authProvider` Prop.
 

--- a/content/docs/reference/self-hosted/auth-provider/clerk-auth.mdx
+++ b/content/docs/reference/self-hosted/auth-provider/clerk-auth.mdx
@@ -3,7 +3,7 @@ id: '/docs/reference/self-hosted/auth-provider/clerk-auth'
 title: Clerk Auth Provider
 ---
 
-[Clerk](https://clerk.com) is a user management service which you can use with a self-hosted Tina setup.
+[Clerk](https://clerk.com) is a user management service which you can use with a self-hosted TinaCMS setup.
 
 > Looking for the code? Check out the [GitHub repository](https://github.com/tinacms/tinacms/tree/main/packages/tinacms-clerk).
 
@@ -40,7 +40,7 @@ When self-hosting, you may want to disable auth for local development.
 }
 ```
 
-## Update your Tina Config
+## Update your TinaCMS Config
 
 Add the following to your `tina/config.{ts.js}` file. Be sure to replace "my-email@gmail.com" with the email you're signing in with:
 
@@ -64,7 +64,7 @@ Note that we're checking if the signed-in user's email exists in a hardcoded arr
 - Create an organization in Clerk, and check to see if the signed-in user is part of the org for this project. Note that organizations are currently limited to 3 users on the free plan.
 - Create an ["allow-list"](https://clerk.com/docs/authentication/allowlist). Note that this is a paid feature.
 
-## Update the Tina Backend
+## Update the TinaCMS Backend
 
 Add the following to your `pages/api/tina/[...routes].{ts,js}` file
 

--- a/content/docs/reference/self-hosted/auth-provider/overview.mdx
+++ b/content/docs/reference/self-hosted/auth-provider/overview.mdx
@@ -8,16 +8,16 @@ previous: ''
 
 The term "Auth Provider" refers to the TinaCMS component that handles authentication and authorization of users when self-hosting.
 
-The recommended auth provider for Tina is based on [Auth.js](https://authjs.dev/). It leverages a user collection
+The recommended auth provider for TinaCMS is based on [Auth.js](https://authjs.dev/). It leverages a user collection
 in your database to store user information and uses the Auth.js api to handle authentication and authorization. By leveraging Auth.js,
 you can also easily add support for any Auth.js [Login Provider](https://authjs.dev/getting-started/providers) such as Auth0, GitHub, Google, etc.
 
 The auth provider is configured in two places when self-hosting:
 
-* The Tina Config
-* The Tina Backend
+* The TinaCMS Config
+* The TinaCMS Backend
 
-## 1. Tina Config (tina/config.ts,tsx,js)
+## 1. TinaCMS Config (tina/config.ts,tsx,js)
 
 This is done by providing an [Auth Provider](/docs/reference/self-hosted/auth-provider/bring-your-own#) to the `authProvider` option in `defineConfig`.
 
@@ -35,7 +35,7 @@ export default defineConfig({
 })
 ```
 
-## 2. Tina Backend
+## 2. TinaCMS Backend
 
 `/api/tina/[...routes].{ts,js}`
 

--- a/content/docs/reference/self-hosted/auth-provider/tinacloud.mdx
+++ b/content/docs/reference/self-hosted/auth-provider/tinacloud.mdx
@@ -14,7 +14,7 @@ NEXT_PUBLIC_TINA_CLIENT_ID=***
 
 ## Configure the auth provider
 
-To enable TinaCloud for auth, make sure the `clientId` property is set to the `NEXT_PUBLIC_TINA_CLIENT_ID` environment variable in your Tina config.
+To enable TinaCloud for auth, make sure the `clientId` property is set to the `NEXT_PUBLIC_TINA_CLIENT_ID` environment variable in your TinaCMS config.
 
 `tina/config.{ts,js}`
 
@@ -33,7 +33,7 @@ export default defineConfig({
 })
 ```
 
-## Update the Tina Backend
+## Update the TinaCMS Backend
 
 First install the `@tinacms/auth` package:
 
@@ -41,7 +41,7 @@ First install the `@tinacms/auth` package:
 yarn add @tinacms/auth
 ```
 
-Next you can update your Tina Backend to use the `TinaCloudBackendAuthProvider` class.
+Next you can update your TinaCMS Backend to use the `TinaCloudBackendAuthProvider` class.
 
 `/pages/api/tina/[...routes].{ts,js}`
 

--- a/content/docs/reference/self-hosted/database-adapter/overview.mdx
+++ b/content/docs/reference/self-hosted/database-adapter/overview.mdx
@@ -8,7 +8,7 @@ previous: ''
 
 ## Overview
 
-A database adapter provides an interface between the Tina database and the underlying database implementation. It implements a limited subset of functionality required by a sorted key-value store, which can be provided by almost any database implementation. We currently have database adapters for the following database implementations:
+A database adapter provides an interface between the TinaCMS database and the underlying database implementation. It implements a limited subset of functionality required by a sorted key-value store, which can be provided by almost any database implementation. We currently have database adapters for the following database implementations:
 
 * [Vercel KV](/docs/reference/self-hosted/database-adapter/vercel-kv)
 * [MongoDB](/docs/reference/self-hosted/database-adapter/mongodb)

--- a/content/docs/reference/self-hosted/database-adapter/vercel-kv.mdx
+++ b/content/docs/reference/self-hosted/database-adapter/vercel-kv.mdx
@@ -3,7 +3,7 @@ title: Vercel KV Database Adapter (Upstash Redis)
 id: '/docs/reference/self-hosted/database-adapter/vercel-kv'
 ---
 
-The Vercel KV database adapter allows you to use the [Vercel KV](https://vercel.com/docs/storage/vercel-kv) database with Tina. This adapter uses the [Upstash Redis client](https://www.npmjs.com/package/@upstash/redis), allowing it to also work with [Upstash Redis](https://docs.upstash.com/redis) as well.
+The Vercel KV database adapter allows you to use the [Vercel KV](https://vercel.com/docs/storage/vercel-kv) database with TinaCMS. This adapter uses the [Upstash Redis client](https://www.npmjs.com/package/@upstash/redis), allowing it to also work with [Upstash Redis](https://docs.upstash.com/redis) as well.
 
 > Looking for the code? Check out the [GitHub repository](https://github.com/tinacms/upstash-redis-level).
 

--- a/content/docs/reference/self-hosted/tina-backend/netlify-functions.mdx
+++ b/content/docs/reference/self-hosted/tina-backend/netlify-functions.mdx
@@ -1,12 +1,12 @@
 ---
 id: /docs/reference/self-hosted/tina-backend/netlify-functions
-title: Hosting The Tina Backend on Netlify Functions
+title: Hosting The TinaCMS Backend on Netlify Functions
 last_edited: '2024-09-04T14:41:43.173Z'
 next: content/docs/reference/self-hosted/git-provider/overview.mdx
 previous: content/docs/reference/self-hosted/tina-backend/vercel-functions.mdx
 ---
 
-If you are not using Next.js but are using Netlify to host your site, you can deploy the Tina Backend as a [Netlify function](https://www.netlify.com/platform/core/functions/). This function will be responsible for handling all TinaCMS requests. This includes the GraphQL API, authentication, and authorization.
+If you are not using Next.js but are using Netlify to host your site, you can deploy the TinaCMS Backend as a [Netlify function](https://www.netlify.com/platform/core/functions/). This function will be responsible for handling all TinaCMS requests. This includes the GraphQL API, authentication, and authorization.
 
 If you want to see Netlify functions in action, check out the [demo repo](https://github.com/tinacms/tina-self-hosted-static-demo)
 

--- a/content/docs/reference/self-hosted/tina-backend/nextjs.mdx
+++ b/content/docs/reference/self-hosted/tina-backend/nextjs.mdx
@@ -1,9 +1,9 @@
 ---
-title: Hosting The Tina Backend on Next.js
+title: Hosting The TinaCMS Backend on Next.js
 id: '/docs/reference/self-hosted/tina-backend/nextjs'
 ---
 
-The Tina Backend is hosted in a single endpoint that is responsible for handling all TinaCMS requests. This includes the GraphQL API, authentication, and authorization.
+The TinaCMS Backend is hosted in a single endpoint that is responsible for handling all TinaCMS requests. This includes the GraphQL API, authentication, and authorization.
 
 The handler can be created with a `TinaNodeBackend` function. This function takes a `TinaNodeBackendOptions` object as an argument.
 

--- a/content/docs/reference/self-hosted/tina-backend/vercel-functions.mdx
+++ b/content/docs/reference/self-hosted/tina-backend/vercel-functions.mdx
@@ -1,9 +1,9 @@
 ---
-title: Hosting The Tina Backend with Vercel Functions
+title: Hosting The TinaCMS Backend with Vercel Functions
 id: '/docs/reference/self-hosted/tina-backend/vercel-functions'
 ---
 
-If you are not using Next.js but are using Vercel to host your site, you can deploy the Tina Backend as a [Vercel Function](https://vercel.com/docs/functions/serverless-functions). This function will be responsible for handling all TinaCMS requests. This includes the GraphQL API, authentication, and authorization.
+If you are not using Next.js but are using Vercel to host your site, you can deploy the TinaCMS Backend as a [Vercel Function](https://vercel.com/docs/functions/serverless-functions). This function will be responsible for handling all TinaCMS requests. This includes the GraphQL API, authentication, and authorization.
 
 If you want to see Vercel Functions in action, check out the [demo repo](https://github.com/tinacms/tina-self-hosted-static-demo)
 

--- a/content/docs/reference/templates.mdx
+++ b/content/docs/reference/templates.mdx
@@ -94,7 +94,7 @@ export default defineConfig({
 })
 ```
 
-Tina uses folder names matching the template to organize files correctly, e.g.:
+TinaCMS uses folder names matching the template to organize files correctly, e.g.:
 
 ```javascript
 /content/pages/marketing/home.md

--- a/content/docs/reference/toolkit/cms.mdx
+++ b/content/docs/reference/toolkit/cms.mdx
@@ -11,11 +11,11 @@ previous: ''
   </>}
 />
 
-The CMS object in Tina is a container for attaching and accessing plugins, APIs, and the event bus. On its own, the CMS does very little; however, since it's the central integration point for everything that Tina does, it's extremely important!
+The CMS object in TinaCMS is a container for attaching and accessing plugins, APIs, and the event bus. On its own, the CMS does very little; however, since it's the central integration point for everything that TinaCMS does, it's extremely important!
 
 ## Accessing the CMS Object
 
-The CMS object can be retrieved from context via the `useCMS` hook (from anywhere within the Tina provider). Reference the available [core properties](/docs/cms#reference) to work with.
+The CMS object can be retrieved from context via the `useCMS` hook (from anywhere within the TinaCMS provider). Reference the available [core properties](/docs/cms#reference) to work with.
 
 ```javascript
 import * as React from 'react'
@@ -42,7 +42,7 @@ export default function ExitButton() {
 
   return (
     <button onClick={() => cms.toggle()}>
-      {cms.enabled ? `Exit Tina` : `Edit with Tina`}
+      {cms.enabled ? `Exit TinaCMS` : `Edit with TinaCMS`}
     </button>
   )
 }

--- a/content/docs/reference/toolkit/fields.mdx
+++ b/content/docs/reference/toolkit/fields.mdx
@@ -9,7 +9,7 @@ last_edited: '2020-08-05T15:33:06.570Z'
   </>}
 />
 
-Field plugins are the components that the editor interacts with to edit a given field. Tina provides some out of the box field plugins for its basic field types. We also allow you to extend any of the provided field plugins, of create your own.
+Field plugins are the components that the editor interacts with to edit a given field. TinaCMS provides some out of the box field plugins for its basic field types. We also allow you to extend any of the provided field plugins, of create your own.
 
 ## Default Field Plugins
 

--- a/content/docs/reference/toolkit/forms.mdx
+++ b/content/docs/reference/toolkit/forms.mdx
@@ -13,7 +13,7 @@ previous: ''
 
 ## Form Configuration
 
-Forms in Tina are built upon the [Final Form](https://final-form.org/) library, and inherit all of Final Form's configuration options.
+Forms in TinaCMS are built upon the [Final Form](https://final-form.org/) library, and inherit all of Final Form's configuration options.
 
 You can see the all of Final Form's form config options in the [Form Config Documentation](https://final-form.org/docs/final-form/types/Config), but the following options will most commonly be used when creating a form:
 
@@ -22,7 +22,7 @@ You can see the all of Final Form's form config options in the [Form Config Docu
 | `initialValues` | An object containing the initial state of the form. |
 | `onSubmit`      | A function that runs when the form is saved.        |
 
-In addition to Final Form's options, Tina's form hooks accept the following additional configuration options:
+In addition to Final Form's options, TinaCMS's form hooks accept the following additional configuration options:
 
 ```typescript
 interface FormOptions<S> {

--- a/content/docs/reference/types.mdx
+++ b/content/docs/reference/types.mdx
@@ -7,7 +7,7 @@ next: content/docs/reference/types/string.mdx
 previous: content/docs/reference/templates.mdx
 ---
 
-Tina contains multiple tools and applications designed to improve collaboration between content writers and developers who work on web content.
+TinaCMS contains multiple tools and applications designed to improve collaboration between content writers and developers who work on web content.
 
 - [`string`](/docs/reference/types/string/)
 - [`number`](/docs/reference/types/number/)

--- a/content/docs/reference/types/boolean.mdx
+++ b/content/docs/reference/types/boolean.mdx
@@ -30,7 +30,7 @@ A toggle input that stores `true` or `false` values.
 
 ## Examples
 
-Tina will generate the appropriate component depending on the configuration provided.
+TinaCMS will generate the appropriate component depending on the configuration provided.
 
 ### Simple field
 

--- a/content/docs/reference/types/display-only.mdx
+++ b/content/docs/reference/types/display-only.mdx
@@ -49,7 +49,7 @@ Because nothing is persisted, `displayOnly` fields don't appear in your content 
 
 ### Info box (built-in helper)
 
-Tina ships an `InfoBox` helper for the common case of showing a short message, optionally with links. Import it from `tinacms` and pass it as `ui.component`.
+TinaCMS ships an `InfoBox` helper for the common case of showing a short message, optionally with links. Import it from `tinacms` and pass it as `ui.component`.
 
 ```tsx
 import { InfoBox } from 'tinacms';

--- a/content/docs/reference/types/number.mdx
+++ b/content/docs/reference/types/number.mdx
@@ -30,7 +30,7 @@ An input field for storing numeric values.
 
 ## Examples
 
-Tina will generate the appropriate component depending on the configuration provided.
+TinaCMS will generate the appropriate component depending on the configuration provided.
 
 ### Simple field
 

--- a/content/docs/reference/types/reference.mdx
+++ b/content/docs/reference/types/reference.mdx
@@ -91,7 +91,7 @@ schema: {
 
 The `post` collection has a `reference` field to the `author` collection.
 
-When editing in Tina, the user will be able to choose a document in the `author` collection for the value of `author`.
+When editing in TinaCMS, the user will be able to choose a document in the `author` collection for the value of `author`.
 
 ![](/img/docs/reference/reference_field_example_tszsxd.png)
 

--- a/content/docs/reference/types/rendering-markdown.mdx
+++ b/content/docs/reference/types/rendering-markdown.mdx
@@ -5,7 +5,7 @@ next: ''
 previous: ''
 ---
 
-When your markdown content is requested through Tina's API, Tina serves a *parsed AST (abstract syntax tree)* version of the content.
+When your markdown content is requested through TinaCMS's API, TinaCMS serves a *parsed AST (abstract syntax tree)* version of the content.
 
 > The *parsed AST* gives developers the ability to step through each node, and render it with full control.
 
@@ -49,7 +49,7 @@ The below example has some sample markdown and associated AST.
 
 ## Inbuilt Markdown Rendering
 
-Tina also provides a `<TinaMarkdown>` component, which renders your `md` or `mdx` component from the *parsed AST* without having to handle the data structure yourself.
+TinaCMS also provides a `<TinaMarkdown>` component, which renders your `md` or `mdx` component from the *parsed AST* without having to handle the data structure yourself.
 
 It's as easy as passing in the markdown content via the `content` attribute.
 
@@ -143,20 +143,20 @@ function CodeBlock({ value, lang = "ts" }) {
 
 If you are using `mdx` as the format, you'll have the ability to define custom components that your editors can leverage.
 
-### How does MDX work with Tina?
+### How does MDX work with TinaCMS?
 
-Tina doesn't require a compilation step like other MDX tooling you
+TinaCMS doesn't require a compilation step like other MDX tooling you
 might be familiar with, so it needs to know about all the possible elements
 you support ahead of time. \
 \
 Instead of doing an `import` statement in MDX,
-you need to register each element as a `template` in your Tina schema.
+you need to register each element as a `template` in your TinaCMS schema.
 
 ### Rich-text templates
 
 This only works for documents of the `mdx` format.
 
-Tina also needs to have each MDX component defined in advance, when you define your collection.
+TinaCMS also needs to have each MDX component defined in advance, when you define your collection.
 
 By defining the above `NewsletterSignup` template, our editors now have the ability to add that template to the page body.
 
@@ -202,7 +202,7 @@ The rich-text field also gets a new 'embed' option for adding in these component
 
 ### Linking to React components
 
-Once you've registered a `template` with a rich-text field in a collection, Tina still needs to know how to render the custom component. Add the key and component to the mapping you pass into the `components` prop on `<TinaMarkdown>`.
+Once you've registered a `template` with a rich-text field in a collection, TinaCMS still needs to know how to render the custom component. Add the key and component to the mapping you pass into the `components` prop on `<TinaMarkdown>`.
 
 The key should match the templates name property.
 

--- a/content/docs/reference/types/rich-text.mdx
+++ b/content/docs/reference/types/rich-text.mdx
@@ -163,7 +163,7 @@ export const heroBlockSchema = {
 
 ## Examples
 
-Tina will generate the appropriate component depending on the
+TinaCMS will generate the appropriate component depending on the
 configuration provided.
 
 ### Simple field


### PR DESCRIPTION
Part of #4845 (batch 4 of the standalone-`Tina` cleanup — English docs, second slice).

## Summary

90 in-content occurrences of standalone `Tina` replaced with `TinaCMS` across three docs subtrees. Same semi-automated approach as #4851: `perl -pi -e 's/\bTina\b(?!\.io|-CMS|-Docs|-Cloud| CMS| Teams| Grande)/TinaCMS/g'` on 43 files, plus targeted edits on `authjs.mdx` to preserve two sample-user names.

## Scope

- `content/docs/reference/` — 40 files (config, fields, collections, templates, types, toolkit, self-hosted/{auth-provider, tina-backend, database-adapter}, content-api, rich-text-usage, media)
- `content/docs/graphql/` — 3 files (cli, queries/add-document, queries/query-documents, queries/advanced/{filter-documents, limitations})
- `content/docs/extending-tina/` — 3 files (edit-state, filename-customization, overview, custom-field-components)

44 files changed, 90 insertions / 90 deletions.

## Intentionally NOT changed (5 hits)

| File:line | Text | Why |
|---|---|---|
| `reference/types/object.mdx:139` | `- name: Tina` (YAML author sample) | Sample content data; the author character is named Tina (like Meet Tina / mascot) |
| `reference/types/object.mdx:349` | same | same |
| `reference/self-hosted/auth-provider/authjs.mdx:57` | `"name": "Tina User"` | Sample JSON user record — a made-up user, not a product reference |
| `reference/self-hosted/auth-provider/authjs.mdx:192` | `"name": "Tina Discord User"` | same |
| `reference/toolkit/fields/blocks.mdx:24` | `[Tina Grande Starter](https://github.com/tinacms/tina-starter-grande)` | Legacy starter's proper name — matches the GitHub repo `tina-starter-grande` |

## Verify

```bash
# after merge, only the 5 sample-data / product-name survivors above should remain:
grep -rnP "\bTina\b" \
  content/docs/reference/ content/docs/graphql/ content/docs/extending-tina/ \
  | grep -vE "TinaCMS|TinaCloud|TinaDocs|TinaGPT|TinaTeach|Tina\.io|Tina-Docs|Tina-Cloud|Tina-CMS|Tina Teams|Tina CMS"
```

## Test plan

- [ ] Preview deploy → spot-check a few:
  - `/docs/reference/config` — mentions of "TinaCMS admin", "TinaCMS Cloud search" (as comment in code sample).
  - `/docs/reference/content-api/data-layer` — "What is the TinaCMS Data Layer?" section renders correctly.
  - `/docs/reference/self-hosted/auth-provider/authjs` — "Update Your TinaCMS Config" / "Update TinaCMS Backend" headings; sample JSON records still show `"Tina User"` verbatim.
  - `/docs/reference/toolkit/fields/blocks` — the "Tina Grande Starter" link is unchanged and still points at `tina-starter-grande`.
  - `/docs/extending-tina/overview` — page title reads "Extending TinaCMS".
  - `/docs/graphql/cli` — "install any required TinaCMS dependencies" etc.
