### PR TITLE
Brand: 'Tina' -> 'TinaCMS' in next-20 hot blog posts (259 hits)

### DIFF
--- a/content/blog/2021-a-year-in-review.mdx
+++ b/content/blog/2021-a-year-in-review.mdx
@@ -12,11 +12,11 @@ prev: content/blog/using-the-power-of-mdx-with-tina.mdx
 next: content/blog/new-year-new-cms.mdx
 ---
 
-As the year is winding down, the team and I spent some time reflecting on how far Tina has come from the beginning of the year. At the beginning of 2021 TinaCMS was a new and growing open-source project that the Forestry team was excited to build. That project, in many ways, looked very different from the TinaCMS you know today. This year's journey involved some significant changes to the open-source project but our mission has remained the same: to deliver an open-source CMS that provides a 10x experience for the world's best web developers and content editors.
+As the year is winding down, the team and I spent some time reflecting on how far TinaCMS has come from the beginning of the year. At the beginning of 2021 TinaCMS was a new and growing open-source project that the Forestry team was excited to build. That project, in many ways, looked very different from the TinaCMS you know today. This year's journey involved some significant changes to the open-source project but our mission has remained the same: to deliver an open-source CMS that provides a 10x experience for the world's best web developers and content editors.
 
-Earlier this year we received a lot of feedback from both small and large companies using TinaCMS in that early phase. We learned that Tina was too open-ended and was trying to do too much. We decided to put certain constraints in place that narrowed Tina's focus but provided a better overall experience for more users. We chose Next.js as Tina's preferred framework for now (instead of Gatsby and others), focused on content stored in Git instead of supporting any data store, and replaced the in-page editing experience for a side-by-side editing experience that you see now in order to improve the overall developer experience. Also, we added a [GraphQL API](/docs/graphql/overview/) to TinaCMS that gives you all the benefits of Git-backed content (version control, content-ownership, branching, etc) but also adds a structured API that can easily be queried.
+Earlier this year we received a lot of feedback from both small and large companies using TinaCMS in that early phase. We learned that TinaCMS was too open-ended and was trying to do too much. We decided to put certain constraints in place that narrowed TinaCMS's focus but provided a better overall experience for more users. We chose Next.js as TinaCMS's preferred framework for now (instead of Gatsby and others), focused on content stored in Git instead of supporting any data store, and replaced the in-page editing experience for a side-by-side editing experience that you see now in order to improve the overall developer experience. Also, we added a [GraphQL API](/docs/graphql/overview/) to TinaCMS that gives you all the benefits of Git-backed content (version control, content-ownership, branching, etc) but also adds a structured API that can easily be queried.
 
-Now, here we are in December, and Tina has evolved significantly. We're truly proud of what we accomplished in 2021. We narrowed Tina's focus and built a solid foundation for a future where Git-backed content editing will be game-changing.
+Now, here we are in December, and TinaCMS has evolved significantly. We're truly proud of what we accomplished in 2021. We narrowed TinaCMS's focus and built a solid foundation for a future where Git-backed content editing will be game-changing.
 
 In the new year, we look forward to sharing our vision for 2022 and talking about all the exciting features we have planned for TinaCMS.
 
@@ -44,11 +44,11 @@ Working with a single framework helped us iterate quickly and focus on the right
 
 ## I was hired as a Developer Advocate
 
-We felt that we were on track and that we need more developers using Tina so that we could keep the momentum of innovation moving forward. At the end of May we hired a Developer Advocate (hey, that's me!) to connect with our audience (hey, that's you!), we felt ready to start building our community. Prior to being hired, I had been interested in the concept of Tina and what Tina was doing after researching it for a video. I will never forget what I said in that video,
+We felt that we were on track and that we need more developers using TinaCMS so that we could keep the momentum of innovation moving forward. At the end of May we hired a Developer Advocate (hey, that's me!) to connect with our audience (hey, that's you!), we felt ready to start building our community. Prior to being hired, I had been interested in the concept of TinaCMS and what TinaCMS was doing after researching it for a video. I will never forget what I said in that video,
 
-"Tina is really powerful and I am going to show you only the surface of what it can do."
+"TinaCMS is really powerful and I am going to show you only the surface of what it can do."
 
-After talking to the team about the vision of Tina, I was all in, I didn't want to do or go anywhere else. It felt like just yesterday, but here we are seven months later and I still feel exactly the same!
+After talking to the team about the vision of TinaCMS, I was all in, I didn't want to do or go anywhere else. It felt like just yesterday, but here we are seven months later and I still feel exactly the same!
 
 ## June 2021
 
@@ -56,13 +56,13 @@ After talking to the team about the vision of Tina, I was all in, I didn't want 
 
 June 2nd, 2021 we announced to the community that TinaCloud was in public alpha, and we encouraged anyone who wanted to see the future of content editing and management to give it a shot.
 
-![Tina Alpha Tweet](/img/blog/2021-a-year-in-review/alpha.png)
+![TinaCMS Alpha Tweet](/img/blog/2021-a-year-in-review/alpha.png)
 
-You all took us up on our offer, users spiked, commits were made, and feedback started to come in. We felt the beginnings of a community that wanted and cared about Tina. Your feedback went directly to the team and into brainstorming product meetings.
+You all took us up on our offer, users spiked, commits were made, and feedback started to come in. We felt the beginnings of a community that wanted and cared about TinaCMS. Your feedback went directly to the team and into brainstorming product meetings.
 
 ## July 2021
 
-One of the most common and most impactful pieces of feedback we received was around media management. You wanted to know why you couldn't have your media managed using Tina + Cloud. We knew that this was a big hurdle for users, so we immediately started working on a solution and introduced the integration with Cloudinary. We chose Cloudinary because:
+One of the most common and most impactful pieces of feedback we received was around media management. You wanted to know why you couldn't have your media managed using TinaCMS + Cloud. We knew that this was a big hurdle for users, so we immediately started working on a solution and introduced the integration with Cloudinary. We chose Cloudinary because:
 
 1. Support for all image types
 2. Optimized images
@@ -72,7 +72,7 @@ We wanted to make it as easy as possible to add Cloudinary support for your site
 
 ## August 2021
 
-In August we made the biggest announcement since I started at Tina. We placed the product in beta. I remember the buzz around the "office" as we got closer and closer to the announcement. There was a lot of hard work that went into our beta release, so the team were excited to see what the world though of these changes. We had no idea how we were going to fit it all in a blog post, the announcement wasn't just about changing the words alpha to beta we also had:
+In August we made the biggest announcement since I started at TinaCMS. We placed the product in beta. I remember the buzz around the "office" as we got closer and closer to the announcement. There was a lot of hard work that went into our beta release, so the team were excited to see what the world though of these changes. We had no idea how we were going to fit it all in a blog post, the announcement wasn't just about changing the words alpha to beta we also had:
 
 * Better documentation
 * A new CLI
@@ -86,43 +86,43 @@ In August we made the biggest announcement since I started at Tina. We placed th
 
 ![Beta Tweet](/img/blog/2021-a-year-in-review/beta.png)
 
-We also hired Kelly to help with our Cloud offering and Logan to help with our open-source product. Logan had already been working as an intern but he was an integral part of the team and we wanted him to work at Tina after he graduated.
+We also hired Kelly to help with our Cloud offering and Logan to help with our open-source product. Logan had already been working as an intern but he was an integral part of the team and we wanted him to work at TinaCMS after he graduated.
 
 ## September 2021
 
-September was the hardest month for the team at Tina, as our team member Frank passed away unexpectedly. His amazing ability to connect with anyone he met, from users to team members led him in his mission to bring together the user, the product, and the Jamstack. He is missed, but we talk about his contributions to Tina regularly.
+September was the hardest month for the team at TinaCMS, as our team member Frank passed away unexpectedly. His amazing ability to connect with anyone he met, from users to team members led him in his mission to bring together the user, the product, and the Jamstack. He is missed, but we talk about his contributions to TinaCMS regularly.
 
 ## October 2021
 
 ### MDX Support
 
-Up to this point, we had been focusing heavily on developers, but we wanted to ensure that we were also building for the content editors. We introduced MDX support for Tina so that developers can create all the reusable components your team needs and allow your content teams to reuse those components with a single click of a button. This feature really speaks to the heart of Tina, providing both the developers and content editors with seamless experiences.
+Up to this point, we had been focusing heavily on developers, but we wanted to ensure that we were also building for the content editors. We introduced MDX support for TinaCMS so that developers can create all the reusable components your team needs and allow your content teams to reuse those components with a single click of a button. This feature really speaks to the heart of TinaCMS, providing both the developers and content editors with seamless experiences.
 
 ### Documentation Starter
 
-We also introduced a Tina Documentation Starter that allows documentation teams to get started quickly by giving them the ability to create new pages and edit pages with a single click. This starter is also powered by MDX so not only can you get started with a single click, you can add all the reusable components that your teams might need for creating fantastic documentation.
+We also introduced a TinaCMS Documentation Starter that allows documentation teams to get started quickly by giving them the ability to create new pages and edit pages with a single click. This starter is also powered by MDX so not only can you get started with a single click, you can add all the reusable components that your teams might need for creating fantastic documentation.
 
 ## November
 
 ### Documentation improvements
 
-In November we set out to look at our documentation from all sides to ensure that you, no matter how you wanted to use Tina, are getting the information that you need. We gathered the team and each person came with a different perspective informed by their experience, user research, and your feedback. This exercise resulted in vast improvements and polished documentation to get you whatever it is you need.
+In November we set out to look at our documentation from all sides to ensure that you, no matter how you wanted to use TinaCMS, are getting the information that you need. We gathered the team and each person came with a different perspective informed by their experience, user research, and your feedback. This exercise resulted in vast improvements and polished documentation to get you whatever it is you need.
 
 ### Dashboard onboarding improvements
 
-We also added the ability to log in with your GitHub account, making it easier to keep everything together. Through a simple quickstart flow, you can log in, pick one of our starters and have us deploy it for you. Essentially, this means you can test and play with Tina in minutes.
+We also added the ability to log in with your GitHub account, making it easier to keep everything together. Through a simple quickstart flow, you can log in, pick one of our starters and have us deploy it for you. Essentially, this means you can test and play with TinaCMS in minutes.
 
 ## December
 
-December is usually a slower time of the year, but not with Tina. We still had some experimental features and a new way to get started with Tina that we wanted to get to you before the year ended.
+December is usually a slower time of the year, but not with TinaCMS. We still had some experimental features and a new way to get started with TinaCMS that we wanted to get to you before the year ended.
 
 ### Barebones Starter
 
-We introduced a new starter called "barebones" which gives you a minimal Next.js project with Tina. This allows you to start a new Tina project in a single step with a minimal Tina integration. Our starters prior to the barebones starter contained a lot of extra code for specific tasks, such as our documentation starter. We wanted to give you a good foundation without any additional code or dependencies.
+We introduced a new starter called "barebones" which gives you a minimal Next.js project with TinaCMS. This allows you to start a new TinaCMS project in a single step with a minimal TinaCMS integration. Our starters prior to the barebones starter contained a lot of extra code for specific tasks, such as our documentation starter. We wanted to give you a good foundation without any additional code or dependencies.
 
 ### `create-tina-app`
 
-We also introduced `npx create-tina-app` which allows you to set up a Tina application using a starter of your choice. As fellow developers, we understand that working locally is important and it allows you to investigate what is happening behind the scenes. With a single command, you can investigate Tina locally, make changes, and deploy later.
+We also introduced `npx create-tina-app` which allows you to set up a TinaCMS application using a starter of your choice. As fellow developers, we understand that working locally is important and it allows you to investigate what is happening behind the scenes. With a single command, you can investigate TinaCMS locally, make changes, and deploy later.
 
 **Autogenerated GraphQL Client (experimental)**
 
@@ -136,12 +136,12 @@ You can see how to use this experimental feature in our [GitHub](https://github.
 
 ### Branching Support (experimental)
 
-Allowing Tina-powered sites to switch to any branch is something that we have been working on for a while. Branching is so important to developers and content teams because if they want to launch a new feature or post they certainly don't want it live right away. We wanted to make sure we did it right, by making the user experience easy to navigate, and we just released it as an experimental feature. You can find out how to implement this on [our docs](https://tina.io/docs/tinacloud/branching/).
+Allowing TinaCMS-powered sites to switch to any branch is something that we have been working on for a while. Branching is so important to developers and content teams because if they want to launch a new feature or post they certainly don't want it live right away. We wanted to make sure we did it right, by making the user experience easy to navigate, and we just released it as an experimental feature. You can find out how to implement this on [our docs](https://tina.io/docs/tinacloud/branching/).
 
 ## The next phase
 
-At the beginning of the year, Tina was an experimental open-source project that was too open ended and was hard to maintain all of the moving pieces. We were supporting dozens of different packages and from the feedback we received, this wasn't the best approach. After making hard decisions on how to refine our approach, we now have a solid product that is seeing growing usage in production sites.
+At the beginning of the year, TinaCMS was an experimental open-source project that was too open ended and was hard to maintain all of the moving pieces. We were supporting dozens of different packages and from the feedback we received, this wasn't the best approach. After making hard decisions on how to refine our approach, we now have a solid product that is seeing growing usage in production sites.
 
-In our next post, we're going to describe where this is all going and our plan for Tina in 2022. The whole team is truly excited to enter the next phase of our project and hope you will check it out and give us honest feedback. We want to hear about your projects that use Tina and anything we can do to make it easier, faster or better.
+In our next post, we're going to describe where this is all going and our plan for TinaCMS in 2022. The whole team is truly excited to enter the next phase of our project and hope you will check it out and give us honest feedback. We want to hear about your projects that use TinaCMS and anything we can do to make it easier, faster or better.
 
-To keep up to date with Tina goings-on make sure to follow [@tinacms](https://twitter.com/tinacms) on Twitter. Want to chat with the team? Join the [Discord](https://discord.gg/njvZZYHj2Q)
+To keep up to date with TinaCMS goings-on make sure to follow [@tinacms](https://twitter.com/tinacms) on Twitter. Want to chat with the team? Join the [Discord](https://discord.gg/njvZZYHj2Q)

--- a/content/blog/2021-q1-tinacms-updates.mdx
+++ b/content/blog/2021-q1-tinacms-updates.mdx
@@ -5,7 +5,7 @@ seo:
     Check out the TinaCMS updates from Q1 2021, including improvements, bug
     fixes, and new features that enhance the platform's performance and
     usability.
-title: 2021 Q1 Tina updates
+title: 2021 Q1 TinaCMS updates
 date: '2021-04-14T13:59:53+02:00'
 last_edited: '2021-04-15T07:46:05.497Z'
 author: Frank Taillandier
@@ -13,9 +13,9 @@ prev: content/blog/more-changes-coming-to-inline-editing.mdx
 next: content/blog/tina-cloud-a-headless-cms-backed-by-git.mdx
 ---
 
-We are regularly improving Tina to provide an effective developer experience *and* a unique visual content editing experience. Latest additions are the result of listening to the feedback of the community as well as scratching our own itch.
+We are regularly improving TinaCMS to provide an effective developer experience *and* a unique visual content editing experience. Latest additions are the result of listening to the feedback of the community as well as scratching our own itch.
 
-Let’s take a closer look at some of the most impactful recent changes in Tina core library.
+Let’s take a closer look at some of the most impactful recent changes in TinaCMS core library.
 
 ## Radio Group Field 🆕
 
@@ -36,8 +36,8 @@ A small, yet big, win for inline editing, you can now duplicate a block with a s
 
 ## Rethinking Inline Editing 🤔
 
-We started reevaluating our approach to how Tina does inline editing. We refactored the code to take advantage of [events and references](https://github.com/tinacms/tinacms/pull/1749) to provide a [new API](https://github.com/tinacms/tinacms/blob/master/packages/react-tinacms-inline/README.md#usefieldref-ref-based-inline-editing). This work is far from done and is currently only available through a feature flag, as this will be subject to more changes.
-We’ll share our views in an upcoming post on what the future of inline editing will look like in Tina from a developer perspective.
+We started reevaluating our approach to how TinaCMS does inline editing. We refactored the code to take advantage of [events and references](https://github.com/tinacms/tinacms/pull/1749) to provide a [new API](https://github.com/tinacms/tinacms/blob/master/packages/react-tinacms-inline/README.md#usefieldref-ref-based-inline-editing). This work is far from done and is currently only available through a feature flag, as this will be subject to more changes.
+We’ll share our views in an upcoming post on what the future of inline editing will look like in TinaCMS from a developer perspective.
 
 Related to this change, we decided to remove drag-and-drop of inline blocks for now. There were some cases where it was creating issues but we might revisit this feature later when we have better inline editing. Now, you can move blocks around a page with up and down block controls, which shouldn't require too many clicks in most cases.
 
@@ -46,35 +46,35 @@ This makes the writing experience much more enjoyable when you write long format
 
 ## Next.js and Tailwind Demo 👀
 
-Our default demo is based on Next.js and Tailwind CSS. It currently showcases how you can set up Tina to provide: theme colors, component variants, dark mode, responsive blocks, etc. In the near future, we’ll dedicate a post on how we built this demo, so you will be able to dig in further and learn from it. For now, feel free to play around and [let us know if you have any feedback](https://github.com/tinacms/tina-tailwind-inline-demo/issues).
+Our default demo is based on Next.js and Tailwind CSS. It currently showcases how you can set up TinaCMS to provide: theme colors, component variants, dark mode, responsive blocks, etc. In the near future, we’ll dedicate a post on how we built this demo, so you will be able to dig in further and learn from it. For now, feel free to play around and [let us know if you have any feedback](https://github.com/tinacms/tina-tailwind-inline-demo/issues).
 
 ## Contentful plugin 🔌
 
-Our homepage makes it very clear that Tina can potentially work with any backend. We did also experiment with Contentful and published [a plugin](https://github.com/tinalabs/tinacms-contentful) for Tina to work with content fetched from their Content API. If you’re working with Contentful, feel free to test the plugin and [leave us feedback](https://github.com/tinalabs/tinacms-contentful/issues).
+Our homepage makes it very clear that TinaCMS can potentially work with any backend. We did also experiment with Contentful and published [a plugin](https://github.com/tinalabs/tinacms-contentful) for TinaCMS to work with content fetched from their Content API. If you’re working with Contentful, feel free to test the plugin and [leave us feedback](https://github.com/tinalabs/tinacms-contentful/issues).
 
 ## Community 💜
 
 ### New Core Team Members
 
-[Jeff](https://github.com/jeffsee55), [Chris](https://github.com/Enigmatical), and [Jack](https://github.com/jbevis) joined the core team. We’re very happy to welcome them to help us unleash the potential Tina has to offer.
+[Jeff](https://github.com/jeffsee55), [Chris](https://github.com/Enigmatical), and [Jack](https://github.com/jbevis) joined the core team. We’re very happy to welcome them to help us unleash the potential TinaCMS has to offer.
 
 ### Some stats 📈
 
 Our community activities are now tracked in Orbit 💜, in order to help us better build better relationships with you. Warm thanks to [Nicolas](https://github.com/phacks/) from the Orbit team for helping out setting things up.
 
-![Member Activity in the Tina Community for 2021 Q1 in Orbit](/img/blog/orbit-members-2021-q1.png)Orbit makes it easy to reflect on the community’s activity, you can easily see when you got on the front page of Hacker News 😊.
+![Member Activity in the TinaCMS Community for 2021 Q1 in Orbit](/img/blog/orbit-members-2021-q1.png)Orbit makes it easy to reflect on the community’s activity, you can easily see when you got on the front page of Hacker News 😊.
 
 Shout out to our most active community members for 2021 Q1: [Joe Innes](https://github.com/joeinnes) 👏, [Matthew Francis Brunetti](https://github.com/zenflow) 👏, [Austin Condiff](https://github.com/austincondiff) 👏, [Hirvin Faria](https://github.com/hirvin-faria) 👏 and [Chadd Poggenpoel](https://github.com/Chizzah) 👏.
 
 Our open source project has reached some new milestones:
 
-* [Tina](https://github.com/tinacms/tinacms) has been starred by more than **6K** people on GitHub 🌟
+* [TinaCMS](https://github.com/tinacms/tinacms) has been starred by more than **6K** people on GitHub 🌟
 * [tinacms core package](https://www.npmjs.com/package/tinacms) has been downloaded more than 250K times 📦
 
 🙏 Thanks for your interest, we’re just getting started here!
 
 ## One more thing... ⏳
 
-In order to enhance the Tina ecosystem, our team is currently working on a new open source tool to ease the way you can do structured content management while keeping control of your content in your Git repository. More on that next week!
+In order to enhance the TinaCMS ecosystem, our team is currently working on a new open source tool to ease the way you can do structured content management while keeping control of your content in your Git repository. More on that next week!
 
 [Subscribe to our blog](/rss.xml) to be the first to know about all our new and exciting developments.

--- a/content/blog/a-b-test-with-tina.mdx
+++ b/content/blog/a-b-test-with-tina.mdx
@@ -13,21 +13,21 @@ next: content/blog/tina-next-i18n.mdx
 
 A/B testing can be an incredibly useful tool on any site. It allows you to increase user engagement, reduce bounce rates, increase conversion rate and effectively create content.
 
-Tina opens up the ability to A/B test, allowing marketing teams to test content without the need for the development team once it has been implemented.
+TinaCMS opens up the ability to A/B test, allowing marketing teams to test content without the need for the development team once it has been implemented.
 
 ## Introduction
 
 We are going to break this tutorial into two sections:
 
 1. Setting up A/B Tests with NextJS's middleware.
-2. Configuring our A/B Tests with Tina, so that our editors can spin up dynamic A/B Tests.
+2. Configuring our A/B Tests with TinaCMS, so that our editors can spin up dynamic A/B Tests.
 
-## Creating our Tina application
+## Creating our TinaCMS application
 
 This blog post is going to use the Tailwind Starter. Using the `create-tina-app` command, choose "Next.js Starter" as the starter template:
 
 ```bash
-# create our Tina application
+# create our TinaCMS application
 
 npx create-tina-app@latest a-b-testing
 
@@ -54,9 +54,9 @@ The home page of the starter should look like this:
 This page is already setup nicely for an A/B test, its page layout (`[slug].tsx`) renders dynamic pages by accepting a variable `slug`.
 
 Let's start by creating an alternate version of the homepage called `home-b`.
-You can do so in Tina [at http://localhost:3000/admin#/collections/page/new](http://localhost:3000/admin#/collections/page/new)
+You can do so in TinaCMS [at http://localhost:3000/admin#/collections/page/new](http://localhost:3000/admin#/collections/page/new)
 
-![Tina Add document](/img/blog/a-b-testing/add-document.png)
+![TinaCMS Add document](/img/blog/a-b-testing/add-document.png)
 
 Once that's done, go to: `http://localhost:3000/home-b` to confirm that your new `/home-b` page has been created.
 
@@ -203,11 +203,11 @@ The above code snippet does the following:
 
 That should be all for our middleware! Now, you should be able to visit the homepage at [http://localhost:3000](http://localhost:3000), and you will have a 50-50 chance of being served the contents of `home.md`, or `home-b.md`. You can reset your bucket by clearing your browser's cookies.
 
-## Using Tina to create A/B Tests
+## Using TinaCMS to create A/B Tests
 
 At this point, our editors can edit the contents of both `home.md` & `home-b.md`, however we'd like our editors to be empowered to setup new A/B tests.
 
-Let's make our `content/ab-test/index.json` file from earlier editable, by creating a Tina collection for it.
+Let's make our `content/ab-test/index.json` file from earlier editable, by creating a TinaCMS collection for it.
 
 Open up your `schema.ts` and underneath the `Pages` collection, create a new collection like this:
 
@@ -278,7 +278,7 @@ We now need to add the fields we want our content team to be able to edit, so th
     }
 ```
 
-> You may notice the `ui` prop. We are using this to give a more descriptive label to the list items. You can read about this in our [extending Tina documentation.](https://tina.io/docs/extending-tina/customize-list-ui/)
+> You may notice the `ui` prop. We are using this to give a more descriptive label to the list items. You can read about this in our [extending TinaCMS documentation.](https://tina.io/docs/extending-tina/customize-list-ui/)
 
 We also need to update our `RouteMappingPlugin` in `.tina/schema.ts` to ensure that our collection is only editable with the basic editor.
 
@@ -292,7 +292,7 @@ We also need to update our `RouteMappingPlugin` in `.tina/schema.ts` to ensure t
 
 Now, restart your dev server, and go to: [`http://localhost:3000/admin#/collections/abtest/index`](http://localhost:3000/admin#/collections/abtest/index). Your editors should be able to wire up their own A/B tests!
 
-![Tina Edit Variant](/img/blog/a-b-testing/edit-test.png)
+![TinaCMS Edit Variant](/img/blog/a-b-testing/edit-test.png)
 
 The process for editors to create new A/B tests would be as follows:
 
@@ -301,21 +301,21 @@ The process for editors to create new A/B tests would be as follows:
 
 And that's it! We hope this empowers your team to start testing out different page variants to start optimizing your content!
 
-## How to keep up to date with Tina?
+## How to keep up to date with TinaCMS?
 
-The best way to keep up with Tina is to subscribe to our newsletter. We send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may have missed, and more!
+The best way to keep up with TinaCMS is to subscribe to our newsletter. We send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may have missed, and more!
 
 You can subscribe by following this link and entering your email: [https://tina.io/community/](https://tina.io/community/)
 
-### Tina Community Discord
+### TinaCMS Community Discord
 
-Tina has a community [Discord](https://discord.com/invite/zumN63Ybpf) full of Jamstack lovers and Tina enthusiasts. When you join, you will find a place:
+TinaCMS has a community [Discord](https://discord.com/invite/zumN63Ybpf) full of Jamstack lovers and TinaCMS enthusiasts. When you join, you will find a place:
 
 * To get help with issues
-* Find the latest Tina news and sneak previews
-* Share your project with the Tina community, and talk about your experience
+* Find the latest TinaCMS news and sneak previews
+* Share your project with the TinaCMS community, and talk about your experience
 * Chat about the Jamstack
 
-### Tina Twitter
+### TinaCMS Twitter
 
-Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to Tina. We would also be psyched if you tagged us in projects you have built.
+Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to TinaCMS. We would also be psyched if you tagged us in projects you have built.

--- a/content/blog/add-and-delete-files.mdx
+++ b/content/blog/add-and-delete-files.mdx
@@ -29,13 +29,13 @@ next: content/blog/jamstack-denver-talk.mdx
 
 ![tinacms-add-new-file-gif](/gif/add-new-blog.gif)
 
-### Tina Overview — sidebar, forms, plugins
+### TinaCMS Overview — sidebar, forms, plugins
 
-When you install Tina, you immediately get access to a **sidebar**. This sidebar is the main interface for editing and managing content with Tina
+When you install TinaCMS, you immediately get access to a **sidebar**. This sidebar is the main interface for editing and managing content with TinaCMS
 
-To make content editable on your site, you need to register a form to Tina. Forms appear in the sidebar, displaying [fields](https://tinacms.org/docs/plugins/fields) where you can edit content on the page.
+To make content editable on your site, you need to register a form to TinaCMS. Forms appear in the sidebar, displaying [fields](https://tinacms.org/docs/plugins/fields) where you can edit content on the page.
 
-Plugins extend the functionality of the core CMS. Behind the scenes, plugins do some big work with Tina. They register forms, create new screen views, and allow us to add new content. If you're interested to learn more, read this post on Tina's [dynamic plugin system](https://tinacms.org/blog/dynamic-plugin-system/).
+Plugins extend the functionality of the core CMS. Behind the scenes, plugins do some big work with TinaCMS. They register forms, create new screen views, and allow us to add new content. If you're interested to learn more, read this post on TinaCMS's [dynamic plugin system](https://tinacms.org/blog/dynamic-plugin-system/).
 
 ## Creating New Files
 
@@ -44,7 +44,7 @@ Plugins extend the functionality of the core CMS. Behind the scenes, plugins do 
 These steps will be our journey-map for setting up content-creation functionality in a [Gatsby](https://www.gatsbyjs.org/) website.
 
 1. [Set-up a `content-creator` plugin](https://tinacms.org/blog/add-and-delete-files#step-1-set-up-a-content-creator-plugin)
-2. [Register the plugin with Tina](https://tinacms.org/blog/add-and-delete-files#2-register-the-plugin-with-the-sidebar)
+2. [Register the plugin with TinaCMS](https://tinacms.org/blog/add-and-delete-files#2-register-the-plugin-with-the-sidebar)
 3. [Customize the `create-form`](https://tinacms.org/blog/add-and-delete-files#3-customize-the-create-form)
 4. [Configure default data for the new file](https://tinacms.org/blog/add-and-delete-files#4-configure-defaults)
 
@@ -58,7 +58,7 @@ You may want create a new blog only when you're on the blog list page. To do thi
 
 If you always want to be able to create new blogs, you'll register the plugin on a component that is always rendered. Examples of this could be the `Layout` or `Root` component.
 
-**Consider the experience before you dig into code.** One of the incredible things about Tina is that you have this finite control, so use it.
+**Consider the experience before you dig into code.** One of the incredible things about TinaCMS is that you have this finite control, so use it.
 
 ## Step 1: Set-up a content-creator plugin
 
@@ -149,7 +149,7 @@ $ yarn add tinacms || npm install tinacms
 
 Then import `withPlugin` from `tinacms`. `withPlugin` is a [higher-order component](https://reactjs.org/docs/higher-order-components.html) used for adding plugins to the CMS.
 
-Export the component and plugin using `withPlugin` and you should now be able to add new posts from the Tina sidebar. The location of the new files will be based on the return value from the `filename` function.
+Export the component and plugin using `withPlugin` and you should now be able to add new posts from the TinaCMS sidebar. The location of the new files will be based on the return value from the `filename` function.
 
 ```javascript
 // 1. Import withPlugin
@@ -286,7 +286,7 @@ Both the frontmatter and body functions receive the data captured by fields in t
 With the power to create, comes the power to delete 🧙‍♀️. I promise you this step is much simpler.
 
 Instead of adding a ‘delete’ plugin, we simply need to pass a `delete-action` to the main form options.
-Head to a file where you have a Tina form configured in your project. This will typically be a template file that generates multiple posts, case studies, etc. If you don't have a Tina form configured in your project, learn more about [creating forms with Gatsby+Tina](/docs/guides/converting-gatsby-to-tina).
+Head to a file where you have a TinaCMS form configured in your project. This will typically be a template file that generates multiple posts, case studies, etc. If you don't have a TinaCMS form configured in your project, learn more about [creating forms with Gatsby+TinaCMS](/docs/guides/converting-gatsby-to-tina).
 
 You don't want to give the editors the power to delete files that they shouldn't. So think about where you want this action to be available. For something like a blog, it makes sense to add the `delete-action` to a blog template form. But it might not make sense to add the `delete-action` to a form that edits global site configuration, for example.
 
@@ -333,6 +333,6 @@ You can now access this `delete-action` via the three-dot icon near the save but
 
 ## Happy Creating (and Deleting)! 👩‍🎤
 
-Hopefully this tutorial gave you some insight into setting up two core bits of CMS functionality with Tina + Gatsby.
+Hopefully this tutorial gave you some insight into setting up two core bits of CMS functionality with TinaCMS + Gatsby.
 
-Stoked on TinaCMS? Please ⭐️ us on [GitHub](https://github.com/tinacms/tinacms) or [Tweet us](https://twitter.com/Tina_cms) 🐦 to show-off your Tina projects.
+Stoked on TinaCMS? Please ⭐️ us on [GitHub](https://github.com/tinacms/tinacms) or [Tweet us](https://twitter.com/Tina_cms) 🐦 to show-off your TinaCMS projects.

--- a/content/blog/automating-pull-requests.mdx
+++ b/content/blog/automating-pull-requests.mdx
@@ -82,21 +82,21 @@ The `GITHUB_TOKEN` doesn’t need to be set, since GitHub will retrieve a `GITHU
 
 Now that we have created the action, when you create a pull request, you need to add `/schedule YYYY-MM-DD` to your pull request description. This GitHub Action will run on the schedule defined in the cron statement and check for PRs where the date matches and then deploy the code. If you need precise deployments you can use `/schedule 2019-12-31T00:00:00.000Z.`
 
-## How to keep up to date with Tina?
+## How to keep up to date with TinaCMS?
 
-The best way to keep up with Tina is to subscribe to our newsletter, we send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may have missed, and so much more!
+The best way to keep up with TinaCMS is to subscribe to our newsletter, we send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may have missed, and so much more!
 
 You can subscribe by following this link and entering your email: [https://tina.io/community/](https://tina.io/community/)
 
-### Tina Community Discord
+### TinaCMS Community Discord
 
-Tina has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and Tina enthusiasts. When you join you will find a place:
+TinaCMS has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and TinaCMS enthusiasts. When you join you will find a place:
 
 * To get help with issues
-* Find the latest Tina news and sneak previews
-* Share your project with Tina community, and talk about your experience
+* Find the latest TinaCMS news and sneak previews
+* Share your project with TinaCMS community, and talk about your experience
 * Chat about the Jamstack
 
-### Tina Twitter
+### TinaCMS Twitter
 
-Our Twitter account ([@tina\_cms](https://twitter.com/tina_cms)) announces the latest features, improvements, and sneak peeks to Tina. We would also be psyched if you tagged us in projects you have built.
+Our Twitter account ([@tina\_cms](https://twitter.com/tina_cms)) announces the latest features, improvements, and sneak peeks to TinaCMS. We would also be psyched if you tagged us in projects you have built.

--- a/content/blog/basics-of-graphql.mdx
+++ b/content/blog/basics-of-graphql.mdx
@@ -13,7 +13,7 @@ next: content/blog/a-b-test-with-tina.mdx
 ---
 
 ​​
-The Tina team is a big fan of GraphQL, and it is a core component of our project. One reason for this is that it allows a developer to retrieve only the data required and makes it easier to evolve APIs. This blog post will cover the basics of GraphQL.
+The TinaCMS team is a big fan of GraphQL, and it is a core component of our project. One reason for this is that it allows a developer to retrieve only the data required and makes it easier to evolve APIs. This blog post will cover the basics of GraphQL.
 
 ## Queries
 
@@ -69,7 +69,7 @@ query MyAwesomeQuery(){
       "name": "James"
 			"posts": [
         {
-          "title": "Tina in 2022"
+          "title": "TinaCMS in 2022"
         },
         {
           "title": "From Contextual to CMS"
@@ -212,21 +212,21 @@ mutation createNewAuthor(
 
 In this example, we create a new Author and return just the author's id and name on successful creation.
 
-## **How to keep up to date with Tina?**
+## **How to keep up to date with TinaCMS?**
 
-The best way to keep up with Tina is to subscribe to our newsletter. We send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may have missed, and more!
+The best way to keep up with TinaCMS is to subscribe to our newsletter. We send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may have missed, and more!
 
 You can subscribe by following this link and entering your email: [https://tina.io/community/](https://tina.io/community/)
 
-### Tina Community Discord
+### TinaCMS Community Discord
 
-Tina has a community [Discord](https://discord.com/invite/zumN63Ybpf) full of Jamstack lovers and Tina enthusiasts. When you join, you will find a place:
+TinaCMS has a community [Discord](https://discord.com/invite/zumN63Ybpf) full of Jamstack lovers and TinaCMS enthusiasts. When you join, you will find a place:
 
 * To get help with issues
-* Find the latest Tina news and sneak previews
-* Share your project with the Tina community, and talk about your experience
+* Find the latest TinaCMS news and sneak previews
+* Share your project with the TinaCMS community, and talk about your experience
 * Chat about the Jamstack
 
-### Tina Twitter
+### TinaCMS Twitter
 
-Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to Tina. We would also be psyched if you tagged us in projects you have built.
+Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to TinaCMS. We would also be psyched if you tagged us in projects you have built.

--- a/content/blog/custom-field-components.mdx
+++ b/content/blog/custom-field-components.mdx
@@ -21,7 +21,7 @@ prev: content/blog/exporting-wordpress-content-to-gatsby.mdx
 next: content/blog/custom-field-plugins.mdx
 ---
 
-Form fields are the bread and butter of any CMS. While Tina provides a solid collection of fields 'out-of-the-box', you can also create your own. This post will show you the basic concepts of how to create custom field components and use them in the Tina sidebar.
+Form fields are the bread and butter of any CMS. While TinaCMS provides a solid collection of fields 'out-of-the-box', you can also create your own. This post will show you the basic concepts of how to create custom field components and use them in the TinaCMS sidebar.
 
 **Prerequisites 👩‍🏫**
 
@@ -29,7 +29,7 @@ Throughout the post, I'll refer to a few core TinaCMS concepts such as [forms](h
 
 ## Why would you create a custom field?
 
-Tina was intended to be fully customizable and extensible. Creating **custom fields can provide precise control** over the sidebar configuration and styling, along with implementing unique field functionality.
+TinaCMS was intended to be fully customizable and extensible. Creating **custom fields can provide precise control** over the sidebar configuration and styling, along with implementing unique field functionality.
 
 <WebmEmbed embedSrc="/img/blog/custom-field-components/saturate-custom-field.webm" />
 
@@ -37,15 +37,15 @@ Tina was intended to be fully customizable and extensible. Creating **custom fie
 
 ## Two Methods — Let’s start simple
 
-There are two ways to add [custom fields](https://tinacms.org/docs/plugins/fields/custom-fields) to Tina. The first approach involves defining a React component and passing it into the `component` property of a field definition. The Tina Team refers to this as an **inline field component.** This option is more straightforward; it will be the method of focus in this post.
+There are two ways to add [custom fields](https://tinacms.org/docs/plugins/fields/custom-fields) to TinaCMS. The first approach involves defining a React component and passing it into the `component` property of a field definition. The TinaCMS Team refers to this as an **inline field component.** This option is more straightforward; it will be the method of focus in this post.
 
-The second approach involves defining a custom component, then registering that component as a [field plugin](https://tinacms.org/docs/plugins/fields/custom-fields#2-creating-field-plugins) with the CMS. All the [core fields](https://tinacms.org/docs/plugins/fields) provided by Tina are used as plugins.
+The second approach involves defining a custom component, then registering that component as a [field plugin](https://tinacms.org/docs/plugins/fields/custom-fields#2-creating-field-plugins) with the CMS. All the [core fields](https://tinacms.org/docs/plugins/fields) provided by TinaCMS are used as plugins.
 
 There are some advantages to creating a plugin versus an inline field — the main points being reusability and access to additional functions for parsing, validation etc. But **for simpler cases**, when you need a custom field in just one form or don’t necessarily need validation, an inline field component will do just fine 👌.
 
 ## Creating a custom inline field
 
-Say we have a [Tina Form](https://tinacms.org/docs/plugins/forms) set up for an *About Me* page:
+Say we have a [TinaCMS Form](https://tinacms.org/docs/plugins/forms) set up for an *About Me* page:
 
 > *Note:* The examples below will be referencing a Next.js setup, but this approach can be applied to Gatsby as well.
 
@@ -106,7 +106,7 @@ const formOptions = {
 
 *Pretty cool huh?* 🤩
 
-Notice how in all of the other field objects, the `component` property is referencing a Tina field plugin, whereas **with our custom inline field, we are passing in a React component.**
+Notice how in all of the other field objects, the `component` property is referencing a TinaCMS field plugin, whereas **with our custom inline field, we are passing in a React component.**
 
 ![Custom Inline Field In Sidebar](/img/blog/custom-field-inline.png)
 
@@ -160,7 +160,7 @@ function RangeInput(props) {
 
 Notice this line, `{...props.input}`. You may be wondering where this magical object with all of the necessary input props is coming from?
 
-When the custom field is registered with Tina, this **input object** is passed in as a prop to the field. This object contains necessary data and callbacks for the input to function properly: [`value`](https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputvalue), [`name`](https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputname), [`onChange`](https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputonchange), [`onFocus`](https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputonfocus), [`onBlur`](https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputonblur).
+When the custom field is registered with TinaCMS, this **input object** is passed in as a prop to the field. This object contains necessary data and callbacks for the input to function properly: [`value`](https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputvalue), [`name`](https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputname), [`onChange`](https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputonchange), [`onFocus`](https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputonfocus), [`onBlur`](https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputonblur).
 
 > If your custom component is not a standard [HTML input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input), you will need to manually pass in the necessary input props, as opposed to using the [spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax).
 
@@ -177,17 +177,17 @@ The [react-final-form documentation](https://final-form.org/docs/react-final-for
 
 As we saw in the first example, we can pass in the custom field component directly via the `component` property — `component: () => <p>Hi<p>`. But when we are creating more complex fields, we will most likely want to extract the field into its own function.
 
-In the example above, `RangeInput` could be defined alongside the `AboutMe` component where the Tina form is set up:
+In the example above, `RangeInput` could be defined alongside the `AboutMe` component where the TinaCMS form is set up:
 
 ```jsx
 /*
 ** Custom field defined alongside
-** component using a Tina Form
+** component using a TinaCMS Form
 */
 import { useLocalJsonForm, JsonFile } from "next-tinacms-json";
 
 export default function AboutMe(props) {
-  // Tina Form config
+  // TinaCMS Form config
   const [data] = useLocalJsonForm(props.data, formOptions)
   return (
     //...
@@ -210,7 +210,7 @@ AboutMe.getInitialProps = async function() {
 }
 ```
 
-It could also be defined in its own file and imported into the file where the Tina form options are configured:
+It could also be defined in its own file and imported into the file where the TinaCMS form options are configured:
 
 ```jsx
 /*
@@ -221,7 +221,7 @@ import { useLocalJsonForm, JsonFile } from "next-tinacms-json";
 import RangeInput from '../components/RangeInput';
 
 export default function AboutMe(props) {
-  // Tina Form config
+  // TinaCMS Form config
   const [data] = useLocalJsonForm(props.data, formOptions)
   return (
     //...
@@ -244,7 +244,7 @@ As with many things in development, the answer **depends on your use case** 😉
 
 ### 2. Add the value to the source data
 
-Now that the custom input field is defined, we need to add the `image_saturation` value to our source data. The source data could be a Markdown or JSON file. If you already have a Tina Form set up, it should be linked with a data source, so head to that file.
+Now that the custom input field is defined, we need to add the `image_saturation` value to our source data. The source data could be a Markdown or JSON file. If you already have a TinaCMS Form set up, it should be linked with a data source, so head to that file.
 
 For our example, let's say we have a local JSON file called `about.json`. This file contains the data used in the *About Me* page. In it we can add the `image_saturation` value.
 
@@ -262,11 +262,11 @@ The value can be any integer or floating point number that exists between the ra
 
 > If you’re using Gatsby, you will **need to update your GraphQL query** to get this new data. Add the `image_saturation` field to your query.
 
-So now we have a source value that can be connected to the custom input field. This way, **Tina can update the value in the source file** in sync with the changes picked up by the `RangeInput` component.
+So now we have a source value that can be connected to the custom input field. This way, **TinaCMS can update the value in the source file** in sync with the changes picked up by the `RangeInput` component.
 
-### 3. Add the custom field to a Tina Form
+### 3. Add the custom field to a TinaCMS Form
 
-How about we wire up this custom field to Tina? 🎊
+How about we wire up this custom field to TinaCMS? 🎊
 
 In this step, we need to create the custom field definition and pass in the `RangeInput` component inline. We'll go back to our *About Me* page [form options](/docs/guides/converting-gatsby-to-tina):
 
@@ -347,7 +347,7 @@ Some other examples of awesome *CSS-in-JS* frameworks are [styled-components](ht
 
 ### Next Steps
 
-A good next step would be *adding styles to the custom `RangeInput` component*. You could use [`@tinacms/styles`](https://tinacms.org/docs/plugins/fields/custom-fields#using-tina-styles) to fit the vibe of other Tina fields ✌️. Or you could go wild and spice up the sidebar in your own way 🤠.
+A good next step would be *adding styles to the custom `RangeInput` component*. You could use [`@tinacms/styles`](https://tinacms.org/docs/plugins/fields/custom-fields#using-tina-styles) to fit the vibe of other TinaCMS fields ✌️. Or you could go wild and spice up the sidebar in your own way 🤠.
 
 If we wanted to reuse this component throughout the site, we could take a step further and make it into a [Field Plugin](https://tinacms.org/docs/plugins/fields/custom-fields#2-creating-field-plugins). Stay tuned for a follow-up post that dives into creating custom Field Plugins, or swing by the [docs](https://tinacms.org/docs/plugins/fields/custom-fields#2-creating-field-plugins) to get a head start.
 

--- a/content/blog/data-layer-performant-editing.mdx
+++ b/content/blog/data-layer-performant-editing.mdx
@@ -4,16 +4,16 @@ seo:
   description: >-
     Explore how TinaCMS’s Data Layer improves editing performance by optimizing
     data fetching and reducing load times during content updates.
-title: 'Tina Data Layer: Performant Editing'
+title: 'TinaCMS Data Layer: Performant Editing'
 date: '2022-03-24T07:00:00.000Z'
 author: James Perkins
 prev: content/blog/from-cms-to-contextual.mdx
 next: content/blog/read-only-tokens-content-anytime.mdx
 ---
 
-Tina has worked on the premise of direct interaction with Tina's GraphQL API and GitHub’s API. While this is a perfectly acceptable option, it does reduce performance slightly due to the nature of sending and retrieving data as “new” each time. 
+TinaCMS has worked on the premise of direct interaction with TinaCMS's GraphQL API and GitHub’s API. While this is a perfectly acceptable option, it does reduce performance slightly due to the nature of sending and retrieving data as “new” each time. 
 
-The Tina team recently introduced a new optional data layer that sits between Tina and GitHub. In the future, this will be our default offering once it is out of the experimental stage. Our data layer buffers the requests between Tina and GitHub, increasing performance while editing your content. This blog post is going to explain how it works, what it does and what we have planned for the future!
+The TinaCMS team recently introduced a new optional data layer that sits between TinaCMS and GitHub. In the future, this will be our default offering once it is out of the experimental stage. Our data layer buffers the requests between TinaCMS and GitHub, increasing performance while editing your content. This blog post is going to explain how it works, what it does and what we have planned for the future!
 
 <WebmEmbed embedSrc="/video/before-data-layer.webm" />
 
@@ -29,13 +29,13 @@ We made enabling and using the Data Layer with minimal development required. In 
   },
 ```
 
-Once the flag is added and the CLI has been run, Tina will update the generated schema letting Tina know you want to use the Data Layer.
+Once the flag is added and the CLI has been run, TinaCMS will update the generated schema letting TinaCMS know you want to use the Data Layer.
 
 > Once you have generated the Schema, you will need to commit the changes to GitHub for it to start working on the project.
 
 ## What does the Data Layer do to increase Performance?
 
-Once the Data Layer is enabled on your project, we will automatically synchronize a copy of your repository with our secure cloud database. After Tina has run the initial indexing of your repository, Tina will automatically index new or updated content. This is done behind the scenes and you won’t notice that we are doing this, except the increase in performance when editing.
+Once the Data Layer is enabled on your project, we will automatically synchronize a copy of your repository with our secure cloud database. After TinaCMS has run the initial indexing of your repository, TinaCMS will automatically index new or updated content. This is done behind the scenes and you won’t notice that we are doing this, except the increase in performance when editing.
 
 ### When we might do a full re-index
 
@@ -58,17 +58,17 @@ This is still an experimental feature and the following things should be conside
 
 > The following section may no longer be accurate, see the[ official roadmap](https://tina.io/roadmap/ "Roadmap") and [GitHub](https://github.com/tinacms) pages for up to date development info
 
-The team at Tina has plans for the following highly requested features as the Data Layer matures out of its experimental phase. In fact we have already begun working on some of the features mentioned below, so stay tuned! 
+The team at TinaCMS has plans for the following highly requested features as the Data Layer matures out of its experimental phase. In fact we have already begun working on some of the features mentioned below, so stay tuned! 
 
 ### More complex and advanced queries
 
-The Data Layer opens up our GraphQL layer to be even more powerful, in the future Tina plans to offer: 
+The Data Layer opens up our GraphQL layer to be even more powerful, in the future TinaCMS plans to offer: 
 
 1. Pagination
 2. Filtering
 3. Sorting 
 
-This means you will be able to reduce some of your calls if you don’t need a full data set. A good example of this would be where you only need 3 blog posts for a features section. In the current Tina integration, you need to retrieve all of the posts and filter them down after the fact. In the future you won’t need to do this. 
+This means you will be able to reduce some of your calls if you don’t need a full data set. A good example of this would be where you only need 3 blog posts for a features section. In the current TinaCMS integration, you need to retrieve all of the posts and filter them down after the fact. In the future you won’t need to do this. 
 
 ### Referential Integrity
 

--- a/content/blog/mdx-powered-docs.mdx
+++ b/content/blog/mdx-powered-docs.mdx
@@ -2,7 +2,7 @@
 seo:
   title: MDX Powered Docs | TinaCMS Blog
   description: >-
-    Discover how to create dynamic, interactive documentation with MDX in Tina,
+    Discover how to create dynamic, interactive documentation with MDX in TinaCMS,
     combining Markdown content with React components for enhanced flexibility
 title: Introducing the Documentation Starter powered by MDX.
 date: '2021-11-02T08:00:00-04:00'
@@ -12,7 +12,7 @@ prev: content/blog/tina-supports-mdx.mdx
 next: content/blog/using-the-power-of-mdx-with-tina.mdx
 ---
 
-When we released our MDX Support, we wanted to create a real-world application that showed the power of Tina and MDX. We know how important documentation is to teams and that the market’s current offerings lack features that bring collaboration.
+When we released our MDX Support, we wanted to create a real-world application that showed the power of TinaCMS and MDX. We know how important documentation is to teams and that the market’s current offerings lack features that bring collaboration.
 
 <WebmEmbed embedSrc="/img/blog/mdx-powered-docs/Docs_Starter_Example.webm" />
 
@@ -52,13 +52,13 @@ We are big fans of markdown and have just introduced the ability to support MDX.
 
 Each one of these components is easily edited by content teams with no development experience. We also give developers the ability to create their own components for their content teams, such as a newsletter signup.
 
-## Tina
+## TinaCMS
 
-The MDX-powered Tina delivers a world-class experience for both developers and content teams. We allow you to create new documentation with ease by unlocking a visual editing experience versus a traditional CMS.
+The MDX-powered TinaCMS delivers a world-class experience for both developers and content teams. We allow you to create new documentation with ease by unlocking a visual editing experience versus a traditional CMS.
 
 ## How the flow works for teams
 
-Once you have cloned the repository, you can immediately start creating your documentation. There are a few scenarios to cover when working with Tina.
+Once you have cloned the repository, you can immediately start creating your documentation. There are a few scenarios to cover when working with TinaCMS.
 
 ### Editing Content
 
@@ -73,7 +73,7 @@ When editing content, a user will just need to login via the /admin once they ha
 
 ### Creating a new documentation pages
 
-One benefit of using Tina is that you can create new pages without leaving your site, which allows teams to move swiftly. To add a new page to your documentation site just:
+One benefit of using TinaCMS is that you can create new pages without leaving your site, which allows teams to move swiftly. To add a new page to your documentation site just:
 
 1. Make sure the user is in edit mode.
 2. Select the large blue + in the top corner of the sidebar
@@ -82,4 +82,4 @@ One benefit of using Tina is that you can create new pages without leaving your 
 
 We hope you enjoy the documentation starter and it unlocks your team’s productivity. If you have any questions or issues please make sure to join the [Discord](https://discord.gg/njvZZYHj2Q) or use our [GitHub Discussions](https://github.com/tinacms/tinacms/discussions).
 
-To keep up to date with Tina’s goings-on make sure to follow [@tinacms](https://twitter.com/tinacms) on Twitter.
+To keep up to date with TinaCMS’s goings-on make sure to follow [@tinacms](https://twitter.com/tinacms) on Twitter.

--- a/content/blog/read-only-tokens-content-anytime.mdx
+++ b/content/blog/read-only-tokens-content-anytime.mdx
@@ -11,7 +11,7 @@ prev: content/blog/data-layer-performant-editing.mdx
 next: content/blog/automating-pull-requests.mdx
 ---
 
-Read-only tokens allow you to query data from your project at any point in your application, whether that is on the server or on the client. Prior to Read-only tokens everything Tina did was through `getStaticProps` or `getStaticPaths`. This, for the most part, would handle most cases when using a headless CMS with an SSG. However as we move towards the 1.0 release of TinaCMS we want to be able to support more frameworks including React, Remix, and Gatsby.
+Read-only tokens allow you to query data from your project at any point in your application, whether that is on the server or on the client. Prior to Read-only tokens everything TinaCMS did was through `getStaticProps` or `getStaticPaths`. This, for the most part, would handle most cases when using a headless CMS with an SSG. However as we move towards the 1.0 release of TinaCMS we want to be able to support more frameworks including React, Remix, and Gatsby.
 
 ## Some use cases for Read-only tokens
 
@@ -41,11 +41,11 @@ Finally, click "Create Token".
 
 ### Ready for requests
 
-At this point you are now ready to make requests using the Read-only token. I have put together some examples of different use cases, they include SSR, CSR, SSG with fallback which should satisfy most use cases with Tina.
+At this point you are now ready to make requests using the Read-only token. I have put together some examples of different use cases, they include SSR, CSR, SSG with fallback which should satisfy most use cases with TinaCMS.
 
 ### SSR - Server Side Rendering content
 
-In most cases your content will be statically generated at build time, but on occasion you might need to use SSR in your Tina-powered app. It could be a page that isn’t powered by Tina but you are using our graphQL layer to power your whole application.
+In most cases your content will be statically generated at build time, but on occasion you might need to use SSR in your TinaCMS-powered app. It could be a page that isn’t powered by TinaCMS but you are using our graphQL layer to power your whole application.
 
 ```javascript
 const query = `
@@ -80,11 +80,11 @@ export async function getServerSideProps(context) {
 }
 ```
 
-Every time a user returns to this page, they will receive a freshly served page with the latest content from Tina.
+Every time a user returns to this page, they will receive a freshly served page with the latest content from TinaCMS.
 
 ### CSR - Client Side Rendering
 
-Client side rendering can be a great way to keep content on the page up to date, every-time someone visits a page. Tina content can be retrieved using your favorite http client such as fetch or axios.
+Client side rendering can be a great way to keep content on the page up to date, every-time someone visits a page. TinaCMS content can be retrieved using your favorite http client such as fetch or axios.
 
 ```javascript
 import { useState, useEffect } from 'react'
@@ -142,11 +142,11 @@ function BlogPostPage() {
 export default BlogPostPage
 ```
 
-As you can see for this example we are using useEffect to fetch the data from Tina using our read-only token. The URL you see is powered by your `clientId` and GitHub branch of choice. We then set the data to use `useTina` and present the data through the UI.
+As you can see for this example we are using useEffect to fetch the data from TinaCMS using our read-only token. The URL you see is powered by your `clientId` and GitHub branch of choice. We then set the data to use `useTina` and present the data through the UI.
 
 ### SSG with Fallback
 
-Up until now most Tina users use `fallback: blocking` for creating new pages with Tina.
+Up until now most TinaCMS users use `fallback: blocking` for creating new pages with TinaCMS.
 
 This comes with issues:
 
@@ -230,21 +230,21 @@ The code above does a lot of different things, so let us break it down into the 
 2. If there is no data returned, we set the error flag to true. If the error flag is true, we attempt to use read-only tokens to retrieve your data and return it to be displayed to the user, or to the content editor.
 3. If there is no data returned and the read-only token returns no data, we return `notFound: true` (this is a special flag for Next.js). This flag will return your 404 error page as well as `404` in the status code.
 
-## How to keep up to date with Tina?
+## How to keep up to date with TinaCMS?
 
-The best way to keep up with Tina is to subscribe to our newsletter, we send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may have missed, and so much more!
+The best way to keep up with TinaCMS is to subscribe to our newsletter, we send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may have missed, and so much more!
 
 You can subscribe by following this link and entering your email: [https://tina.io/community/](https://tina.io/community/)
 
-### Tina Community Discord
+### TinaCMS Community Discord
 
-Tina has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and Tina enthusiasts. When you join you will find a place:
+TinaCMS has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and TinaCMS enthusiasts. When you join you will find a place:
 
 * To get help with issues
-* Find the latest Tina news and sneak previews
-* Share your project with Tina community, and talk about your experience
+* Find the latest TinaCMS news and sneak previews
+* Share your project with TinaCMS community, and talk about your experience
 * Chat about the Jamstack
 
-### Tina Twitter
+### TinaCMS Twitter
 
-Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to Tina. We would also be psyched if you tagged us in projects you have built.
+Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to TinaCMS. We would also be psyched if you tagged us in projects you have built.

--- a/content/blog/structure-your-content-with-graphql-in-tina.mdx
+++ b/content/blog/structure-your-content-with-graphql-in-tina.mdx
@@ -1,10 +1,10 @@
 ---
 seo:
-  title: Structure Your Content with GraphQL in Tina | TinaCMS Blog
+  title: Structure Your Content with GraphQL in TinaCMS | TinaCMS Blog
   description: >-
     Explore how to use GraphQL in TinaCMS to structure and query your content
     more efficiently, improving data fetching and content management.
-title: Structure your content with GraphQL in Tina
+title: Structure your content with GraphQL in TinaCMS
 date: '2021-06-25T18:34:12+02:00'
 last_edited: '2021-06-25T20:42:18.533Z'
 author: Frank Taillandier
@@ -14,26 +14,26 @@ next: content/blog/manage-your-media-with-cloudinary.mdx
 
 <WarningCallout
   body={<>
-    **Update**: The Tina API has been evolving, and the content in this post
-    is outdated. For help getting started with Tina, we suggest checking out
+    **Update**: The TinaCMS API has been evolving, and the content in this post
+    is outdated. For help getting started with TinaCMS, we suggest checking out
     our [getting started doc](https://tina.io/docs/setup-overview/).
   </>}
 />
 
-Tina adopts a developer-centric approach to structure content, which means you can model your content locally in your favourite editor. Thanks to a [GraphQL layer on top of the files](/blog/using-graphql-with-the-filesystem/) stored in your repository, Tina makes it more straightforward to query content all across your files. Let's see how this feels.
+TinaCMS adopts a developer-centric approach to structure content, which means you can model your content locally in your favourite editor. Thanks to a [GraphQL layer on top of the files](/blog/using-graphql-with-the-filesystem/) stored in your repository, TinaCMS makes it more straightforward to query content all across your files. Let's see how this feels.
 
 When we refer to Git-based, it means your content is stored in Markdown and JSON files and modelled with front matter; on top of that TinaCloud aims to let you leverage the power of [GraphQL](https://graphql.org/).
 
-We open-sourced the [tina-graphql-gateway package](https://github.com/tinacms/tina-graphql-gateway) so that you can see how it works under the hood. It contains different tools for developers to work with Tina and GraphQL:
+We open-sourced the [tina-graphql-gateway package](https://github.com/tinacms/tina-graphql-gateway) so that you can see how it works under the hood. It contains different tools for developers to work with TinaCMS and GraphQL:
 
 - a GraphQL schema compiler,
 - a GraphQL Server,
 - a GraphQL Client (Altair),
 - a command-line interface to compile the schema and launch a local server,
-- Next.js helpers for Tina,
+- Next.js helpers for TinaCMS,
 - and more…
 
-The typical developer workflow when working on your structured content is to run Tina local GraphQL server, edit your schema, create and test queries to use those in your Next.js pages.
+The typical developer workflow when working on your structured content is to run TinaCMS local GraphQL server, edit your schema, create and test queries to use those in your Next.js pages.
 
 ## The GraphQL schema is the single source of truth
 
@@ -124,7 +124,7 @@ export default defineSchema({
 
 ## Query your content with GraphQL
 
-The Tina CLI provides a command to run a local GraphQL server to watch for changes in our schema and compiles it when edited; it runs alongside Next.js in development mode. We make it our default `dev` npm script in the `package.json`, so that when we run `yarn dev`, we have access to a GraphQL playground:
+The TinaCMS CLI provides a command to run a local GraphQL server to watch for changes in our schema and compiles it when edited; it runs alongside Next.js in development mode. We make it our default `dev` npm script in the `package.json`, so that when we run `yarn dev`, we have access to a GraphQL playground:
 
 yarn dev
 yarn tina-gql server\:start -c "next dev"
@@ -157,6 +157,6 @@ query BlogPost {
 }
 ```
 
-Now that we know how to query data from our files, we still need to use that query in our Next.js application, request it from the client and ask Tina to generate the corresponding form so that our contributors are able to edit it visually. We'll detail the remaining steps in a follow-up post, stay tuned!
+Now that we know how to query data from our files, we still need to use that query in our Next.js application, request it from the client and ask TinaCMS to generate the corresponding form so that our contributors are able to edit it visually. We'll detail the remaining steps in a follow-up post, stay tuned!
 
-_[Join our Discord](https://discord.com/invite/zumN63Ybpf), if you have any question regarding how to work with Tina and Next.js._
+_[Join our Discord](https://discord.com/invite/zumN63Ybpf), if you have any question regarding how to work with TinaCMS and Next.js._

--- a/content/blog/syntax-highlighting-with-tina.mdx
+++ b/content/blog/syntax-highlighting-with-tina.mdx
@@ -4,9 +4,9 @@ opengraph:
     url: /img/blog/syntax-highlighting-with-tina/syntax-highlight-cover.png
     width: '1920,'
     height: '1080,'
-    alt: Syntax Highlighting with Tina
+    alt: Syntax Highlighting with TinaCMS
 seo:
-  title: Syntax Highlighting with Tina Markdown | TinaCMS Blog
+  title: Syntax Highlighting with TinaCMS Markdown | TinaCMS Blog
   description: >-
     Learn how to add syntax highlighting in TinaCMS to enhance the readability
     of code snippets and improve content presentation for developers.
@@ -26,7 +26,7 @@ Prefer to learn through videos? Check out our video covering syntax highlighting
 
 ## Setup
 
-The starting point that I have created for this tutorial contains a very basic implementation of Tina that includes a blog. It is using our `rich-text` editor and our `TinaMarkdown` component.
+The starting point that I have created for this tutorial contains a very basic implementation of TinaCMS that includes a blog. It is using our `rich-text` editor and our `TinaMarkdown` component.
 
 ```bash
 # clone the repository
@@ -42,7 +42,7 @@ cd syntax-highlighting
 # install the dependencies
 yarn
 
-# launch Tina + Next.js
+# launch TinaCMS + Next.js
 yarn dev
 ```
 
@@ -190,19 +190,19 @@ Now, you can launch using `yarn dev` and navigate back to [http://localhost:3000
 
 You can find the finished code in our [GitHub examples repository](https://github.com/tinacms/tinacms/tree/main/examples)
 
-## Where can you keep up to date with Tina?
+## Where can you keep up to date with TinaCMS?
 
-You know that you will want to be part of this creative, innovative, supportive community of developers (and even some editors and designers) who are experimenting and implementing Tina daily.
+You know that you will want to be part of this creative, innovative, supportive community of developers (and even some editors and designers) who are experimenting and implementing TinaCMS daily.
 
-### Tina Community Discord
+### TinaCMS Community Discord
 
-Tina has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and Tina enthusiasts. When you join you will find a place:
+TinaCMS has a community [Discord](https://discord.com/invite/zumN63Ybpf) that is full of Jamstack lovers and TinaCMS enthusiasts. When you join you will find a place:
 
 * To get help with issues
-* Find the latest Tina news and sneak previews
-* Share your project with Tina community, and talk about your experience
+* Find the latest TinaCMS news and sneak previews
+* Share your project with TinaCMS community, and talk about your experience
 * Chat about the Jamstack
 
-### Tina Twitter
+### TinaCMS Twitter
 
-Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to Tina. We would also be psyched if you tagged us in projects you have built.
+Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to TinaCMS. We would also be psyched if you tagged us in projects you have built.

--- a/content/blog/three-ways-to-edit-md.mdx
+++ b/content/blog/three-ways-to-edit-md.mdx
@@ -12,11 +12,11 @@ warningMessage: >-
   implementation. We recommend using [Next.js](/docs/setup-overview/) for a
   solution with less friction.
 seo:
-  title: Three Ways to Edit Markdown with Tina | TinaCMS Blog
+  title: Three Ways to Edit Markdown with TinaCMS | TinaCMS Blog
   description: >-
     Discover three different methods for editing Markdown content in TinaCMS,
     offering flexibility and efficiency for managing your content.
-title: 3 ways to edit Markdown with Tina + Gatsby
+title: 3 ways to edit Markdown with TinaCMS + Gatsby
 date: '2020-01-09T07:00:00.000Z'
 author: Thomas Weibenfalk
 prev: content/blog/using-tinacms-on-gatsby-cloud.mdx
@@ -25,13 +25,13 @@ next: content/blog/exporting-wordpress-content-to-gatsby.mdx
 
 **Supercharge your static site with real-time content editing!** 🚀
 
-In this post, I will explore *the three different methods* Tina offers to edit Markdown on your Gatsby site. You’ll learn how to set up Tina with both Page Queries and Static Queries.
+In this post, I will explore *the three different methods* TinaCMS offers to edit Markdown on your Gatsby site. You’ll learn how to set up TinaCMS with both Page Queries and Static Queries.
 
-*This post will not cover the basics of using Tina with Gatsby. Please reference the [documentation](/docs/guides/converting-gatsby-to-tina) on how to initially set up Tina with Gatsby.*
+*This post will not cover the basics of using TinaCMS with Gatsby. Please reference the [documentation](/docs/guides/converting-gatsby-to-tina) on how to initially set up TinaCMS with Gatsby.*
 
 ## What’s the deal with Page Queries and Static Queries?
 
-Before we dive down into editing Markdown with Tina we have to understand how Gatsby handles querying data with GraphQL. You can source data from almost anywhere in Gatsby. In our case, we’re using *Markdown*. When you build your site, Gatsby creates a GraphQL schema for all the data. Then you use [GraphQL](https://graphql.org/learn/) in your React components to query your sourced data.
+Before we dive down into editing Markdown with TinaCMS we have to understand how Gatsby handles querying data with GraphQL. You can source data from almost anywhere in Gatsby. In our case, we’re using *Markdown*. When you build your site, Gatsby creates a GraphQL schema for all the data. Then you use [GraphQL](https://graphql.org/learn/) in your React components to query your sourced data.
 
 Gatsby allows you to query your data in two ways: *[Page Queries and Static Queries](https://www.gatsbyjs.org/docs/static-vs-normal-queries/)*.
 Since the release of the [React Hooks API](https://legacy.reactjs.org/docs/hooks-intro.html) and the [`useStaticQuery` hook](https://www.gatsbyjs.org/docs/use-static-query/) in Gatsby, it is very easy to query your data. There are cases when you can’t use a Static Query though. First, let’s explore the differences.
@@ -53,9 +53,9 @@ Another great thing with Static Queries is that you can grab the data in the com
 
 For getting data, we can use Gatsby's query options. For structuring our components, React also offers a couple of options. You can either create your component as a [class or a functional component](https://legacy.reactjs.org/docs/components-and-props.html). Before the React Hooks API, you had to use class components to have state in your components. Now with hooks, you can do this with functional components.🥰
 
-## Three ways to edit Markdown with Tina
+## Three ways to edit Markdown with TinaCMS
 
-Given all the options for creating components and sourcing data in Gatsby, we have to choose the most suitable approach for the project. Tina can work with all of these options, providing **[three different approaches](/docs/guides/converting-gatsby-to-tina)** for editing Markdown with Gatsby as described below.
+Given all the options for creating components and sourcing data in Gatsby, we have to choose the most suitable approach for the project. TinaCMS can work with all of these options, providing **[three different approaches](/docs/guides/converting-gatsby-to-tina)** for editing Markdown with Gatsby as described below.
 
 * **remarkForm** - A [Higher Order Component](https://legacy.reactjs.org/docs/higher-order-components.html) used when you source data from a Page Query in Gatsby. This component can be utilized with both functional and class components. Please note the subtle difference here! The only difference in naming from the render props component is the lowercase “r”.
 * **useLocalRemarkForm** - A [React Hook](https://legacy.reactjs.org/docs/hooks-overview.html) that is intended for functional components sourcing data from either a Static or a Page Query. If the component is sourcing static data, Gatsby's `useStaticQuery` hook would be called.
@@ -106,7 +106,7 @@ The first step in this example is to import the `remarkForm` hook from the Gatsb
 
 There’s no need to do any additions to the code inside of the component itself. It could be any component — functional or class — structured in the way you want it. The only thing you have to do with the component itself is to wrap your component with the `remarkForm` HOC when you export it.
 
-One more thing you have to do before you are good to go is to add the GraphQL fragment `...TinaRemark` in your query. This is needed for TinaCMS to recognize your data and create the required editor fields in the TinaCMS sidebar. After that, you only have to start up your dev server to show the site and the Tina sidebar.
+One more thing you have to do before you are good to go is to add the GraphQL fragment `...TinaRemark` in your query. This is needed for TinaCMS to recognize your data and create the required editor fields in the TinaCMS sidebar. After that, you only have to start up your dev server to show the site and the TinaCMS sidebar.
 
 Easy enough isn’t it? Just three small steps and you’ll have a beautiful sidebar to edit your content on your site. 🤟
 
@@ -160,7 +160,7 @@ Let’s break down what’s happening here:
 
 1. We import the `useLocalRemarkForm` custom hook so we can use it in our component.
 2. Just as before, the `...TinaRemark` fragment is needed in the GraphQL query. So we add that one there.
-3. When we’ve got our data back from the Gatsby `useStaticQuery` hook we can call the TinaCMS `useLocalRemarkForm` hook with that data. This hook will return an array with two elements. The first element is practically the data that we called the hook with. It has the same shape and is ready for us to use in our component. The second element is a reference to the Tina form. We don’t need that one so we don’t destructure it out as we do with the `markdownRemark`.
+3. When we’ve got our data back from the Gatsby `useStaticQuery` hook we can call the TinaCMS `useLocalRemarkForm` hook with that data. This hook will return an array with two elements. The first element is practically the data that we called the hook with. It has the same shape and is ready for us to use in our component. The second element is a reference to the TinaCMS form. We don’t need that one so we don’t destructure it out as we do with the `markdownRemark`.
 
 If you're wondering about this line:
 
@@ -172,7 +172,7 @@ It is an example of [ES6 destructuring](https://developer.mozilla.org/en-US/docs
 
 ### RemarkForm - The Render Prop Component
 
-You can’t use React Hooks on class components. That’s why Tina provides a [`RemarkForm`](/docs/guides/converting-gatsby-to-tina) component that uses the [Render Props](https://legacy.reactjs.org/docs/render-props.html) pattern.
+You can’t use React Hooks on class components. That’s why TinaCMS provides a [`RemarkForm`](/docs/guides/converting-gatsby-to-tina) component that uses the [Render Props](https://legacy.reactjs.org/docs/render-props.html) pattern.
 
 This component works with both Page and Static Queries. I will show how to use it with a Page Query below.
 
@@ -222,22 +222,22 @@ export const pageQuery = graphql`
 Ok, yet again, let’s see what’s happening here:
 
 1. We import the `RemarkForm` component for us to use in our code.
-2. In our return statement we return the `RemarkForm` component and pass in it's predefined, and required props. The remark prop provides `RemarkForm` with the Markdown data sourced from the Page Query. The render prop gets the JSX that we want to render through a function, or a render prop. `RemarkForm` will hook up Tina for editing the data and then render whatever is specified in the render prop function.
+2. In our return statement we return the `RemarkForm` component and pass in it's predefined, and required props. The remark prop provides `RemarkForm` with the Markdown data sourced from the Page Query. The render prop gets the JSX that we want to render through a function, or a render prop. `RemarkForm` will hook up TinaCMS for editing the data and then render whatever is specified in the render prop function.
 3. Just as before we have to add the `...TinaRemark` fragment to the Page Query.
 
 ## Next steps
 
-**That's it**! Three ways of using Tina for editing Markdown files in Gatsby. 🎉
+**That's it**! Three ways of using TinaCMS for editing Markdown files in Gatsby. 🎉
 
-In this post, we learned about how to *set up Tina with both Static Queries and Page Queries in Gatsby*. We also learned about three different ways to edit Markdown with Tina depending on your type of React component.
+In this post, we learned about how to *set up TinaCMS with both Static Queries and Page Queries in Gatsby*. We also learned about three different ways to edit Markdown with TinaCMS depending on your type of React component.
 
-This is just the basics to get you started. If you like Tina and want to learn more you should check out the [official docs](/docs/). There’s a lot more stuff to read there and some interesting use cases.
+This is just the basics to get you started. If you like TinaCMS and want to learn more you should check out the [official docs](/docs/). There’s a lot more stuff to read there and some interesting use cases.
 
-For example, you can learn how to apply [inline editing](/docs/contextual-editing/overview) and also how to [customize the form fields](/docs/plugins/fields) in the Tina sidebar.
+For example, you can learn how to apply [inline editing](/docs/contextual-editing/overview) and also how to [customize the form fields](/docs/plugins/fields) in the TinaCMS sidebar.
 
-Tina is a great addition to the React ecosystem and static site generators like Gatsby. It gives your site a pleasant and easy way to edit and interact with your content.
+TinaCMS is a great addition to the React ecosystem and static site generators like Gatsby. It gives your site a pleasant and easy way to edit and interact with your content.
 I’m thrilled to see how big TinaCMS will be and what it can do as it evolves!
 
 ## More reading and learning
 
-Watch my tutorial for [Tina & Gatsby](https://www.youtube.com/watch?v=eZWJ9ZtF61A\&t=265s). Also catch me on Twitter — [@weibenfalk](https://twitter.com/weibenfalk), [Youtube](https://www.youtube.com/c/weibenfalk), or on my [website](https://www.weibenfalk.com).
+Watch my tutorial for [TinaCMS & Gatsby](https://www.youtube.com/watch?v=eZWJ9ZtF61A\&t=265s). Also catch me on Twitter — [@weibenfalk](https://twitter.com/weibenfalk), [Youtube](https://www.youtube.com/c/weibenfalk), or on my [website](https://www.weibenfalk.com).

--- a/content/blog/tina-is-in-beta.mdx
+++ b/content/blog/tina-is-in-beta.mdx
@@ -12,23 +12,23 @@ prev: content/blog/manage-your-media-with-cloudinary.mdx
 next: content/blog/who-is-logan-anderson.mdx
 ---
 
-The team at Tina has been working hard since June 2nd when we launched TinaCloud alpha. We took all your feedback and thoughts and iterated to make huge improvements to the product. The alpha release contained the core product yet we knew we had some features we wanted to add immediately, including a simplified integration path.
+The team at TinaCMS has been working hard since June 2nd when we launched TinaCloud alpha. We took all your feedback and thoughts and iterated to make huge improvements to the product. The alpha release contained the core product yet we knew we had some features we wanted to add immediately, including a simplified integration path.
 
-We are pleased to announce that Tina is in beta, and all of the core functionality is in place for your team to have a great content editing experience on Next.js sites! If you are excited as we are you can get started by [signing up](https://app.tina.io/register). But first, I'd love for you to stick around and hear about the team's vision, lessons learned, and what we have added. If you are new to Tina, here is a quick demo:
+We are pleased to announce that TinaCMS is in beta, and all of the core functionality is in place for your team to have a great content editing experience on Next.js sites! If you are excited as we are you can get started by [signing up](https://app.tina.io/register). But first, I'd love for you to stick around and hear about the team's vision, lessons learned, and what we have added. If you are new to TinaCMS, here is a quick demo:
 
 <WebmEmbed embedSrc="/img/blog/tina-is-in-beta/Beta_Launch_Demo.webm" />
 
 ## A quick Message from Scott our CEO
 
-The Tina Beta is a big milestone! All the core functionality is in place for teams to edit content on their Next.js sites. We’re just scratching the surface of what’s possible when you add an amazing content editing experience to content stored in your Git repo. Our goal is to 10x the experience for both developers and content editors.
+The TinaCMS Beta is a big milestone! All the core functionality is in place for teams to edit content on their Next.js sites. We’re just scratching the surface of what’s possible when you add an amazing content editing experience to content stored in your Git repo. Our goal is to 10x the experience for both developers and content editors.
 
 ## Lessons Learned
 
 We learned a lot during the alpha stage, which allowed us to drive the product forward.
 
-* It took users a lot longer than we expected to make their first commit using Tina. At the beginning on average, it was over 8 hours. This signaled to us that even our starter took too long to set up.
+* It took users a lot longer than we expected to make their first commit using TinaCMS. At the beginning on average, it was over 8 hours. This signaled to us that even our starter took too long to set up.
 * You had a lot of questions after using our starter, mostly surrounding content modeling, and our documentation didn't answer them.
-* Tina could be used in Production on large sites, and both developers and content writers loved it.
+* TinaCMS could be used in Production on large sites, and both developers and content writers loved it.
 * Creating a [Discord](https://discord.gg/njvZZYHj2Q) allowed us to give and receive real-time feedback, which allowed us to add features, fix bugs, and get people unstuck quickly.
 
 ## What Does Being Beta Mean for You?
@@ -38,7 +38,7 @@ We believe that our product combines a fantastic developer and content creator e
 * [Better Documentation](#better-documentation)
 * [A new initialize command in the CLI](#a-new-initialize-command-in-the-cli)
 * [Improving and adding guides](#improving-and-adding-guides)
-* [Improving our Tina Starter](#improving-our-tina-starter)
+* [Improving our TinaCMS Starter](#improving-our-tina-starter)
 * [Media Manager](#media-manager)
 * [Caching improvements](#caching-improvements)
 * [Creating @tinacms/toolkit](#creating-tinacmstoolkit)
@@ -48,9 +48,9 @@ We believe that our product combines a fantastic developer and content creator e
 
 <Callout title="Ready to get started?" description="Get a website running with TinaCloud in no time!" url="/docs/setup-overview/" buttonText="Quick Start Guide" />
 
-## Getting Started with Tina
+## Getting Started with TinaCMS
 
-We wanted to speed up getting Tina up and running, whether this was a newly bootstrapped Next.js application or your Production application. We introduced several things to improve this:
+We wanted to speed up getting TinaCMS up and running, whether this was a newly bootstrapped Next.js application or your Production application. We introduced several things to improve this:
 
 * Better documentation
 * A tina init command
@@ -58,52 +58,52 @@ We wanted to speed up getting Tina up and running, whether this was a newly boot
 
 ### Better Documentation
 
-The documentation at Tina has been something that we wanted to improve as much as possible, we found people were unsure of Tina's concepts because we did not clearly explain them in the documentation. We spent time crafting documentation that gives a developer of any experience a better understanding of each part of Tina, how they work together and how to accomplish specific tasks.
+The documentation at TinaCMS has been something that we wanted to improve as much as possible, we found people were unsure of TinaCMS's concepts because we did not clearly explain them in the documentation. We spent time crafting documentation that gives a developer of any experience a better understanding of each part of TinaCMS, how they work together and how to accomplish specific tasks.
 
 We also moved and created new navigation menus to better convey the intent of a piece of documentation, for example, if you were looking for the Next.js APIs we have a section for that.
 
 ### A New Initialize Command in the CLI
 
-Tina init is my favorite addition to the Tina experience. A single command can bootstrap Tina on a Next.js application and do all the heavy lifting for you. The team spent quite a bit of time working on this, and refining it, to get it just right. The command `npx @tinacms/cli init` command currently does the following:
+TinaCMS init is my favorite addition to the TinaCMS experience. A single command can bootstrap TinaCMS on a Next.js application and do all the heavy lifting for you. The team spent quite a bit of time working on this, and refining it, to get it just right. The command `npx @tinacms/cli init` command currently does the following:
 
 1. Install all dependencies to your application
-2. Add the updated Tina commands to your package.json (`dev`, `build`, `start`)
+2. Add the updated TinaCMS commands to your package.json (`dev`, `build`, `start`)
 3. Wrap your `app.js` / `app.tsx` in our `TinaEditProvider`
-4. Create demo data that you can test Tina out with.
+4. Create demo data that you can test TinaCMS out with.
 5. Create an admin route to allow people to edit, and a way to exit.
 6. Create a schema file ready for you to shape your content
 
-This allows you to move quickly and experience Tina without having to write any code. Then when you are ready you can easily extend it to use parts of your existing site.
+This allows you to move quickly and experience TinaCMS without having to write any code. Then when you are ready you can easily extend it to use parts of your existing site.
 
 ### Improving and Adding Guides
 
-When we introduced Tina, we had a single guide that got you up and running with our TinaCloud Starter. This was a great way for users to experience Tina but we found that people were missing some key concepts of Tina.
+When we introduced TinaCMS, we had a single guide that got you up and running with our TinaCloud Starter. This was a great way for users to experience TinaCMS but we found that people were missing some key concepts of TinaCMS.
 
-I went back to the drawing board and created a new guide that takes the Next.js Starter Blog and adds Tina and TinaCloud to it while explaining each concept as we went. This feels like a perfect way to show off Tina, learn how to use Tina, with something that many users are familiar with.
+I went back to the drawing board and created a new guide that takes the Next.js Starter Blog and adds TinaCMS and TinaCloud to it while explaining each concept as we went. This feels like a perfect way to show off TinaCMS, learn how to use TinaCMS, with something that many users are familiar with.
 
-We also removed old guides that no longer promote Tina's best practices and moved some of our other guides into our experimental section. Experimental to us means that we can't guarantee that there won't be bugs or issues with the packages used.
+We also removed old guides that no longer promote TinaCMS's best practices and moved some of our other guides into our experimental section. Experimental to us means that we can't guarantee that there won't be bugs or issues with the packages used.
 
-## Improving our Tina Starter
+## Improving our TinaCMS Starter
 
-The Tina Starter was built originally to show "the power of Tina" while it did that, we didn't feel that it showed a real-world example. So we went back to the drawing board and created our new [Tina Starter](/docs/introduction/using-starter), which includes a landing page, blog, and about pages. You can edit and rearrange the content and we styled it with TailwindCSS to give it some extra shine! Below is an example of just some of the work you can do:
+The TinaCMS Starter was built originally to show "the power of TinaCMS" while it did that, we didn't feel that it showed a real-world example. So we went back to the drawing board and created our new [TinaCMS Starter](/docs/introduction/using-starter), which includes a landing page, blog, and about pages. You can edit and rearrange the content and we styled it with TailwindCSS to give it some extra shine! Below is an example of just some of the work you can do:
 
 <WebmEmbed embedSrc="/img/blog/tinacms-is-in-beta/edit-alongside-content.webm" />
 
 ## Media Manager
 
-Media manager was one of the most important features that we needed for TinaCloud. Our [Cloudinary Media manager](/docs/reference/media/external/cloudinary/) allows you to change images, upload new images, and delete ones you no longer need without ever leaving the Tina editing experience.
+Media manager was one of the most important features that we needed for TinaCloud. Our [Cloudinary Media manager](/docs/reference/media/external/cloudinary/) allows you to change images, upload new images, and delete ones you no longer need without ever leaving the TinaCMS editing experience.
 
 I wrote a [blog post announcing it](/blog/manage-your-media-with-cloudinary/) and how to implement it into your application.
 
 ## Caching Improvements
 
-Speed and performance have been something we have been actively working on. We introduced some improvements behind the scenes to improve the way we retrieve the data for your site. Tina is carefully built with performance in mind and is now faster!
+Speed and performance have been something we have been actively working on. We introduced some improvements behind the scenes to improve the way we retrieve the data for your site. TinaCMS is carefully built with performance in mind and is now faster!
 
 ## Creating `@tinacms/toolkit`
 
 TinaCMS was built with small modular packages, this meant that we relied heavily on React context. The dependency mismatches from over-modularizing our toolkit, led to many bugs related to missing context.
 
-Our open-source team created `@tinacms/toolkit` which incorporates the essentials of Tina all in one place. This simplifies everything for you as a user and Tina as a product.
+Our open-source team created `@tinacms/toolkit` which incorporates the essentials of TinaCMS all in one place. This simplifies everything for you as a user and TinaCMS as a product.
 
 You can read about all the updates and why decided to make the changes in our pinned [GitHub issue](https://github.com/tinacms/tinacms/issues/1898).
 
@@ -123,12 +123,12 @@ Content Modeling is the core of how you interact with TinaCMS and also retrieve 
 
 This allows for simplistic queries that don't require disambiguation, we believe this will allow you as a developer to craft queries with ease.
 
-If you used the alpha of Tina you might want to read this article the team put together to explain all of the [changes and how to migrate](/docs/tinacloud/migration-overview/).
+If you used the alpha of TinaCMS you might want to read this article the team put together to explain all of the [changes and how to migrate](/docs/tinacloud/migration-overview/).
 
 ## Give Us Feedback!
 
 The whole team is truly excited to enter the beta phase and hope you will check it out and give us honest feedback. We want to hear about your projects or, let us know how TinaCloud can help your team make progress.
 
-To keep up to date with Tina goings-on make sure to follow [@tinacms](https://twitter.com/tinacms) on Twitter. Want to chat with the team? Join the [Discord](https://discord.gg/njvZZYHj2Q)
+To keep up to date with TinaCMS goings-on make sure to follow [@tinacms](https://twitter.com/tinacms) on Twitter. Want to chat with the team? Join the [Discord](https://discord.gg/njvZZYHj2Q)
 
 Stay tuned for further improvements, features, community-built projects and more!

--- a/content/blog/tina-next-i18n.mdx
+++ b/content/blog/tina-next-i18n.mdx
@@ -4,14 +4,14 @@ seo:
   description: >-
     Learn how to use TinaCMS with Next.js i18n to manage multilingual content,
     including setup tips and best practices for internationalized websites.
-title: Using Tina to power Internationalization
+title: Using TinaCMS to power Internationalization
 date: '2022-06-16T14:00:00.000Z'
 author: James Perkins
 prev: content/blog/a-b-test-with-tina.mdx
 next: content/blog/tina-v-0.68.14.mdx
 ---
 
-When working on a website you may need to introduce internationalization also known as i18n. While Tina currently doesn’t offer a plugin or native support we can leverage Next.js’s i18n feature to create a site that has internationalization support.
+When working on a website you may need to introduce internationalization also known as i18n. While TinaCMS currently doesn’t offer a plugin or native support we can leverage Next.js’s i18n feature to create a site that has internationalization support.
 
 ## Create a new project.
 
@@ -153,31 +153,31 @@ We need to make a small change to our `getStaticProps` function to look for the 
 
 With this change, we can now open any of the support locale URLs. Our application is now ready to support our locales, but how do we create new files for each locale?
 
-## Using Tina to create files for each locale
+## Using TinaCMS to create files for each locale
 
 To create our files we are going to leverage a filename structure of `<locale>/posname` the locale will be handled by Next.js So a filename of `fr/bonjour` will be treated as `<domain>/fr/another-post` in your Next.js application.
 
 Below is an example of the file structure.
 
-![Example of the file structure used when creating a new file in Tina](/img/blog/i18n/test-blog-post.png)
+![Example of the file structure used when creating a new file in TinaCMS](/img/blog/i18n/test-blog-post.png)
 
-## How to keep up to date with Tina?
+## How to keep up to date with TinaCMS?
 
-The best way to keep up with Tina is to subscribe to our newsletter. We send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may have missed, and more!
+The best way to keep up with TinaCMS is to subscribe to our newsletter. We send out updates every two weeks. Updates include new features, what we have been working on, blog posts you may have missed, and more!
 
 You can subscribe by following this link and entering your email: [https://tina.io/community/](https://tina.io/community/)
 
-### Tina Community Discord
+### TinaCMS Community Discord
 
-Tina has a community [Discord](https://discord.com/invite/zumN63Ybpf) full of Jamstack lovers and Tina enthusiasts. When you join, you will find a place:
+TinaCMS has a community [Discord](https://discord.com/invite/zumN63Ybpf) full of Jamstack lovers and TinaCMS enthusiasts. When you join, you will find a place:
 
 * To get help with issues
-* Find the latest Tina news and sneak previews
-* Share your project with the Tina community, and talk about your experience
+* Find the latest TinaCMS news and sneak previews
+* Share your project with the TinaCMS community, and talk about your experience
 * Chat about the Jamstack
 
-### Tina Twitter
+### TinaCMS Twitter
 
-Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to Tina. We would also be psyched if you tagged us in projects you have built.
+Our Twitter account ([@tinacms](https://twitter.com/tinacms)) announces the latest features, improvements, and sneak peeks to TinaCMS. We would also be psyched if you tagged us in projects you have built.
 
 For more information about Next.js configuration, check out the [Next.js configuration documentation](https://nextjs.org/docs/app/api-reference/next-config-js).

--- a/content/blog/tinacms-2022.mdx
+++ b/content/blog/tinacms-2022.mdx
@@ -18,35 +18,35 @@ prev: content/blog/syntax-highlighting-with-tina.mdx
 next: content/blog/tina-cms-get-started.mdx
 ---
 
-The Tina team is off-to-the races on an exciting year. We’re on a mission to redefine web publishing by making the most hackable CMS on the planet, giving developers complete control over the editing experience for their sites.
+The TinaCMS team is off-to-the races on an exciting year. We’re on a mission to redefine web publishing by making the most hackable CMS on the planet, giving developers complete control over the editing experience for their sites.
 
-Tina has two unique differentiators from other, more traditional, CMSs:
+TinaCMS has two unique differentiators from other, more traditional, CMSs:
 
 1. **Git -** We’re big believers in using files (Markdown, MDX, JSON, etc) and Git for content storage
 2. **Visual Editing -** The best editing experience is contextual, where your content editors can see their changes reflected on their site in real-time
 
 Using Git to store your content is the dream. When your content is in Markdown and JSON files, it simplifies your stack. You get the benefits of structured content without a database. You own your content in *your* repo, in open-formats, instead of renting space in a 3rd-party database or managing a backend server.  When you use the file system + Git for your content you get version control (history, roll-backs, etc) and a CI/CD-friendly workflow. Most importantly, you gain portability and aren’t locked into any one system. With Git, you’re in control of your site: code and content.
 
-Your content creators don't need to know that - under the hood - Tina is powered by Git. The editing experience shows your content changes in the context of your site, in real-time.  This is the case for every B2C site-builder tool on the market and it’s finally possible now for developer-first, headless CMSs when using modern frameworks like those built on React, Vue, and Svelte. We’re just getting started on what’s possible and we’re seeing teams build platforms that give their teams complete creative control, while giving developers complete control over the code and CMS guide rails.  Having said that, Tina will also offer a basic editing mode for content that isn’t rendered in a view (described below).
+Your content creators don't need to know that - under the hood - TinaCMS is powered by Git. The editing experience shows your content changes in the context of your site, in real-time.  This is the case for every B2C site-builder tool on the market and it’s finally possible now for developer-first, headless CMSs when using modern frameworks like those built on React, Vue, and Svelte. We’re just getting started on what’s possible and we’re seeing teams build platforms that give their teams complete creative control, while giving developers complete control over the code and CMS guide rails.  Having said that, TinaCMS will also offer a basic editing mode for content that isn’t rendered in a view (described below).
 
 Here’s a summary of what’s coming in 2022 with more details below.
 
-![Tina launches version 1. More frameworks (Remix, Nuxt, SvelteKit, etc). A Headless API on top of your Git content. Markdown at scale. New UI. More open and more extendable](/img/blog/tinacms-2022/tinacms-2022-vision.png)
+![TinaCMS launches version 1. More frameworks (Remix, Nuxt, SvelteKit, etc). A Headless API on top of your Git content. Markdown at scale. New UI. More open and more extendable](/img/blog/tinacms-2022/tinacms-2022-vision.png)
 
-## Tina Goes 1.0
+## TinaCMS Goes 1.0
 
-Tina is currently in Beta but we’re steadily progressing toward 1.0.  We expect this to happen relatively soon because we’re seeing more and more people try and fall in love with Tina every day ❤️.
+TinaCMS is currently in Beta but we’re steadily progressing toward 1.0.  We expect this to happen relatively soon because we’re seeing more and more people try and fall in love with TinaCMS every day ❤️.
 
 ![Community Feedback from Leroy](/img/blog/tinacms-2022/tinacms-community-feedback-leroy.png)
 ![Community Feedback from Jason Mason](/img/blog/tinacms-2022/tinacms-community-feedback-jason.png)
 
-As Tina approaches 1.0 you will see some rough edges smoothed out like the UX around media management and improved performance when loading content in the CMS. Also, since we’ve been focused on solving the hardest problems first (like scaling Git to thousands of pages) you might have noticed that some functionality is missing, like simply deleting pages.  This functionality will be in place before 1.0 and Tina will be a full-fledged, mature CMS.
+As TinaCMS approaches 1.0 you will see some rough edges smoothed out like the UX around media management and improved performance when loading content in the CMS. Also, since we’ve been focused on solving the hardest problems first (like scaling Git to thousands of pages) you might have noticed that some functionality is missing, like simply deleting pages.  This functionality will be in place before 1.0 and TinaCMS will be a full-fledged, mature CMS.
 
 ## More frameworks (Remix, Nuxt, SvelteKit, etc)
 
 ![next.js, remix, nuxt, hugo, eleventy](/img/blog/tinacms-2022/SSG-logos.png)
 
-Tina has been focused on Next.js while in beta. This has reduced our maintenance “surface area” while we get the product right.  Before 1.0, we will open up Tina to other frameworks.  Phase 1 will include modern, data-agnostic, Javascript frameworks like Remix, Nuxt, and SvelteKit.  Phase 2 will include all JAMstack frameworks (Jekyll, Hugo, 11ty, etc).
+TinaCMS has been focused on Next.js while in beta. This has reduced our maintenance “surface area” while we get the product right.  Before 1.0, we will open up TinaCMS to other frameworks.  Phase 1 will include modern, data-agnostic, Javascript frameworks like Remix, Nuxt, and SvelteKit.  Phase 2 will include all JAMstack frameworks (Jekyll, Hugo, 11ty, etc).
 
 > For up to date details on supported frameworks, please see [our framework-specific guides]()
 
@@ -60,15 +60,15 @@ As mentioned above, we’re big believers in using Markdown, MDX, and JSON files
 * CI/CD-friendly workflow
 * Use of open-formats like Markdown, MDX, and JSON
 
-However, using Git as content storage comes with limitations.  Typically, files like Markdown are only queried at build time and ideal for statically generated pages, and not used for dynamic pages with server-side rendering (SSR).  To allow for SSR with Git-backed content, Tina will be expanding on its GraphQL API to allow public access (with a read-only token), so you can query your Git-backed content like you would with any other API-first Headless CMS. This gives you the best of both worlds: the ability to use open, reliable formats and version control for your content, and the flexibility to query that data dynamically, if needed (i.e. getStaticProps in [Next.js](https://nextjs.org/) or useLoaderData in [Remix](https://remix.run/)).
+However, using Git as content storage comes with limitations.  Typically, files like Markdown are only queried at build time and ideal for statically generated pages, and not used for dynamic pages with server-side rendering (SSR).  To allow for SSR with Git-backed content, TinaCMS will be expanding on its GraphQL API to allow public access (with a read-only token), so you can query your Git-backed content like you would with any other API-first Headless CMS. This gives you the best of both worlds: the ability to use open, reliable formats and version control for your content, and the flexibility to query that data dynamically, if needed (i.e. getStaticProps in [Next.js](https://nextjs.org/) or useLoaderData in [Remix](https://remix.run/)).
 
-Tina’s headless API will allow you to use advanced queries for your content (i.e. sort, filter, paginate, and relations) which we will cover in the next section.
+TinaCMS’s headless API will allow you to use advanced queries for your content (i.e. sort, filter, paginate, and relations) which we will cover in the next section.
 
 ## Markdown at Scale
 
 Using Markdown for sites with thousands of pages has become a much better experience with tools like [Incremental Static Regeneration](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration) (ISR) in Next.js. Now you can get the reliability of storing content in Markdown files without the need to compile every page upfront, resulting in shorter build-times.  This year, we will improve what it’s like to manage content across all of those thousands of Markdown, MDX, or JSON files. This includes:
 
-* Migration and audit capabilities in the TinaCMS CLI to ensure data consistency across all of your files based on your Tina Schema file
+* Migration and audit capabilities in the TinaCMS CLI to ensure data consistency across all of your files based on your TinaCMS Schema file
 * Improved querying with the [GraphQL API](https://tina.io/docs/graphql/overview/) - supporting advanced queries for your content (i.e. sort, filter, paginate) and relational data across multiple files (i.e. if your Markdown blog post has an associated author, query the author name, bio, etc)
 * A workflow that supports local and cloud development
 
@@ -76,37 +76,37 @@ We are making the Markdown experience feel more like working with a database so 
 
 ## New UI
 
-We’ve been making major improvements to Tina’s UI. Specifically:
+We’ve been making major improvements to TinaCMS’s UI. Specifically:
 
 ### 1. Revamped UI
 
-Tina’s UI will offer a more-traditional CMS experience for browsing content on your site.  That way, you can browse and edit content that isn’t associated with a view, like an author in the example below and you will get the rich preview of your site only when you wire up “visual editing” on specific pages.
+TinaCMS’s UI will offer a more-traditional CMS experience for browsing content on your site.  That way, you can browse and edit content that isn’t associated with a view, like an author in the example below and you will get the rich preview of your site only when you wire up “visual editing” on specific pages.
 
 <Youtube embedSrc="https://youtube.com/embed/GMe8F7vyUa0" />
 
 ### 2. Built on Tailwind
 
-Tina’s editing UI is moving to [Tailwind](https://tailwindcss.com/) to make it easier to customize and extend. ![tailwind css logo](/img/blog/tinacms-2022/tailwindcss.jpg)
+TinaCMS’s editing UI is moving to [Tailwind](https://tailwindcss.com/) to make it easier to customize and extend. ![tailwind css logo](/img/blog/tinacms-2022/tailwindcss.jpg)
 
 ### 3. Blocks UI
 
-Tina will have an improved block-picking experience so users can get a visual preview of their blocks before adding them to the page.
+TinaCMS will have an improved block-picking experience so users can get a visual preview of their blocks before adding them to the page.
 
 <Youtube embedSrc="https://youtube.com/embed/iiJo8mBE9Oo" />
 
 ### 4. Rich Text Editing and MDX
 
-Tina’s rich text editing (with embeddable [MDX](https://mdxjs.com/) components) experience will see major improvements.  Content creators who write long-form content like blog posts or documentation are going to love the new rich text field
+TinaCMS’s rich text editing (with embeddable [MDX](https://mdxjs.com/) components) experience will see major improvements.  Content creators who write long-form content like blog posts or documentation are going to love the new rich text field
 
 <Youtube embedSrc="https://youtube.com/embed/rZG_HxT-2Bc" />
 
-## A more open and more extendable Tina
+## A more open and more extendable TinaCMS
 
 In a previous chapter of my life, I was a freelance and agency developer and I benefited greatly from using open-source WordPress. I was a part of the so-called “WordPress economy”. Now with TinaCMS, we want to allow others to leverage our open-source software.
 
-Currently, most of Tina is open-source, but TinaCloud is required when editing content in your production site.  TinaCloud proxies requests through to the GitHub API and this allows us to ensure the editing experience is great. For example, you don’t need a GitHub account to edit content, you’re not being rate limited by the GitHub API, and we can prevent people from overwriting each others’ changes when multiple people are editing the same piece of content simultaneously.  However, in the future, we want to ensure TinaCloud is opt-in and not lock-in.  We’re currently researching our options to provide a path that doesn’t require TinaCloud later this year.
+Currently, most of TinaCMS is open-source, but TinaCloud is required when editing content in your production site.  TinaCloud proxies requests through to the GitHub API and this allows us to ensure the editing experience is great. For example, you don’t need a GitHub account to edit content, you’re not being rate limited by the GitHub API, and we can prevent people from overwriting each others’ changes when multiple people are editing the same piece of content simultaneously.  However, in the future, we want to ensure TinaCloud is opt-in and not lock-in.  We’re currently researching our options to provide a path that doesn’t require TinaCloud later this year.
 
-We don’t just want Tina to be open-source, but we want it to be the most hackable CMS on the planet to give developers complete control over customizing the editing experience for their teammates and clients.  Currently, it can be cumbersome to extend and customize Tina in some specific ways. Expect to see big improvements when it comes to extending Tina. If you’re interested in how some of this will be architected, see this [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2402).
+We don’t just want TinaCMS to be open-source, but we want it to be the most hackable CMS on the planet to give developers complete control over customizing the editing experience for their teammates and clients.  Currently, it can be cumbersome to extend and customize TinaCMS in some specific ways. Expect to see big improvements when it comes to extending TinaCMS. If you’re interested in how some of this will be architected, see this [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2402).
 
 Finally, we are making the [TinaCMS Schema](https://tina.io/docs/schema/) more modular. That way, you can split up your schema and keep it close to your React components for more portability.
 
@@ -114,7 +114,7 @@ Finally, we are making the [TinaCMS Schema](https://tina.io/docs/schema/) more m
 
 I hope this gives you a picture of what we’re trying to accomplish this year.  We are already seeing people build great things with TinaCMS. This year will be full of upgrades, new features, and an all around amazing CMS experience for both developers and content creators.  We will show the world what becomes possible when you use Git + the JAMstack.
 
-If you haven’t had a chance to try Tina yet, spin up a starter site on TinaCloud or with the command line and share your feedback.
+If you haven’t had a chance to try TinaCMS yet, spin up a starter site on TinaCloud or with the command line and share your feedback.
 
 <CreateAppCta ctaText="Try a starter" cliText="npx create-tina-app@latest" />
 

--- a/content/blog/using-graphql-with-the-filesystem.mdx
+++ b/content/blog/using-graphql-with-the-filesystem.mdx
@@ -13,7 +13,7 @@ prev: content/blog/tina-cloud-a-headless-cms-backed-by-git.mdx
 next: content/blog/evolution-of-inline-editing.mdx
 ---
 
-Today we want to introduce you to the Tina GraphQL gateway that brings reliability to Git-based content management. It's an essential piece to provide a robust structured content, while your content remains fully portable.
+Today we want to introduce you to the TinaCMS GraphQL gateway that brings reliability to Git-based content management. It's an essential piece to provide a robust structured content, while your content remains fully portable.
 
 ## Overcoming the limitations of the filesystem
 
@@ -116,7 +116,7 @@ Let's add a new post to test this out, this one *won't* be featured:
 
 ```markdown
 ---
-title: 'Why Tina is Great'
+title: 'Why TinaCMS is Great'
 excerpt: 'Lorem  ...'
 coverImage: '/assets/blog/dynamic-routing/cover.jpg'
 date: '2021-04-25T05:35:07.322Z'
@@ -147,7 +147,7 @@ Let's look at the data from our new blog post again:
 
 ***
 
-title: "Why Tina is Great"
+title: "Why TinaCMS is Great"
 excerpt: "Lorem ..."
 coverImage: "/assets/blog/dynamic-routing/cover.jpg"
 date: "2021-04-25T05:35:07.322Z"
@@ -178,13 +178,13 @@ With a CMS, when you make a change to the shape of your content you also need to
 
 Most CMSs have come up with various ways to help with this: separate sandbox environments, preview APIs, and migration SDK scripts — all of which carry their own set of headaches. None of this is necessary with file-based content, *everything moves and changes together*. So what if we could bring the robust features of a headless CMS to your local filesystem? What might that look like?
 
-## Meet Tina Content API
+## Meet TinaCMS Content API
 
-Today we're introducing a tool that marries the power of a headless CMS with the convenience and portability of file-based content. **The Tina Content API is a GraphQL service that sources content from your local filesystem**. It will soon be available via [TinaCloud](https://app.tina.io), which connects to your GitHub repository to offer an identical, cloud-based, headless API.
+Today we're introducing a tool that marries the power of a headless CMS with the convenience and portability of file-based content. **The TinaCMS Content API is a GraphQL service that sources content from your local filesystem**. It will soon be available via [TinaCloud](https://app.tina.io), which connects to your GitHub repository to offer an identical, cloud-based, headless API.
 
 To get a sense for how this works, let's make some tweaks to the blog demo.
 
-First let's install Tina CLI:
+First let's install TinaCMS CLI:
 
 ```sh
 yarn add tina-graphql-gateway-cli
@@ -308,8 +308,8 @@ Run the `dev` command, you can see that we now have a local GraphQL server liste
 
 ```sh
 Started Filesystem GraphQL server on port: 4001
-Generating Tina config
-Tina config ======> /.tina/__generated__/config
+Generating TinaCMS config
+TinaCMS config ======> /.tina/__generated__/config
 Typescript types => /.tina/__generated__/types.ts
 GraphQL types ====> /.tina/__generated__/schema.gql
 ready - started server on 0.0.0.0:3000, url: http://localhost:3000
@@ -393,7 +393,7 @@ query BlogPostQuery($relativePath: String!) {
 }
 ```
 
-> Demo: [View the changes](https://github.com/tinacms/next-blog-starter-graphql/compare/split-author-data..add-tina-gql) we made to add Tina GraphQL
+> Demo: [View the changes](https://github.com/tinacms/next-blog-starter-graphql/compare/split-author-data..add-tina-gql) we made to add TinaCMS GraphQL
 
 ## To be continued
 

--- a/content/blog/using-the-power-of-mdx-with-tina.mdx
+++ b/content/blog/using-the-power-of-mdx-with-tina.mdx
@@ -1,10 +1,10 @@
 ---
 seo:
-  title: Using the Power of MDX with Tina | TinaCMS Blog
+  title: Using the Power of MDX with TinaCMS | TinaCMS Blog
   description: >-
     Learn how to leverage MDX in TinaCMS for combining Markdown with React
     components, enabling more dynamic and customizable content management.
-title: Using the power of MDX with Tina
+title: Using the power of MDX with TinaCMS
 date: '2021-12-09T12:09:32-04:00'
 last_edited: '2021-12-09T12:09:32-04:00'
 author: James Perkins
@@ -12,9 +12,9 @@ prev: content/blog/mdx-powered-docs.mdx
 next: content/blog/2021-a-year-in-review.mdx
 ---
 
-# Using the power of MDX with Tina
+# Using the power of MDX with TinaCMS
 
-Tina allows content teams and developers to work at a fast pace and removes the friction between static sites and editing content. We took this approach a step further with the release of our MDX support, which allows developers to create reusable components and content teams to use them whenever they need to. This blog post will show you how to add Tina to your site, then how to create and use components to Tina.
+TinaCMS allows content teams and developers to work at a fast pace and removes the friction between static sites and editing content. We took this approach a step further with the release of our MDX support, which allows developers to create reusable components and content teams to use them whenever they need to. This blog post will show you how to add TinaCMS to your site, then how to create and use components to TinaCMS.
 
 ### Project setup.
 
@@ -25,24 +25,24 @@ npx create-next-app -e with-tailwindcss tina-demo
 cd tina-demo
 ```
 
-Step 2: Add Tina to the project
+Step 2: Add TinaCMS to the project
 
-Use the following command inside of the project to add all the Tina dependencies and wrap the application, ready to be used.
+Use the following command inside of the project to add all the TinaCMS dependencies and wrap the application, ready to be used.
 
 ```bash
 npx @tinacms/cli@latest init
 ```
 
-When you are asked if you want to replace your `_app.js` file, select Y as we want our init command to take care of adding the Tina specific code.
-Step 3: Test Tina
+When you are asked if you want to replace your `_app.js` file, select Y as we want our init command to take care of adding the TinaCMS specific code.
+Step 3: Test TinaCMS
 
 Run `yarn dev` from the project directory and navigate to [http://localhost:3000/demo/blog/HelloWorld](http://localhost:3000/demo/blog/HelloWorld) , you can then enter edit mode by navigating to [http://localhost:3000/admin](http://localhost:3000/admin)
 
-## Using Tina rich editor
+## Using TinaCMS rich editor
 
-To first use an MDX component we need to use Tina's rich editor, this will allow us to render the components and still have the power of an intuitive markdown editor. Shutdown your local server and we can start adding our changes.
+To first use an MDX component we need to use TinaCMS's rich editor, this will allow us to render the components and still have the power of an intuitive markdown editor. Shutdown your local server and we can start adding our changes.
 
-### Update our Tina Schema.
+### Update our TinaCMS Schema.
 
 Open up the `.tina/schema.ts` file and edit the body section from the following
 
@@ -128,11 +128,11 @@ Then on line 234 we can replace the div that held the parsed markdown with our T
 
 Go ahead and run `yarn dev` and navigate back to [http://localhost:3000/demo/blog/HelloWorld](http://localhost:3000/demo/blog/HelloWorld) you'll notice that the editing experience has changed, with the ability to insert markdown and a new button called "Embed".
 
-![Tina Markdown Example](/img/blog/using-the-power-of-mdx-with-tina/Tina-markdown-demo.png)
+![TinaCMS Markdown Example](/img/blog/using-the-power-of-mdx-with-tina/TinaCMS-markdown-demo.png)
 
 ## Adding an MDX Component
 
-Adding components to Tina requires the following:
+Adding components to TinaCMS requires the following:
 
 1. A component that is powered by props
 2. Adding the component and editable fields
@@ -211,7 +211,7 @@ The piece is to register the component with our `TinaMarkdown` . Open up the `[f
 import Callout from '../../../components/Callout'
 ```
 
-For code clarity, we can create an object that contains all the different Tina-powered components. We are going to pass the props through to our components so we can define that here.
+For code clarity, we can create an object that contains all the different TinaCMS-powered components. We are going to pass the props through to our components so we can define that here.
 
 ```javascript
 const components = {

--- a/content/blog/what-are-blocks.mdx
+++ b/content/blog/what-are-blocks.mdx
@@ -16,21 +16,21 @@ next: content/blog/editing-on-the-cloud.mdx
 
 This axiom, [attributed to Phil Karlton](http://www.tbray.org/ongoing/When/200x/2005/12/23/UPI), resonates with anyone who has spent any amount of time working with software. The post you're currently reading is, in some ways, about the latter problem.
 
-One concept that we were eager to introduce to Tina is something we refer to as **Blocks fields**. We first introduced this concept in Forestry some time ago, and we think it's a powerful idea. The challenge with Blocks is that it’s kind of an abstract idea, and thus was tagged with a similarly abstract name.
+One concept that we were eager to introduce to TinaCMS is something we refer to as **Blocks fields**. We first introduced this concept in Forestry some time ago, and we think it's a powerful idea. The challenge with Blocks is that it’s kind of an abstract idea, and thus was tagged with a similarly abstract name.
 
-**What are Blocks?** To put it succinctly, Blocks refers to a data structure that consists of an *array of unlike objects*. If you didn’t quite grok that, read on and I’ll do my best to explain why we introduced the Blocks concept to Tina and how it relates to other kinds of fields.
+**What are Blocks?** To put it succinctly, Blocks refers to a data structure that consists of an *array of unlike objects*. If you didn’t quite grok that, read on and I’ll do my best to explain why we introduced the Blocks concept to TinaCMS and how it relates to other kinds of fields.
 
 ## Simple Fields and Compound Fields
 
-The field types we’ve implemented in Tina can be broadly grouped into two categories: **simple fields** and **compound fields**. The designation for whether a field is simple or compound has to do with the kind of data that the field represents.
+The field types we’ve implemented in TinaCMS can be broadly grouped into two categories: **simple fields** and **compound fields**. The designation for whether a field is simple or compound has to do with the kind of data that the field represents.
 
-**Simple fields** are fields for data that can be represented as a single value, like a string or number. In computer science lingo, these are referred to as [scalar values](https://softwareengineering.stackexchange.com/questions/238033/what-does-it-mean-when-data-is-scalar). An example of simple fields in Tina would be the text field, color field, or toggle. Even the [markdown WYSIWYG](/docs/editing/markdown) can be considered a simple field, in spite of its complex frontend behavior, because the value it exports is just a big block of text.
+**Simple fields** are fields for data that can be represented as a single value, like a string or number. In computer science lingo, these are referred to as [scalar values](https://softwareengineering.stackexchange.com/questions/238033/what-does-it-mean-when-data-is-scalar). An example of simple fields in TinaCMS would be the text field, color field, or toggle. Even the [markdown WYSIWYG](/docs/editing/markdown) can be considered a simple field, in spite of its complex frontend behavior, because the value it exports is just a big block of text.
 
-**Compound fields** are fields that can’t be represented by a single value. Data exported by a compound field is *structured.* When saved, a compound field’s data will be represented by a non-scalar data type such as an array or object. Compound fields are **fields composed of other fields**. The compound fields in Tina include the Group, Group List, and Blocks.
+**Compound fields** are fields that can’t be represented by a single value. Data exported by a compound field is *structured.* When saved, a compound field’s data will be represented by a non-scalar data type such as an array or object. Compound fields are **fields composed of other fields**. The compound fields in TinaCMS include the Group, Group List, and Blocks.
 
 ## Groups and Group Lists
 
-Tina’s **Group** field is a collection of **simple fields**. The fields that comprise a Group field can all be of the same type, or be of different types. Group fields are good for representing a single *entity* that is comprised of smaller pieces of data.
+TinaCMS’s **Group** field is a collection of **simple fields**. The fields that comprise a Group field can all be of the same type, or be of different types. Group fields are good for representing a single *entity* that is comprised of smaller pieces of data.
 
 Consider two ways to store a name in JSON. We could store the full name as a simple string:
 
@@ -99,7 +99,7 @@ Another way Grande makes use of Blocks is in its embedded form builder. Like the
 
 ## Give Blocks a Chance
 
-By now, you should have a better sense of what we mean when we talk about Blocks in Tina.
+By now, you should have a better sense of what we mean when we talk about Blocks in TinaCMS.
 
 If you want to see a glimpse of what you can do with a blocks-based content strategy, fork [Tina Grande](https://github.com/tinacms/tina-starter-grande) and give it a try.
 

--- a/content/blog/who-is-logan-anderson.mdx
+++ b/content/blog/who-is-logan-anderson.mdx
@@ -12,9 +12,9 @@ prev: content/blog/tina-is-in-beta.mdx
 next: content/blog/our-friend-frank-taillandier-fr.mdx
 ---
 
-Tina has a small core team of developers who work on both our open-source toolkit and cloud offering.
+TinaCMS has a small core team of developers who work on both our open-source toolkit and cloud offering.
 
-When I started here, I was introduced to Logan as a member of the Open Source team, Logan was interning at Tina while pursuing his degree. Logan has done some impressive work while working with the Tina team, recently we offered him a full-time position and we are happy to announce that he accepted!
+When I started here, I was introduced to Logan as a member of the Open Source team, Logan was interning at TinaCMS while pursuing his degree. Logan has done some impressive work while working with the TinaCMS team, recently we offered him a full-time position and we are happy to announce that he accepted!
 
 Who is Logan Anderson I hear you cry? Well, I sat down and asked the important questions, so without further ado, let us talk all about Logan.
 
@@ -24,21 +24,21 @@ Who is Logan Anderson I hear you cry? Well, I sat down and asked the important q
 
 I enjoy playing disc golf, spending time with my fiancé, going for walks, and just enjoying the outdoors whenever I can. I try to spend time outside when it is not raining and I am not working.
 
-## **When and how did you get started with Tina?**
+## **When and how did you get started with TinaCMS?**
 
-I started my adventure with Tina when I first started working here on my second co-op work term in May 2020. I was tasked with making a documentation starter repo that we then used for our internal employee handbook. I later went on to do my third work term here in 2021.
+I started my adventure with TinaCMS when I first started working here on my second co-op work term in May 2020. I was tasked with making a documentation starter repo that we then used for our internal employee handbook. I later went on to do my third work term here in 2021.
 
 ## **What has been your favorite project so far?**
 
-I really enjoy working on our core project. It is very open and flexible and is possible to do almost anything with. One of my favorite projects I have worked on is trying to make Tina easier to set up for users. It is a constant challenge between openness and ease of use. I enjoy this challenge!
+I really enjoy working on our core project. It is very open and flexible and is possible to do almost anything with. One of my favorite projects I have worked on is trying to make TinaCMS easier to set up for users. It is a constant challenge between openness and ease of use. I enjoy this challenge!
 
 > If you used our `@tinacms/cli init` command, this was Logan's hard work.
 
-## **What do you believe makes Tina different than others?**
+## **What do you believe makes TinaCMS different than others?**
 
 I really like one of the things that we call-out on our homepage. "Edit with Real-Time Visual Feedback". This is something that I do not see in any other CMS
 
-## **Why did you decide to stay at Tina after your internship ended?**
+## **Why did you decide to stay at TinaCMS after your internship ended?**
 
 I really love the people and the culture we have here. Continuous learning and having good relationships with the people I work with are core values that I admire and share.
 

--- a/content/blog/who-is-logan-anderson.mdx
+++ b/content/blog/who-is-logan-anderson.mdx
@@ -36,7 +36,7 @@ I really enjoy working on our core project. It is very open and flexible and is 
 
 ## **What do you believe makes TinaCMS different than others?**
 
-I really like one of the things that we call-out on our homepage. "Edit with Real-Time Visual Feedback". This is something that I do not see in any other CMS
+I really like one of the things that we call-out on our homepage. "Edit with Real-Time Visual Feedback". This is something that I do not see in any other CMS.
 
 ## **Why did you decide to stay at TinaCMS after your internship ended?**
 


### PR DESCRIPTION
Part of #4845 (batch 7 of the standalone-`Tina` cleanup — English blog, next 20 hot posts).

## Summary

259 in-content occurrences of standalone `Tina` → `TinaCMS` across the next 20 blog posts by count (7–21 hits each). Applied with the same `perl -pi` pass used in previous batches, then manual carve-outs for the 4 "Tina Grande" starter references (handled automatically by the ` Grande` exclusion in the regex) and the historical post title on `tina-is-in-beta.mdx` (reverted after perl).

## Files (20)

| File | Occurrences |
|---|---:|
| `content/blog/2021-a-year-in-review.mdx` | 21 |
| `content/blog/tina-is-in-beta.mdx` | 20 (18 changed + 2 title fields kept) |
| `content/blog/custom-field-components.mdx` | 19 (17 changed + 2 "Tina Grande" kept) |
| `content/blog/a-b-test-with-tina.mdx` | 18 |
| `content/blog/tinacms-2022.mdx` | 17 |
| `content/blog/three-ways-to-edit-md.mdx` | 14 |
| `content/blog/read-only-tokens-content-anytime.mdx` | 14 |
| `content/blog/using-the-power-of-mdx-with-tina.mdx` | 13 |
| `content/blog/tina-next-i18n.mdx` | 12 |
| `content/blog/syntax-highlighting-with-tina.mdx` | 11 |
| `content/blog/2021-q1-tinacms-updates.mdx` | 11 |
| `content/blog/structure-your-content-with-graphql-in-tina.mdx` | 10 |
| `content/blog/basics-of-graphql.mdx` | 10 |
| `content/blog/what-are-blocks.mdx` | 9 (7 changed + 2 "Tina Grande" kept) |
| `content/blog/add-and-delete-files.mdx` | 9 |
| `content/blog/using-graphql-with-the-filesystem.mdx` | 8 |
| `content/blog/data-layer-performant-editing.mdx` | 8 |
| `content/blog/automating-pull-requests.mdx` | 8 |
| `content/blog/who-is-logan-anderson.mdx` | 7 |
| `content/blog/mdx-powered-docs.mdx` | 7 |
| **Total** | **~236 flagged, 259 replacements** (some lines had multiple hits) |

20 files changed, 259 insertions / 259 deletions.

## Intentionally NOT changed (6 hits)

| File:line | Text | Why |
|---|---|---|
| `blog/tina-is-in-beta.mdx` (seo.title + title) | `Tina is in Beta` | Historical landmark post title — matches the "Tina Joins SSW" / "Announcing Tina" style calls flagged in #4845 |
| `blog/custom-field-components.mdx:36, 354` | `Tina Grande` (×2) | Legacy starter proper name — matches the GitHub repo `tina-starter-grande` |
| `blog/what-are-blocks.mdx:96, 104` | `Tina Grande` / `Tina Grande starter` (×2) | same |

Body copy inside `tina-is-in-beta.mdx` was rewritten — only the two title fields kept.

## Verify

```bash
# after merge, only the 6 intentional survivors above should remain in these 20 files:
grep -rnP "\bTina\b" content/blog/{2021-a-year-in-review,tina-is-in-beta,custom-field-components,a-b-test-with-tina,tinacms-2022,three-ways-to-edit-md,read-only-tokens-content-anytime,using-the-power-of-mdx-with-tina,tina-next-i18n,syntax-highlighting-with-tina,2021-q1-tinacms-updates,structure-your-content-with-graphql-in-tina,basics-of-graphql,what-are-blocks,add-and-delete-files,using-graphql-with-the-filesystem,data-layer-performant-editing,automating-pull-requests,who-is-logan-anderson,mdx-powered-docs}.mdx \
  | grep -vE "TinaCMS|TinaCloud|TinaDocs|TinaGPT|TinaTeach|Tina\.io|Tina-Docs|Tina-Cloud|Tina-CMS|Tina Teams|Tina CMS"
```

## Test plan

- [ ] `/blog/tina-is-in-beta` — post title still reads "Tina is in Beta"; body copy uses "TinaCMS" throughout.
- [ ] `/blog/custom-field-components` — "Tina Grande repo" link text unchanged (×2); rest of body uses "TinaCMS".
- [ ] `/blog/what-are-blocks` — "Tina Grande starter" / "Tina Grande" links unchanged (×2); rest of body uses "TinaCMS".
- [ ] `/blog/using-the-power-of-mdx-with-tina` — post title now reads "Using the power of MDX with TinaCMS".
- [ ] `/blog/tinacms-2022`, `/blog/2021-a-year-in-review`, `/blog/2021-q1-tinacms-updates` — mid-year recap posts read naturally with "TinaCMS".
- [ ] `/blog/a-b-test-with-tina` — title unchanged (it was already "…with TinaCMS"), body uses "TinaCMS".
