### PR TITLE
Brand: 'Tina' -> 'TinaCMS' in top-5 hot blog posts (145 hits)

### DIFF
--- a/content/blog/from-cms-to-contextual.mdx
+++ b/content/blog/from-cms-to-contextual.mdx
@@ -11,18 +11,18 @@ prev: content/blog/tina-cms-get-started.mdx
 next: content/blog/data-layer-performant-editing.mdx
 ---
 
-Tina allows you as a developer to create an amazing editing experience. By default the editing experience is a more traditional CMS, where you login to a specific URL and you edit your content without being able to see the content till after you finish your changes. But, if you are looking for a more transparent real-time editing experience, Tina has a superpower, called Visual Editing. Just as it sounds, you get instant feedback on the page as well as being able to preview the changes before publishing live to your site.
+TinaCMS allows you as a developer to create an amazing editing experience. By default the editing experience is a more traditional CMS, where you login to a specific URL and you edit your content without being able to see the content till after you finish your changes. But, if you are looking for a more transparent real-time editing experience, TinaCMS has a superpower, called Visual Editing. Just as it sounds, you get instant feedback on the page as well as being able to preview the changes before publishing live to your site.
 
 <WebmEmbed embedSrc="/img/blog/from-cms-to-contextual/TinaSuper.webm" />
 
 ## Getting our project started
 
-For this blog post we are going to use Tina’s example which is located in the Next.js official examples and allows us to use `create-next-app`.This example is based upon Next.js blog starter which is a markdown blog.
+For this blog post we are going to use TinaCMS’s example which is located in the Next.js official examples and allows us to use `create-next-app`.This example is based upon Next.js blog starter which is a markdown blog.
 
 > You can find the source code in the Next.js examples directory, under the name [cms-tina](https://github.com/vercel/next.js/tree/canary/examples/cms-tina).
 
 ```bash
-## Create our new Tina site
+## Create our new TinaCMS site
 
 npx create-next-app --example cms-tina tina-contextual-editing
 
@@ -33,19 +33,19 @@ cd tina-contextual-editing
 ## Open with your favorite editor
 ```
 
-> If you want to learn how this example was created check out the blog post that covers [getting started with Tina](https://tina.io/blog/tina-cms-get-started/).
+> If you want to learn how this example was created check out the blog post that covers [getting started with TinaCMS](https://tina.io/blog/tina-cms-get-started/).
 
-## What does the Tina code do?
+## What does the TinaCMS code do?
 
-Before you add any code to this example, I want to cover how Tina is integrated and how it works.
+Before you add any code to this example, I want to cover how TinaCMS is integrated and how it works.
 
 ### `.tina` folder
 
-You will find a `.tina` folder in the root of the project, this is the heart and brain of Tina in any project.
+You will find a `.tina` folder in the root of the project, this is the heart and brain of TinaCMS in any project.
 
 ### `schema.ts`
 
-The schema file contains two important pieces of code `defineSchema` and `defineConfig`. The `defineSchema` allows you to define the shape of your content. If you have used a more traditional CMS before you may have done this via a GUI. However, given how Tina is tightly coupled with Git and we treat the filesystem as the “source of truth”, we take the approach of “content-modeling as code”.
+The schema file contains two important pieces of code `defineSchema` and `defineConfig`. The `defineSchema` allows you to define the shape of your content. If you have used a more traditional CMS before you may have done this via a GUI. However, given how TinaCMS is tightly coupled with Git and we treat the filesystem as the “source of truth”, we take the approach of “content-modeling as code”.
 
 If you look at the current defined schema, you will see that each one of the fields is related to the front matter contained within any of the posts in the `_posts` folder.
 
@@ -53,11 +53,11 @@ Moving on to the `defineConfig`, the `defineConfig` tells your project where the
 
 ### `components`
 
-The `components` folder inside the `.tina` holds both our `TinaProvider` and `DynamicTinaProvider`; these two components wrap your application with the power of Tina. We will be heading back here later for some updates.
+The `components` folder inside the `.tina` holds both our `TinaProvider` and `DynamicTinaProvider`; these two components wrap your application with the power of TinaCMS. We will be heading back here later for some updates.
 
 ### `_generated__`
 
-This folder holds all the auto generated files from Tina, if you open this up you will see files that contain queries, fragments and types. You won’t need to make changes here but it’s good to know what you might find in there.
+This folder holds all the auto generated files from TinaCMS, if you open this up you will see files that contain queries, fragments and types. You won’t need to make changes here but it’s good to know what you might find in there.
 
 Before we add visual editing, go ahead and launch the application using `yarn tina-dev` and navigate to [`http://localhost:3000/`](http://localhost:3000/). You will notice that it is a static blog. Feel free to navigate around and get a feel for the blog.
 
@@ -69,7 +69,7 @@ Now if you navigate to [http://localhost:3000/admin](http://localhost:3000/admin
 
 Now you have an understanding of both how the CMS works, and how the code behind is laid out we can start working on adding visual editing to our project. What do we need to do to make visual editing work?
 
-1. Update `getStaticPaths` and `getStaticProps` to use Tina’s graphql layer
+1. Update `getStaticPaths` and `getStaticProps` to use TinaCMS’s graphql layer
 2. Update the page to use `useTina` and power the project props
 3. Update the TinaCMS configuration
 
@@ -308,7 +308,7 @@ const query = `query BlogPostQuery($relativePath: String!) {
 
 ### Adding `useTina` hook
 
-The `useTina` hook is used to make a piece of Tina content editable. It is code-split so in production, this hook will pass through the data value. When you are in edit mode, it registers an editable form in the sidebar.
+The `useTina` hook is used to make a piece of TinaCMS content editable. It is code-split so in production, this hook will pass through the data value. When you are in edit mode, it registers an editable form in the sidebar.
 
 ### Adding imports
 
@@ -338,9 +338,9 @@ We are going to update our props from `({ post, morePosts, preview })` to `(prop
 
 As you can see, we are reusing our query from before and passing the variables, and data to `useTina`. This now means we can power our site using visual editing. Congratulations your site now has superpowers!
 
-### Update our elements to use Tina data
+### Update our elements to use TinaCMS data
 
-Now we have access to our Tina powered data we can go through and update all of our elements to use Tina. You can replace each of the `post.` with `data.getPostsDocument.data.` and then replace the `!post?.slug` with `!props.variables.relativePath` when you are finished your return code should look like:
+Now we have access to our TinaCMS powered data we can go through and update all of our elements to use TinaCMS. You can replace each of the `post.` with `data.getPostsDocument.data.` and then replace the `!post?.slug` with `!props.variables.relativePath` when you are finished your return code should look like:
 
 ```diff
 const router = useRouter()
@@ -412,26 +412,26 @@ Now all we need to do is update our post body content from `data.post.body` to `
 
 ## Next steps
 
-Now that you have visual editing here are a few things you can explore with Tina
+Now that you have visual editing here are a few things you can explore with TinaCMS
 
 * [Media management through Cloudinary](https://tina.io/docs/reference/media/external/cloudinary/)
 * [Route Mapping - connect the CMS to visual editing](/docs/contextual-editing/overview)
 
-## How to keep up to date with Tina?
+## How to keep up to date with TinaCMS?
 
-The best way to keep up with Tina is to subscribe to our newsletter, we send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may of missed and so much more!
+The best way to keep up with TinaCMS is to subscribe to our newsletter, we send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may of missed and so much more!
 
 You can subscribe by following this link and entering your email: [https://tina.io/community/](https://tina.io/community/)
 
-### Tina Community Discord
+### TinaCMS Community Discord
 
-Tina has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and Tina enthusiasts. When you join you will find a place:
+TinaCMS has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and TinaCMS enthusiasts. When you join you will find a place:
 
 * To get help with issues
-* Find the latest Tina news and sneak previews
-* Share your project with Tina community, and talk about your experience
+* Find the latest TinaCMS news and sneak previews
+* Share your project with TinaCMS community, and talk about your experience
 * Chat about the Jamstack
 
-### Tina Twitter
+### TinaCMS Twitter
 
-Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to Tina. We would also be psyched if you tagged us in projects you have built.
+Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to TinaCMS. We would also be psyched if you tagged us in projects you have built.

--- a/content/blog/gatsby-tina-101.mdx
+++ b/content/blog/gatsby-tina-101.mdx
@@ -12,11 +12,11 @@ warningMessage: >-
   implementation. We recommend using [Next.js](/docs/setup-overview/) for a
   solution with less friction.
 seo:
-  title: Gatsby + Tina 101 | TinaCMS Blog
+  title: Gatsby + TinaCMS 101 | TinaCMS Blog
   description: >-
     Learn the basics of integrating Gatsby with TinaCMS in this guide and start
     building fast, dynamic websites with a powerful content management setup.
-title: Gatsby + Tina 101
+title: Gatsby + TinaCMS 101
 date: '2020-02-25T07:00:00.000Z'
 author: Madelyn Eriksen
 prev: content/blog/custom-field-plugins.mdx
@@ -27,19 +27,19 @@ Static site generators like [Gatsby](https://www.gatsbyjs.org/) are a massive wi
 
 Despite the technical gains, **static sites can have a hampered content editing story.** Those comfortable with Git and Markdown might edit files directly. But content authors need a better solution for editing.
 
-[TinaCMS](https://tinacms.org/docs/getting-started/introduction) is an *extensible* toolkit that can help meet these needs. Tina allows developers to use formats we love, like Markdown and JSON, while providing a smooth experience for content authors.
+[TinaCMS](https://tinacms.org/docs/getting-started/introduction) is an *extensible* toolkit that can help meet these needs. TinaCMS allows developers to use formats we love, like Markdown and JSON, while providing a smooth experience for content authors.
 
-To understand better how Tina works, I decided to add it to an existing site, my [Gatsby starter, *Tyra*](https://github.com/madelyneriksen/gatsby-starter-tyra/). What follows is a walkthrough of my process. Feel free to *use this as a reference for adding TinaCMS to an existing Gatsby site!*
+To understand better how TinaCMS works, I decided to add it to an existing site, my [Gatsby starter, *Tyra*](https://github.com/madelyneriksen/gatsby-starter-tyra/). What follows is a walkthrough of my process. Feel free to *use this as a reference for adding TinaCMS to an existing Gatsby site!*
 
 > **In a rush?** Check out the code [on GitHub](https://github.com/madelyneriksen/gatsby-starter-tyra/tree/feature/add-tyra)
 
-## Getting Started with Tina
+## Getting Started with TinaCMS
 
-Tina is a non-intrusive library you can use to add editing capabilities to your site. All your **page generation logic can remain exactly the same**, making it easier to 'drop-in' dynamic content editing.
+TinaCMS is a non-intrusive library you can use to add editing capabilities to your site. All your **page generation logic can remain exactly the same**, making it easier to 'drop-in' dynamic content editing.
 
-There is a collection of plugins you need to install and register with Gatsby to add Tina to your site. Let's do that now.
+There is a collection of plugins you need to install and register with Gatsby to add TinaCMS to your site. Let's do that now.
 
-### Installing Tina
+### Installing TinaCMS
 
 Like most things in the JavaScript world, we can install the packages we need with `npm` or `yarn`. Use whichever package manager is relevant for your project.
 
@@ -51,13 +51,13 @@ npm i --save gatsby-plugin-tinacms gatsby-tinacms-git gatsby-tinacms-remark styl
 yarn add gatsby-plugin-tinacms gatsby-tinacms-git gatsby-tinacms-remark styled-components
 ```
 
-This command adds the Gatsby plugins for Tina itself, to interface Git with Tina, and to support markdown files (via Remark). Since *Tyra* already had the `gatsby-transformer-remark` plugin and all related dependencies installed, I only needed to install plugins specific to TinaCMS.
+This command adds the Gatsby plugins for TinaCMS itself, to interface Git with TinaCMS, and to support markdown files (via Remark). Since *Tyra* already had the `gatsby-transformer-remark` plugin and all related dependencies installed, I only needed to install plugins specific to TinaCMS.
 
 If you're starting from scratch, you'll need to install Gatsby plugins for loading Markdown files. The [Gatsby docs](https://www.gatsbyjs.org/docs/adding-markdown-pages/) have a great guide on using Markdown in Gatsby!
 
-### Configuring Tina
+### Configuring TinaCMS
 
-To add new or complex functionality in Gatsby, you can use a plugin. Tina is no different in this regard. We'll need to add the relevant entries for Tina to our `gatsby-config.js` file.
+To add new or complex functionality in Gatsby, you can use a plugin. TinaCMS is no different in this regard. We'll need to add the relevant entries for TinaCMS to our `gatsby-config.js` file.
 
 ```javascript
 # gatsby-config.js
@@ -85,11 +85,11 @@ module.exports = {
 
 Since the content *Tyra* is Git-based, all edits need to be committed back into the repository. `gatsby-tinacms-git` tracks content changes and handles the creation of new commits with content. By default, changes are pushed to a remote branch, but the plugin is configurable.
 
-## Tina-Powered Editing
+## TinaCMS-Powered Editing
 
 In the *Tyra Starter*, the functional `Post` template creates all blog posts. `Post` renders Markdown content, SEO-focused metadata, and the hero image for each post.
 
-To enable editing, we can wrap the `Post` component in a Higher-Order Component provided by Tina — `inlineRemarkForm`.
+To enable editing, we can wrap the `Post` component in a Higher-Order Component provided by TinaCMS — `inlineRemarkForm`.
 
 Here's what that looks like:
 
@@ -103,7 +103,7 @@ import Body from './components/body.js'
 import Seo from './seo.js'
 import MetaSeo from '../common/seo'
 import { graphql } from 'gatsby'
-// New Tina Import!
+// New TinaCMS Import!
 import { inlineRemarkForm } from 'gatsby-tinacms-remark'
 
 const Post = ({ location, data }) => {
@@ -162,7 +162,7 @@ export const query = graphql`
           }
         }
       }
-      # Tina uses additional, specialized query data.
+      # TinaCMS uses additional, specialized query data.
       # Add the required data using this GraphQL fragment.
       ...TinaRemark
     }
@@ -178,24 +178,24 @@ export const query = graphql`
 export default inlineRemarkForm(Post, { queryName: 'post' })
 ```
 
-`inlineRemarkForm` will take our `Post` component as an argument and **return a component wrapped with Tina plumbing.** [Higher-Order Components](https://reactjs.org/docs/higher-order-components.html) inject custom logic into existing React components.
+`inlineRemarkForm` will take our `Post` component as an argument and **return a component wrapped with TinaCMS plumbing.** [Higher-Order Components](https://reactjs.org/docs/higher-order-components.html) inject custom logic into existing React components.
 
-In our GraphQL query, we've added a fragment, `TinaRemark`, that pulls out extra data for Tina to edit files. I also used a non-standard query name for my post data (`post`). Thankfully, it's easy to change what data Tina uses by passing in a configuration object to `inlineRemarkForm`.
+In our GraphQL query, we've added a fragment, `TinaRemark`, that pulls out extra data for TinaCMS to edit files. I also used a non-standard query name for my post data (`post`). Thankfully, it's easy to change what data TinaCMS uses by passing in a configuration object to `inlineRemarkForm`.
 
-At this point, if we start our application, we can hop over to [localhost:8000](http://localhost:8000/) and see that Tina is working!
+At this point, if we start our application, we can hop over to [localhost:8000](http://localhost:8000/) and see that TinaCMS is working!
 
 ```bash
 # Start the dev server
 npm start
 ```
 
-Navigate to a blog post and click the "Pencil" icon in the bottom left-hand corner. The Tina sidebar should appear and let you edit your Markdown posts.
+Navigate to a blog post and click the "Pencil" icon in the bottom left-hand corner. The TinaCMS sidebar should appear and let you edit your Markdown posts.
 
 ![Woohoo! Markdown editing is working!](/img/blog/gatsby-tina-101/madalyn_blog_1.png)
 
-Awesome right? Here I've changed the author from "Jane Doe" to "Madelyn Eriksen". I can save those changes in the Tina sidebar too. That process triggers an automatic commit in `git` and pushes to a remote branch.
+Awesome right? Here I've changed the author from "Jane Doe" to "Madelyn Eriksen". I can save those changes in the TinaCMS sidebar too. That process triggers an automatic commit in `git` and pushes to a remote branch.
 
-**How Tina interacts with Git is entirely configurable.** It's possible to change the commit message, disable automatic commits, or even change the Git user.
+**How TinaCMS interacts with Git is entirely configurable.** It's possible to change the commit message, disable automatic commits, or even change the Git user.
 
 ```diff
 //gatsby-config.js
@@ -230,7 +230,7 @@ Right now our sidebar forms for editing are 'okay,' but there's room for improve
 
 There are also fields *Tyra* uses that should be "private" and not available to edit in the sidebar. For example, the `type` frontmatter value to identify posts.
 
-We can configure the sidebar form by passing in a `FormConfig` object to Tina. [Customizing forms with Tina](/docs/guides/converting-gatsby-to-tina) is straightforward. We need to define a JavaScript object to declare the desired form fields for Tina to render.
+We can configure the sidebar form by passing in a `FormConfig` object to TinaCMS. [Customizing forms with TinaCMS](/docs/guides/converting-gatsby-to-tina) is straightforward. We need to define a JavaScript object to declare the desired form fields for TinaCMS to render.
 
 Back in `src/blog/post.js`, we can add this configuration object:
 
@@ -307,9 +307,9 @@ const FormConfig = {
 export default inlineRemarkForm(Post, FormConfig)
 ```
 
-In the `FormConfig`, we're using `text`, `markdown`, `date`, and even `image` fields to make the post authoring experience nicer. Tina has [a bunch](https://tinacms.org/docs/plugins/fields/) of built-in fields, and even allows you to [add your own](https://tinacms.org/docs/plugins/fields/custom-fields).
+In the `FormConfig`, we're using `text`, `markdown`, `date`, and even `image` fields to make the post authoring experience nicer. TinaCMS has [a bunch](https://tinacms.org/docs/plugins/fields/) of built-in fields, and even allows you to [add your own](https://tinacms.org/docs/plugins/fields/custom-fields).
 
-The `image` field can be tricky to configure. For the *post image*, we need Tina to handle image uploads, as well as update previews. To configure uploads, you declare the upload directory and parse out a preview thumbnail from the uploaded image.
+The `image` field can be tricky to configure. For the *post image*, we need TinaCMS to handle image uploads, as well as update previews. To configure uploads, you declare the upload directory and parse out a preview thumbnail from the uploaded image.
 
 ```javascript
 {
@@ -341,7 +341,7 @@ Even with the fancy sidebar, it'd sure be nicer to just edit content right on th
 
 Inline editing means **changing the page content on the page itself**. Rather than using a different authoring screen, you can click on the page to start making edits. It's an intuitive way to edit content for the web.
 
-Thankfully, Tina supports inline editing with a "what you see is what you get" (WYSIWYG) editor for Markdown! Adding an inline editor only requires a few changes to our Tina configuration code.
+Thankfully, TinaCMS supports inline editing with a "what you see is what you get" (WYSIWYG) editor for Markdown! Adding an inline editor only requires a few changes to our TinaCMS configuration code.
 
 ### Adding Edit Props
 
@@ -480,9 +480,9 @@ Before adding the inline editor, we had a `div` that renders internal HTML. To c
 </TinaField>
 ```
 
-Since it's wrapping Markdown body, we assign the `name` prop the value `rawMarkdownBody`. To render the WYSIWYG editor, we pass in the `Wysiwyg` component from `@tinacms/fields` as a property. **Tina renders this component when "edit mode" is active.**
+Since it's wrapping Markdown body, we assign the `name` prop the value `rawMarkdownBody`. To render the WYSIWYG editor, we pass in the `Wysiwyg` component from `@tinacms/fields` as a property. **TinaCMS renders this component when "edit mode" is active.**
 
-Of course, we also have to import the relevant Tina components to be able to *use* them:
+Of course, we also have to import the relevant TinaCMS components to be able to *use* them:
 
 ```javascript
 import { Wysiwyg } from '@tinacms/fields'
@@ -493,11 +493,11 @@ With those code snippets added, we can actually use the inline editor to change 
 
 ![Woah! Now that's fancy.](/img/blog/gatsby-tina-101/madalyn_blog_4.png)
 
-To finish of our editing experience, all we really need is the ability to add new posts using Tina!
+To finish of our editing experience, all we really need is the ability to add new posts using TinaCMS!
 
 ## Authoring New Posts
 
-Tina has a type of plugin to create content, aptly named [content creator plugins](/docs/plugins/content-creators). Content creators are like factories that create file objects, except they are "plugged in" to your React site.
+TinaCMS has a type of plugin to create content, aptly named [content creator plugins](/docs/plugins/content-creators). Content creators are like factories that create file objects, except they are "plugged in" to your React site.
 
 Let's make a *content creator plugin* to author new blog posts. We'll add it in a new directory called "plugins" — `src/blog/plugins/postCreator.js`:
 
@@ -560,7 +560,7 @@ export default CreatePostPlugin
 
 `RemarkCreatorPlugin` from `gatsby-tinacms-remark` uses a configuration object to instantiate a new 'content-creator' plugin. Note that defining `fields` in the config object follows the same pattern as those seen in content editing forms.
 
-You also can control the generated frontmatter using the `frontmatter` property. Tina expects a function that transforms an object with form values into an object that becomes the frontmatter.
+You also can control the generated frontmatter using the `frontmatter` property. TinaCMS expects a function that transforms an object with form values into an object that becomes the frontmatter.
 
 I added a function called `defaultFrontmatter` to convert those form values into the frontmatter of a Markdown file. Additionally, "private" parts of the frontmatter, like the `type` field, have values added directly.
 
@@ -578,13 +578,13 @@ const defaultFrontmatter = form => ({
 })
 ```
 
-What you need in each post will be different for every site. This is the best part — **Tina works with the code you have**, rather than requiring you to accommodate it.
+What you need in each post will be different for every site. This is the best part — **TinaCMS works with the code you have**, rather than requiring you to accommodate it.
 
 ### Adding the Plugin to the Site
 
 I wanted content authors to be able to add new posts to the site from anywhere. With this in mind, I added the *content creator* plugin to the root layout component.
 
-The `withPlugin` Higher-Order Component allows you to register new plugins to Tina with ease:
+The `withPlugin` Higher-Order Component allows you to register new plugins to TinaCMS with ease:
 
 ```javascript
 // src/common/layouts/index.js
@@ -623,14 +623,14 @@ Now we can use our new plugin in the sidebar! Hitting the "plus" icon in the sid
 
 ## Conclusions + Next Steps
 
-That's all it takes to create a basic blog CMS with Tina! 🎉 We've allowed content authors to easily create and edit new posts, right on the blog itself. You can **check out the finished result** over [on GitHub](https://github.com/madelyneriksen/gatsby-starter-tyra/tree/feature/add-tyra)!
+That's all it takes to create a basic blog CMS with TinaCMS! 🎉 We've allowed content authors to easily create and edit new posts, right on the blog itself. You can **check out the finished result** over [on GitHub](https://github.com/madelyneriksen/gatsby-starter-tyra/tree/feature/add-tyra)!
 
-This only scratches the surface of what you can build using Tina. If you want to go further, there's several more advanced features you can use to expand your Gatsby site!
+This only scratches the surface of what you can build using TinaCMS. If you want to go further, there's several more advanced features you can use to expand your Gatsby site!
 
 * Creating [custom form fields](https://tinacms.org/docs/plugins/fields/custom-fields) for new data types,
 * Or adding [block-level editing](https://tinacms.org/docs/plugins/fields/blocks) to allow for completely custom pages!
 
-The Tina project is also [active on GitHub](https://github.com/tinacms/tinacms), with a [guide to contribution](https://tinacms.org/docs/contributing/guidelines) if you want to hack on the code!
+The TinaCMS project is also [active on GitHub](https://github.com/tinacms/tinacms), with a [guide to contribution](https://tinacms.org/docs/contributing/guidelines) if you want to hack on the code!
 
 ***
 

--- a/content/blog/new-year-new-cms.mdx
+++ b/content/blog/new-year-new-cms.mdx
@@ -18,13 +18,13 @@ prev: content/blog/2021-a-year-in-review.mdx
 next: content/blog/syntax-highlighting-with-tina.mdx
 ---
 
-Here we are, the new year is upon us, and if you are like us, you have set some New Year’s resolutions for yourself. We are big fans of the fresh start and self-improvement that comes along with this time of year. Have you set any resolutions, maybe building or rebuilding your own personal site, starting a new business, or giving your portfolio a new lick of pain?. That means that you will need a CMS to handle all the content that drives your site and we think Tina can fill the role in some unique ways.
+Here we are, the new year is upon us, and if you are like us, you have set some New Year’s resolutions for yourself. We are big fans of the fresh start and self-improvement that comes along with this time of year. Have you set any resolutions, maybe building or rebuilding your own personal site, starting a new business, or giving your portfolio a new lick of pain?. That means that you will need a CMS to handle all the content that drives your site and we think TinaCMS can fill the role in some unique ways.
 
-## Why Tina?
+## Why TinaCMS?
 
 ### Git Backed
 
-Traditionally when you sign up for a CMS, your content is locked into the vendor. This means if you decide that the CMS is not for you, you have to find a way to export that data and import it into your new CMS. That is not what Tina is about, we don’t want to hold you or your content hostage. In fact, Tina doesn’t store any of your data, it is stored in a GitHub repository that you own. Yep, that is right, you own and control it all. In addition to feeling secure that you own your own content, there are many practical advantages to this approach such as:
+Traditionally when you sign up for a CMS, your content is locked into the vendor. This means if you decide that the CMS is not for you, you have to find a way to export that data and import it into your new CMS. That is not what TinaCMS is about, we don’t want to hold you or your content hostage. In fact, TinaCMS doesn’t store any of your data, it is stored in a GitHub repository that you own. Yep, that is right, you own and control it all. In addition to feeling secure that you own your own content, there are many practical advantages to this approach such as:
 
 * Easy to track when and what changed in your project
 * CI / CD support
@@ -32,63 +32,63 @@ Traditionally when you sign up for a CMS, your content is locked into the vendor
 
 ### Visual Editing
 
-Tina is different from a traditional headless CMS, where you enter your data into a form with no context of how it will behave or look on your site. You then have to kick off a build and navigate to your site to see the changes.
-When you use Tina, the content is edited using a sidebar on your site, you get to see the changes in real time as you make them. This allows you to see exactly what you are editing or creating and how it will look and behave. No more saves, previews, refreshes after every few edits. Once you are happy with the changes, you can hit save and Tina will commit it directly to your GitHub repository and the rebuild process will begin.
+TinaCMS is different from a traditional headless CMS, where you enter your data into a form with no context of how it will behave or look on your site. You then have to kick off a build and navigate to your site to see the changes.
+When you use TinaCMS, the content is edited using a sidebar on your site, you get to see the changes in real time as you make them. This allows you to see exactly what you are editing or creating and how it will look and behave. No more saves, previews, refreshes after every few edits. Once you are happy with the changes, you can hit save and TinaCMS will commit it directly to your GitHub repository and the rebuild process will begin.
 
 ### Native MDX Support
 
-Tina can support MDX out of the box, this means you can create reusable components and Tina can provide an easy way for anyone editing or creating content to add them to the page, no matter how experienced they are.
+TinaCMS can support MDX out of the box, this means you can create reusable components and TinaCMS can provide an easy way for anyone editing or creating content to add them to the page, no matter how experienced they are.
 
 Other headless CMSs require the users who are creating the content to remember the Component names, use the correct syntax when using them, as well as transform the data using mdx-remote or something similar. This is fine for an experienced developer but if you want to bring on guests who have zero experience it is a steep learning curve. Seriously, ask your editor friends about this, see the rage and/or fear in their eyes.
 
 We include a button that will allow anyone to click, select the user-friendly named component, and add it to the page. They can then dynamically edit that component with the correct text, images, or styles that you defined.
-Tina also doesn’t require you to transform the MDX or hydrate your components, making it easier to integrate then traditional CMS.
+TinaCMS also doesn’t require you to transform the MDX or hydrate your components, making it easier to integrate then traditional CMS.
 
 ## Three ways to get started in under five minutes
 
-### Tina Quickstart
+### TinaCMS Quickstart
 
-Our [Tina Quickstart ](https://app.tina.io/quickstart) flow is a web based way to get started with Tina, it allows you to choose from one of our starters (Tina Barebones, Tina Documentation Starter, TinaCloud Starter) and deploy directly to Vercel.
+Our [TinaCMS Quickstart ](https://app.tina.io/quickstart) flow is a web based way to get started with TinaCMS, it allows you to choose from one of our starters (TinaCMS Barebones, TinaCMS Documentation Starter, TinaCloud Starter) and deploy directly to Vercel.
 
-This approach allows you to see how Tina works in a production deployment almost immediately . This is great for getting to know what Tina can do, how Tina works,and show it to others such as your content team.
+This approach allows you to see how TinaCMS works in a production deployment almost immediately . This is great for getting to know what TinaCMS can do, how TinaCMS works,and show it to others such as your content team.
 
 <WebmEmbed embedSrc="/img/blog/new-year-new-cms/tina-quickstart.webm" />
 
 ### `npx create-tina-app`
 
-`create-tina-app` allows you to work locally with one of our starters, this allows you to see how all the code behind the scenes is working before you decide that Tina is right for you.
+`create-tina-app` allows you to work locally with one of our starters, this allows you to see how all the code behind the scenes is working before you decide that TinaCMS is right for you.
 
 To use the `create-tina-app` you will need `Node 14+` .This doesn't require you to already have an application and will create a new project and directory and allow you to start developing locally.
 
 <WebmEmbed embedSrc="/img/blog/new-year-new-cms/create-tina-app.webm" />
 
-### Tina CLI
+### TinaCMS CLI
 
-Tina CLI (`npx @tincms/cli@latest init`) allows you to add Tina to an existing Next.js application. When using the CLI we will take care of the important pieces including:
+TinaCMS CLI (`npx @tincms/cli@latest init`) allows you to add TinaCMS to an existing Next.js application. When using the CLI we will take care of the important pieces including:
 
-* Adding all the Tina dependencies
+* Adding all the TinaCMS dependencies
 * Setting up a .tina folder with a basic schema
-* Creating a demo directory with an example Tina powered page
+* Creating a demo directory with an example TinaCMS powered page
 * Creating an admin route
-* Ensuring Tina best practices are used
+* Ensuring TinaCMS best practices are used
 
-Using the Tina CLI allows you to add Tina and selectively integrate it into your existing Next.js application. This allows you to keep your established site and slowly bring the power of Tina to your editors and content team. Though once you use it, we are not sure how slowly you will want to move.
+Using the TinaCMS CLI allows you to add TinaCMS and selectively integrate it into your existing Next.js application. This allows you to keep your established site and slowly bring the power of TinaCMS to your editors and content team. Though once you use it, we are not sure how slowly you will want to move.
 
 <WebmEmbed embedSrc="/img/blog/new-year-new-cms/tina-cli.webm" />
 
-## Where can you keep up to date with Tina?
+## Where can you keep up to date with TinaCMS?
 
-You know that you will want to be part of this creative, innovative, supportive community of developers (and even some editors and designers) who are experimenting and implementing Tina daily.
+You know that you will want to be part of this creative, innovative, supportive community of developers (and even some editors and designers) who are experimenting and implementing TinaCMS daily.
 
-### Tina Community Discord
+### TinaCMS Community Discord
 
-Tina has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and Tina enthusiasts. When you join you will find a place:
+TinaCMS has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and TinaCMS enthusiasts. When you join you will find a place:
 
 * To get help with issues
-* Find the latest Tina news and sneak previews
-* Share your project with Tina community, and talk about your experience
+* Find the latest TinaCMS news and sneak previews
+* Share your project with TinaCMS community, and talk about your experience
 * Chat about the Jamstack
 
-### Tina Twitter
+### TinaCMS Twitter
 
-Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to Tina. We would also be psyched if you tagged us in projects you have built.
+Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to TinaCMS. We would also be psyched if you tagged us in projects you have built.

--- a/content/blog/tina-cms-get-started.mdx
+++ b/content/blog/tina-cms-get-started.mdx
@@ -11,31 +11,31 @@ prev: content/blog/tinacms-2022.mdx
 next: content/blog/from-cms-to-contextual.mdx
 ---
 
-Until now, as a Tina user, you have enjoyed visual editing when interacting with your content. We know that while this experience is first class for your content team, the amount of time it takes to implement Tina with visual editing into your application is longer than you may want to invest when testing a new CMS.
+Until now, as a TinaCMS user, you have enjoyed visual editing when interacting with your content. We know that while this experience is first class for your content team, the amount of time it takes to implement TinaCMS with visual editing into your application is longer than you may want to invest when testing a new CMS.
 
-## Tina as a CMS in a traditional way
+## TinaCMS as a CMS in a traditional way
 
-In order to give the best experience to all users, Tina now offers two ways to edit content, visual editing and a more traditional looking CMS. Except with our traditional CMS, we are still powered by Markdown, JSON, or MDX and backed by Git. Here is a quick GIF of what it looks like implemented on a deployed website:
+In order to give the best experience to all users, TinaCMS now offers two ways to edit content, visual editing and a more traditional looking CMS. Except with our traditional CMS, we are still powered by Markdown, JSON, or MDX and backed by Git. Here is a quick GIF of what it looks like implemented on a deployed website:
 
 <WebmEmbed embedSrc="/img/blog/mdx-powered-docs/example.webm" />
 
-### How to implement Tina?
+### How to implement TinaCMS?
 
-When we launched Tina + Cloud in it’s alpha, you had to do the following to get Tina integrated and we only supported visual editing:
+When we launched TinaCMS + Cloud in it’s alpha, you had to do the following to get TinaCMS integrated and we only supported visual editing:
 
-1. Add Tina using `npx @tinacms/cli init`
+1. Add TinaCMS using `npx @tinacms/cli init`
 2. Create your schema for your Markdown
 3. Implement your queries, for `getStaticPaths` and `getStaticProps`
 4. Handle the props to make your content editable.
 
-These steps are now cut in half. When you use just Tina as a CMS without visual editing, you will only need to do:
+These steps are now cut in half. When you use just TinaCMS as a CMS without visual editing, you will only need to do:
 
-1. Add Tina using `npx @tinacms/cli init`
+1. Add TinaCMS using `npx @tinacms/cli init`
 2. Create your schema for your Markdown
 
 With that being said, let’s use the Next.js starter to create an editable blog using just the CMS.
 
-The first step is to create the blog starter and initialize Tina
+The first step is to create the blog starter and initialize TinaCMS
 
 ```bash
 #Create your blog
@@ -44,25 +44,25 @@ npx create-next-app --example blog-starter tina-cms-blog
 # Move into your new blog
 cd tina-cms-blog
 
-# Intialize Tina
+# Intialize TinaCMS
 npx @tinacms/cli@latest init
 
 ```
 
-So what did Tina CLI do? It did a number of thing in your Next.js application:
+So what did TinaCMS CLI do? It did a number of thing in your Next.js application:
 
-1. Installs all required dependencies for Tina.
+1. Installs all required dependencies for TinaCMS.
 2. Defines a basic content schema in the `.tina` directory.
 3. Creates example content in the demo directory.
 4. Edits the `package.json` to add scripts to launch tina (tina-dev, tina-build, tina-start).
 
 ### Time to test
 
-Now that you have Tina setup you can launch your application using the following command:
+Now that you have TinaCMS setup you can launch your application using the following command:
 
 `yarn tina-dev`
 
-Now, if you navigate to [http://localhost:3000/admin](http://localhost:3000/admin) you will see a new page. Go ahead and click the Edit with Tina button.
+Now, if you navigate to [http://localhost:3000/admin](http://localhost:3000/admin) you will see a new page. Go ahead and click the Edit with TinaCMS button.
 
 ![](/img/blog/getting-started-tina-admin/login-example.webp)
 You will land on a page that looks like this:
@@ -71,19 +71,19 @@ You will land on a page that looks like this:
 
 ### Edit the content
 
-If you select “Blog Posts” on the left of the screen it will show you all the available posts for editing, you might notice that Tina placed a blog post named “Hello World” for you to look at. Go ahead and click it, and you will see an editable form. Feel free to change the title or the body and hit the save button.
+If you select “Blog Posts” on the left of the screen it will show you all the available posts for editing, you might notice that TinaCMS placed a blog post named “Hello World” for you to look at. Go ahead and click it, and you will see an editable form. Feel free to change the title or the body and hit the save button.
 
-![Example of editing with Tina](/img/blog/getting-started-tina-admin/editing-example.jpg)
+![Example of editing with TinaCMS](/img/blog/getting-started-tina-admin/editing-example.jpg)
 
 ### What exactly happened?
 
-When you hit save, Tina’s GraphQL layer saves those changes directly in the Markdown file “HelloWorld.md” located in the content/posts directory. Go ahead, open it up, see your new changes.
+When you hit save, TinaCMS’s GraphQL layer saves those changes directly in the Markdown file “HelloWorld.md” located in the content/posts directory. Go ahead, open it up, see your new changes.
 
-> When you do this in production, Tina will commit this directly to GitHub for you!
+> When you do this in production, TinaCMS will commit this directly to GitHub for you!
 
 ## Making the starter blog editable
 
-Now you have seen Tina editing in action, let’s make the Next.js starter content editable. The first step is to define the shape of our content. You will see a folder called `.tina` which contains a `schema.ts` file. This file allows you to instruct Tina's Content API which content type to look for, how it should be labeled, and much more!
+Now you have seen TinaCMS editing in action, let’s make the Next.js starter content editable. The first step is to define the shape of our content. You will see a folder called `.tina` which contains a `schema.ts` file. This file allows you to instruct TinaCMS's Content API which content type to look for, how it should be labeled, and much more!
 
 ### Collections
 
@@ -145,7 +145,7 @@ As you can see, you have quite a few fields that you want your content team to b
 
 ### Making changes to the Schema
 
-Open up the Tina `schema.ts` file located at `/.tina/schema.ts` To begin with underneath the object provided, you need to replace the current collection with the content you want:
+Open up the TinaCMS `schema.ts` file located at `/.tina/schema.ts` To begin with underneath the object provided, you need to replace the current collection with the content you want:
 
 ```diff
 {
@@ -261,23 +261,23 @@ Now the new schema is ready, go ahead and restart your server using `yarn tina-d
 
 If you choose the first post “dynamic routing” you will see all of the fields that we defined in our schema which match all the front matter. Go ahead and edit some fields like the title or the body and hit save. Now if you navigate to `http://localhost:3000/posts/dynamic-routing` you will see those changes!
 
-## Where can you try, or keep up to date with Tina?
+## Where can you try, or keep up to date with TinaCMS?
 
-If you haven’t had a chance to try Tina yet, and don't have time to follow this tutorial, spin up a starter site on TinaCloud or with the command line and share your feedback.
+If you haven’t had a chance to try TinaCMS yet, and don't have time to follow this tutorial, spin up a starter site on TinaCloud or with the command line and share your feedback.
 
 <CreateAppCta ctaText="Try a starter" cliText="npx create-tina-app@latest" />
 
-You know that you will want to be part of this creative, innovative, supportive community of developers (and even some editors and designers) who are experimenting and implementing Tina daily.
+You know that you will want to be part of this creative, innovative, supportive community of developers (and even some editors and designers) who are experimenting and implementing TinaCMS daily.
 
-### Tina Community Discord
+### TinaCMS Community Discord
 
-Tina has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and Tina enthusiasts. When you join you will find a place:
+TinaCMS has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and TinaCMS enthusiasts. When you join you will find a place:
 
 * To get help with issues
-* Find the latest Tina news and sneak previews
-* Share your project with Tina community, and talk about your experience
+* Find the latest TinaCMS news and sneak previews
+* Share your project with TinaCMS community, and talk about your experience
 * Chat about the Jamstack
 
-### Tina Twitter
+### TinaCMS Twitter
 
-Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to Tina. We would also be psyched if you tagged us in projects you have built.
+Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to TinaCMS. We would also be psyched if you tagged us in projects you have built.

--- a/content/blog/using-tinacms-with-nextjs.mdx
+++ b/content/blog/using-tinacms-with-nextjs.mdx
@@ -13,27 +13,27 @@ prev: content/blog/introducing-tina-grande.mdx
 next: content/blog/deprecating-tina-git-server.mdx
 ---
 
-## Tina + Next: Part II
+## TinaCMS + Next: Part II
 
-This blog is a part of a series exploring the use of Next.js + Tina. In [Part I](https://tinacms.org/blog/simple-markdown-blog-nextjs/), you learned how to create a simple markdown-based blog with Next. In this post you’ll add content editing capacity by configuring the site with TinaCMS.
+This blog is a part of a series exploring the use of Next.js + TinaCMS. In [Part I](https://tinacms.org/blog/simple-markdown-blog-nextjs/), you learned how to create a simple markdown-based blog with Next. In this post you’ll add content editing capacity by configuring the site with TinaCMS.
 
 ### Next.js Recap ▲
 
 [Next.js](https://nextjs.org/) is **a React “meta-framework”** (a framework built on a framework) for developing web applications, built by the team at [Vercel](https://vercel.com/). Read [Part I](/blog/simple-markdown-blog-nextjs/) to get familiar with Next.js basics.
 
-### Tina Overview 🦙
+### TinaCMS Overview 🦙
 
-[Tina](https://tina.io/) is a Git-backed headless content management system that enables developers and content creators to collaborate seamlessly. With Tina, developers can create a custom visual editing experience that is perfectly tailored to their site.
+[TinaCMS](https://tina.io/) is a Git-backed headless content management system that enables developers and content creators to collaborate seamlessly. With TinaCMS, developers can create a custom visual editing experience that is perfectly tailored to their site.
 
-The best way to get a feel for how Tina works is to use it. We hope that by the end of this tutorial, you’ll not only learn how to use Tina, but also how Tina rethinks the way a CMS should work.
+The best way to get a feel for how TinaCMS works is to use it. We hope that by the end of this tutorial, you’ll not only learn how to use TinaCMS, but also how TinaCMS rethinks the way a CMS should work.
 
 ## Let’s Get Started
 
 ![tinacms editing gif](/gif/tina-nextjs.gif)
 
-This tutorial will show you how to install and **configure Tina for editing content on a simple markdown-based blog** that was created in last week’s post. If you want to dig into how the base blog was made, read [Part I](/blog/simple-markdown-blog-nextjs/) of this series.
+This tutorial will show you how to install and **configure TinaCMS for editing content on a simple markdown-based blog** that was created in last week’s post. If you want to dig into how the base blog was made, read [Part I](/blog/simple-markdown-blog-nextjs/) of this series.
 
-> Jump ahead and check out the [Tina documentation](/docs/setup-overview/) here
+> Jump ahead and check out the [TinaCMS documentation](/docs/setup-overview/) here
 
 ### Set up Locally 🏡
 
@@ -46,7 +46,7 @@ $ git clone https://github.com/tinalabs/brevifolia-next-2022 next-tina-blog
 # navigate to the directory
 $ cd next-tina-blog
 
-# install dependencies & init Tina
+# install dependencies & init TinaCMS
 $ yarn install
 $ npx @tinacms/cli@latest init
 
@@ -55,15 +55,15 @@ $ do you want us to override your _app.js? Yes
 
 The `npx @tinacms/cli@latest init` command does a few things in your Next.js application:
 
-* Install all required dependencies for Tina
+* Install all required dependencies for TinaCMS
 * Define a basic schema that is easily extendable, in the .tina directory
-* Wrap your next.js application with Tina so that any page can be easily edited.
+* Wrap your next.js application with TinaCMS so that any page can be easily edited.
 * Create example content in the demo directory.
 * Edit the package.json to add scripts to launch tina (dev, build, start)
 
 ### A quick test
 
-Now that you have a basic Tina setup you can launch your application using the following command:
+Now that you have a basic TinaCMS setup you can launch your application using the following command:
 
 ```bash
 yarn dev
@@ -74,7 +74,7 @@ Once you have launched the application you have a couple of new URLS:
 * `http://localhost:3000/demo/blog/HelloWorld`
 * `http://localhost:4001/altair/`
 
-The first URL brings you to a demo of TinaCMS, it will show you the power of Tina and also give you some informational links to check out. If you navigate to [http://localhost:3000/demo/blog/HelloWorld](http://localhost:3000/demo/blog/HelloWorld), you won't be able to edit right away. First, you need to enter edit mode. To enter edit mode, navigate to [http://localhost:3000/admin](http://localhost:3000/admin), select login. Then navigate back to [http://localhost:3000/demo/blog/HelloWorld](http://localhost:3000/demo/blog/HelloWorld). Selecting the pencil in the top left allows you to edit the title and the body of the page right in the frontend. When you hit save, that will save your changes to the Markdown file.
+The first URL brings you to a demo of TinaCMS, it will show you the power of TinaCMS and also give you some informational links to check out. If you navigate to [http://localhost:3000/demo/blog/HelloWorld](http://localhost:3000/demo/blog/HelloWorld), you won't be able to edit right away. First, you need to enter edit mode. To enter edit mode, navigate to [http://localhost:3000/admin](http://localhost:3000/admin), select login. Then navigate back to [http://localhost:3000/demo/blog/HelloWorld](http://localhost:3000/demo/blog/HelloWorld). Selecting the pencil in the top left allows you to edit the title and the body of the page right in the frontend. When you hit save, that will save your changes to the Markdown file.
 
 > Want to see your changes? Open up the file located at `/content/posts/HelloWorld.md` and the changes you've made will be there! This works by using our Content API which will go into greater depth during this guide.
 
@@ -82,7 +82,7 @@ The second URL [http://localhost:4001/altair/](http://localhost:4001/altair/) wi
 
 ## Defining the shape of our content
 
-One key element of Tina is defining a schema that allows you to shape and interact with the content on the page. Opening up the project, you will see a folder called `.tina` which contains a `schema.ts` file. This file allows you to instruct Tina's Content API which content type to look for, how it should be labeled, and much more!
+One key element of TinaCMS is defining a schema that allows you to shape and interact with the content on the page. Opening up the project, you will see a folder called `.tina` which contains a `schema.ts` file. This file allows you to instruct TinaCMS's Content API which content type to look for, how it should be labeled, and much more!
 
 Before you look at your current project, let's discuss how the content is shaped. Our schema can be broken down into three concepts: `collections`, `fields` and `references`. Each one of them has its role:
 
@@ -144,7 +144,7 @@ As you can see, you have a few fields that you want to be able to edit as well a
 
 ### Making changes to the Schema
 
-Open up the Tina `schema.ts` file located at `/.tina/schema.ts` To begin with underneath the object we provided, you need to replace the current collection with the content you want:
+Open up the TinaCMS `schema.ts` file located at `/.tina/schema.ts` To begin with underneath the object we provided, you need to replace the current collection with the content you want:
 
 ```diff
 {
@@ -222,7 +222,7 @@ Second, there's a `string` field called `body` with `isBody` set to true. By set
 
 Your Markdown files are now backed by a well-defined schema, this paves the way for us to query file content with GraphQL. You will notice that nothing has changed when navigating around the Next.js blog starter, this is because you need to update the starter to use your GraphQL layer instead of directly accessing the Markdown files. In the next section you will handle converting the frontend to use TinaCMS.
 
-Currently, the Next Blog Starter grabs content from the file system. But since Tina comes with a GraphQL API on top of the filesystem, you’re going to query that instead. Using the GraphQL API will allow you to use the power of TinaCMS, you will be able to retrieve the content and also edit and save the content directly.
+Currently, the Next Blog Starter grabs content from the file system. But since TinaCMS comes with a GraphQL API on top of the filesystem, you’re going to query that instead. Using the GraphQL API will allow you to use the power of TinaCMS, you will be able to retrieve the content and also edit and save the content directly.
 
 ## Creating the getStaticPaths query
 
@@ -304,7 +304,7 @@ Remove all the code inside of this function and you can update it to use your ow
 
 > It's just a helper function which supplies a query to your locally-running GraphQL server, which is started on port 4001. You can just as easily use fetch or an http client of your choice.
 
-Inside of the `getStaticPaths` function you can construct your request to our content-api. When making a request Tina expects a query or mutation and then variables to be passed to the query, here is an example:
+Inside of the `getStaticPaths` function you can construct your request to our content-api. When making a request TinaCMS expects a query or mutation and then variables to be passed to the query, here is an example:
 
 ```javascript
 staticRequest({
@@ -352,7 +352,7 @@ Go ahead and test that your blog posts are still readable by navigating to one, 
 
 ## Creating the `getStaticProps` query
 
-The `getStaticProps` query is going to deliver all the content to the blog, which is how it works currently. When you use the GraphQL API Tina will both deliver the content and give the content team the ability to edit it right in the browser.
+The `getStaticProps` query is going to deliver all the content to the blog, which is how it works currently. When you use the GraphQL API TinaCMS will both deliver the content and give the content team the ability to edit it right in the browser.
 
 You need to query the following items from your content api:
 
@@ -402,7 +402,7 @@ import { useTina } from 'tinacms/dist/edit-state';
 
 > What is `useTina`?
 
-> `useTina` is a hook that can be used to make a piece of Tina content contextually editable. It is code-split, so that in production, this hook will simply pass through its data value. In edit-mode, it registers an editable form in the sidebar, and contextually updates its value as the user types.
+> `useTina` is a hook that can be used to make a piece of TinaCMS content contextually editable. It is code-split, so that in production, this hook will simply pass through its data value. In edit-mode, it registers an editable form in the sidebar, and contextually updates its value as the user types.
 
 You can now use your query that you created as a variable, this variable will be used both in your `getStaticProps` and in your `useTina` hook.
 
@@ -481,7 +481,7 @@ const { data } = useTina({
   })
 ```
 
-This now means you have the ability to edit your content using Tina, but before you do that you need to update all of your elements to use your new Tina powered data.
+This now means you have the ability to edit your content using TinaCMS, but before you do that you need to update all of your elements to use your new TinaCMS powered data.
 
 ```diff
 - if (!frontmatter) return <></>
@@ -520,7 +520,7 @@ This now means you have the ability to edit your content using Tina, but before 
 
 ### Test & Edit Content ✨
 
-If all went well, your blog posts will now be editable by Tina. Let's see it in action!
+If all went well, your blog posts will now be editable by TinaCMS. Let's see it in action!
 
 Start up the dev server by running `yarn dev`, and open up a blog post in the browser. Go ahead and make edits, and then check the source file in a text editor. If you keep the browser and code editor open side-by-side, you should be able to watch the changes reflect in real time in both places!
 
@@ -530,12 +530,12 @@ You had a problem though, your body is a tiny input box that doesn't support Mar
 
 To add markdown support you need to do two things.
 
-1. Tell Tina how to use a different component.
+1. Tell TinaCMS how to use a different component.
 2. Dynamically load the markdown component.
 
-#### Update Tina Schema
+#### Update TinaCMS Schema
 
-Open up your `schema.ts` located in the `.tina` folder. The great thing about Tina is you can extend the UI field for your exact needs, to do this you use `ui` object and tell Tina the component you'd like to use.
+Open up your `schema.ts` located in the `.tina` folder. The great thing about TinaCMS is you can extend the UI field for your exact needs, to do this you use `ui` object and tell TinaCMS the component you'd like to use.
 
 ```typescript
 ui: {
@@ -559,7 +559,7 @@ You want to use the markdown component so you can override your body and it shou
 
 #### Updating `_app.js`
 
-Before opening up your `_app.js` file, you need to install the markdown plugin from Tina.
+Before opening up your `_app.js` file, you need to install the markdown plugin from TinaCMS.
 
 ```bash,cp
 yarn add react-tinacms-editor
@@ -594,21 +594,21 @@ Your TinaCMS should now look like this:
 
 #### Testing
 
-Go ahead and launch your blog and you should be able to see a new markdown editor that allows you to pass in data. Well done! With some config and calling a few hooks, you can now edit all our blog posts with Tina.
+Go ahead and launch your blog and you should be able to see a new markdown editor that allows you to pass in data. Well done! With some config and calling a few hooks, you can now edit all our blog posts with TinaCMS.
 
-## Where can you keep up to date with Tina?
+## Where can you keep up to date with TinaCMS?
 
-You know that you will want to be part of this creative, innovative, supportive community of developers (and even some editors and designers) who are experimenting and implementing Tina daily.
+You know that you will want to be part of this creative, innovative, supportive community of developers (and even some editors and designers) who are experimenting and implementing TinaCMS daily.
 
-### Tina Community Discord
+### TinaCMS Community Discord
 
-Tina has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and Tina enthusiasts. When you join you will find a place:
+TinaCMS has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and TinaCMS enthusiasts. When you join you will find a place:
 
 * To get help with issues
-* Find the latest Tina news and sneak previews
-* Share your project with Tina community, and talk about your experience
+* Find the latest TinaCMS news and sneak previews
+* Share your project with TinaCMS community, and talk about your experience
 * Chat about the Jamstack
 
-### Tina Twitter
+### TinaCMS Twitter
 
-Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to Tina. We would also be psyched if you tagged us in projects you have built.
+Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to TinaCMS. We would also be psyched if you tagged us in projects you have built.


### PR DESCRIPTION
Part of #4845 (batch 6 of the standalone-`Tina` cleanup — English blog, top 5 hot posts).

## Summary

145 in-content occurrences of standalone `Tina` → `TinaCMS` across the 5 blog posts with the highest per-file counts. Applied with the same `perl -pi` pass used in #4851–#4853; every hit in these files was safe to rewrite, so no manual carve-outs were needed.

## Files (5)

| File | Occurrences |
|---|---:|
| `content/blog/gatsby-tina-101.mdx` | 35 |
| `content/blog/using-tinacms-with-nextjs.mdx` | 33 |
| `content/blog/tina-cms-get-started.mdx` | 29 |
| `content/blog/new-year-new-cms.mdx` | 25 |
| `content/blog/from-cms-to-contextual.mdx` | 23 |
| **Total** | **145** |

5 files changed, 145 insertions / 145 deletions.

Covers headings ("Why TinaCMS?", "TinaCMS + Next: Part II", "TinaCMS as a CMS in a traditional way", "TinaCMS Overview 🦙", "TinaCMS-Powered Editing", "TinaCMS CLI", "TinaCMS Community Discord", "TinaCMS Twitter"), post frontmatter titles ("Gatsby + TinaCMS 101"), body prose, and code-fence comments (`// New TinaCMS Import!`, `# TinaCMS uses additional, specialized query data.`, `# Intialize TinaCMS`).

## Called out for reviewer attention

- **`tina-cms-get-started.mdx:24`** — "When we launched **Tina + Cloud** in it's alpha…" became "**TinaCMS + Cloud**". If that phrase was actually referring to what shipped as **TinaCloud** (single word), the reviewer may prefer to change it to `TinaCloud` instead — happy to follow up.

## Not touched by design

- Code identifiers (`TinaProvider`, `DynamicTinaProvider`, `useTina`, `TinaRemark`, `@tinacms/*`) — camelCase / kebab-case tokens skip the `\bTina\b` word boundary.
- URLs (`https://tina.io/*`) — `\.io` excluded in the regex.
- Emoji + friendly section heading `### TinaCMS Overview 🦙` — the llama stays; only "Tina" → "TinaCMS".

## Verify

```bash
# after merge, should be zero standalone Tina in these 5 files:
grep -nP "\bTina\b" \
  content/blog/gatsby-tina-101.mdx \
  content/blog/using-tinacms-with-nextjs.mdx \
  content/blog/tina-cms-get-started.mdx \
  content/blog/new-year-new-cms.mdx \
  content/blog/from-cms-to-contextual.mdx \
  | grep -vE "TinaCMS|TinaCloud|TinaDocs|TinaGPT|TinaTeach|Tina\.io|Tina-Docs|Tina-Cloud|Tina-CMS|Tina Teams|Tina CMS"
```

## Test plan

- [ ] `/blog/gatsby-tina-101` — post title reads "Gatsby + TinaCMS 101", body uses "TinaCMS" throughout.
- [ ] `/blog/using-tinacms-with-nextjs` — "TinaCMS Overview 🦙" heading; TinaCMS Discord / Twitter section headings.
- [ ] `/blog/tina-cms-get-started` — reviewer to confirm "TinaCMS + Cloud" reads correctly (see callout above); the post title change was already landed in #4847.
- [ ] `/blog/new-year-new-cms` — "Why TinaCMS?", "TinaCMS CLI" headings, body reads naturally.
- [ ] `/blog/from-cms-to-contextual` — "Create our new TinaCMS site", "What does the TinaCMS code do?" headings.
