### PR TITLE
📝 Document the rich-text parser, skipEscaping and isBody options

### DIFF
--- a/content/docs/reference/markdown-spec.mdx
+++ b/content/docs/reference/markdown-spec.mdx
@@ -209,4 +209,8 @@ From `- Item 1` to `Item 1`.
 
 From `* > My blockquote` to `* My blockquote`.
 
+### Escaped markdown entities
+
+From `$a + b_{c}$` to `$a + b\_{c}$`. Turn this off with `parser: { type: 'markdown', skipEscaping: 'all' }` on the [rich-text field](/docs/reference/types/rich-text).
+
 ###

--- a/content/docs/reference/types/rich-text.mdx
+++ b/content/docs/reference/types/rich-text.mdx
@@ -26,10 +26,31 @@ The rich-text field stores **markdown content** with a WYSIWYG interface, suppor
       required: true
     },
     {
+      name: "isBody",
+      description:
+        "When the collection's `format` is markdown or MDX, this field's value is saved as the body of the file, and every other field in the collection is saved to frontmatter.\n",
+      type: "boolean"
+    },
+    {
       name: "templates",
       description:
         'MDX support. The "embed" option in the editor to inject custom React components.\n',
       type: "Template[]"
+    },
+    {
+      name: "type",
+      description:
+        "Which parser Tina uses to read and write this field. `mdx` allows custom components (see `templates`) inside the content, `markdown` is a stricter parser that does not, and `slatejson` is experimental and stores the raw editor document as JSON.\n",
+      type: "'mdx' | 'markdown' | 'slatejson'",
+      groupName: "parser"
+    },
+    {
+      name: "skipEscaping",
+      description:
+        "Only applies when `type` is `markdown`. Tina escapes markdown entities when it saves, so `$a + b_{c}$` is written to the file as `$a + b\\_{c}$`. Set `all` to turn escaping off completely, or `html` to stop only `<` being escaped.\n",
+      type: "'all' | 'html' | 'none'",
+      groupName: "parser",
+      default: "none"
     },
     {
       name: "toolbar",
@@ -57,6 +78,10 @@ The rich-text field stores **markdown content** with a WYSIWYG interface, suppor
 />
 
 > The `templates` property is for `mdx` support.
+
+> `parser` sits at the top level of the field, next to `templates`. It is not one of the `overrides`.
+
+The parser default comes from the collection, not from the field. A collection whose `format` is `mdx` gets `{ type: 'mdx' }`, and every other format gets `{ type: 'markdown' }`. Set `parser` on the field when you want something different, for example a `.mdx` collection that should be parsed as plain markdown.
 
 <WarningCallout
   body={<>


### PR DESCRIPTION
No linked issue - the missing options came up in https://github.com/tinacms/tinacms/discussions/7527

**TL;DR** Adds `parser`, its `skipEscaping` option and `isBody` to the rich-text field reference, and says plainly that the parser default comes from the collection's `format` rather than the field. Nothing existing changes and the `overrides` group is untouched.

**Pain:** `parser` is the fix for a whole class of "Tina mangled my markdown on save" reports, like the discussion above where `$a + b_{c}$` is written back as `$a + b\_{c}$`, but it appears nowhere in the docs. `isBody` is used four times in the examples further down the same page and never defined.

**Solution:** documents all three in the existing `apiReference` block, with a note that the default is set by the collection format. The Markdown Syntax Guide also gets a one-line "Escaped markdown entities" entry under Automatic Transforms, pointing back at the option.

`content/docs-zh/reference/types/rich-text.mdx` mirrors this page and is deliberately left alone here, for the auto-translation workflow to pick up.

### General Contributing:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tina.io/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
