### PR TITLE
📝 Document the image field's accept option

### DIFF
--- a/content/docs/reference/media/overriding-accepted-media-types.mdx
+++ b/content/docs/reference/media/overriding-accepted-media-types.mdx
@@ -27,6 +27,19 @@ export default defineConfig({
 
 This property determines the filetypes that can be uploaded
 
+### Restricting a single field
+
+`media.accept` applies to every upload. To restrict one field instead, give an [image field](/docs/reference/types/image#restricting-file-types) its own `accept`. It takes extensions and category shorthand rather than MIME types, and overrides the global list for that field.
+
+```javascript
+{
+  type: 'image',
+  name: 'brochure',
+  label: 'Brochure',
+  accept: 'pdf',
+}
+```
+
 ### next/image
 
 If you are using Next images, you will need to add the following to your next.config.js file to allow access to external images hosted on the TinaCMS media hostname 

--- a/content/docs/reference/media/overview.mdx
+++ b/content/docs/reference/media/overview.mdx
@@ -36,6 +36,14 @@ export default defineConfig({
 
 > Note: Only Repo-based Media or an External Media Provider can be configured, but **not both**
 
+## Filtering by file type
+
+The media manager's toolbar has a type filter for narrowing a large library to images, video, audio or documents.
+
+Opening the manager from an image field that declares [`accept`](/docs/reference/types/image#restricting-file-types) replaces that control with a locked chip, and the library shows only the types the field takes.
+
+The filter is only shown when the media store can filter by extension. Repo-based media, TinaCloud media and the local dev server all can; `staticMedia` can't, so the control is hidden there.
+
 ## Repo-based Media (default)
 
 With the built-in repo-based media option, media is stored within the site's repository.

--- a/content/docs/reference/types/image.mdx
+++ b/content/docs/reference/types/image.mdx
@@ -32,6 +32,11 @@ Images can be uploaded to the image component with drag-and-drop actions, or wit
       description: "The name of the field for internal use.\n",
       type: "string",
       required: true
+    },
+    {
+      name: "accept",
+      type: "string | string[]",
+      description: 'Restricts the field to specific file types. Takes an extension (`"pdf"`), a category (`"image"`, `"video"`, `"audio"` or `"document"`), or an array of either.\n'
     }
   ]}
 />
@@ -71,3 +76,46 @@ If you need to customize how an image is formatted in a field, you can use the `
   }
 }
 ```
+
+### Restricting file types
+
+Set `accept` to limit the field to certain file types. It takes a single extension, a category, or an array of either.
+
+```ts
+{
+  type: 'image',
+  label: 'Brochure',
+  name: 'brochure',
+  accept: 'pdf',
+}
+```
+
+```ts
+{
+  type: 'image',
+  label: 'Logo',
+  name: 'logo',
+  accept: ['png', 'svg'],
+}
+```
+
+The four categories are shorthand for a group of extensions:
+
+| Category     | Extensions                                       |
+| ------------ | ------------------------------------------------ |
+| `image`      | `jpg`, `jpeg`, `png`, `gif`, `webp`, `svg`, `avif`, `ico` |
+| `video`      | `mp4`, `webm`, `mov`                             |
+| `audio`      | `mp3`, `wav`, `ogg`                              |
+| `document`   | `pdf`, `json`, `csv`, `txt`                      |
+
+When a field declares `accept`:
+
+* The media manager lists only matching files, and its type filter is replaced by a locked chip naming what the field takes.
+* A file of any other type is refused before it uploads, whether it is dropped on the field or on the media manager, so nothing unwanted lands in your library.
+* Choosing a file already in the library that doesn't match raises an alert and leaves the field's value untouched.
+* `jpg` and `jpeg` mean the same thing, so `accept: 'jpeg'` still takes `photo.jpg`.
+* The field's `accept` overrides the global [`media.accept`](/docs/reference/media/overriding-accepted-media-types) for this field only.
+
+Values saved before `accept` was added are left alone; the restriction applies to what an editor picks from now on. It applies to `list: true` image fields too.
+
+> Narrowing the library needs a media store that can filter by extension. Repo-based media, TinaCloud media and the local dev server all can. A store that can't, such as `staticMedia`, keeps listing everything and hides the filter control, but the field still refuses a file outside its types.


### PR DESCRIPTION
cc: —
Related PBI: https://github.com/tinacms/tinacms/pull/7477

## TL;DR

The image field's `accept` option and the media manager's type filter shipped in tinacms#7477 with no docs. This documents `accept` on the image field reference, the per-field override on the media accept page, and the toolbar filter on the media overview.

## Reviewer notes

- **Categories, not MIME types.** Field `accept` takes extensions and the four category shorthands; the global `media.accept` still takes MIME types.
- **Filter needs store support.** Called out that `staticMedia` hides the control.

## Links

- [tinacms#7477](https://github.com/tinacms/tinacms/pull/7477) - the feature
- [tinacms#7481](https://github.com/tinacms/tinacms/issues/7481) - the `accept` option
- [tinacms#7474](https://github.com/tinacms/tinacms/issues/7474) - the toolbar filter

---
Changes made by Claude Opus 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)